### PR TITLE
JBIDE-10219 Migrate org.eclipse.core.runtime.contentTypes 

### DIFF
--- a/plugins/org.hibernate.eclipse.mapper/plugin.xml
+++ b/plugins/org.hibernate.eclipse.mapper/plugin.xml
@@ -3,7 +3,7 @@
 <plugin>
 
      <extension
-         point="org.eclipse.core.runtime.contentTypes">
+         point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="xml"


### PR DESCRIPTION
Migrate org.eclipse.core.runtime.contentTypes extension points to org.eclipse.core.contenttype.contentTypes
