### PR TITLE
JBIDE-18282: NPE when expanding console configuration after creating Seam 2.3 project

### DIFF
--- a/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/EclipseLaunchConsoleConfigurationPreferences.java
+++ b/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/EclipseLaunchConsoleConfigurationPreferences.java
@@ -252,10 +252,11 @@ public class EclipseLaunchConsoleConfigurationPreferences implements ConsoleConf
 
 	@Override
 	public String getHibernateVersion() {
+		String defaultVersion = "3.5"; //$NON-NLS-1$
 		if (launchConfiguration.exists()){
-			return getAttribute(IConsoleConfigurationLaunchConstants.HIBERNATE_VERSION, "3.5"); //$NON-NLS-1$
+			return getAttribute(IConsoleConfigurationLaunchConstants.HIBERNATE_VERSION, defaultVersion);
 		}
-		return null;
+		return defaultVersion; 
 	}
 
 }


### PR DESCRIPTION
Use Hibernate 3.5 as a default when not specified
