### PR TITLE
JBIDE-14616: remove parent.relativePath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.1.0.Beta1-SNAPSHOT</version>
-		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>hibernatetools</artifactId>


### PR DESCRIPTION
- To avoid issue with sync of local parent & remote (Nexus) parent
- Make local build behave more like CI build
