### PR TITLE
JBIDE-20042 Cannot generate hbm.xml from java class

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractHibernateMappingExporterFacade.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractHibernateMappingExporterFacade.java
@@ -69,8 +69,8 @@ implements IHibernateMappingExporter {
 		Util.invokeMethod(
 				getTarget(), 
 				"superExportPOJO", 
-				new Class[] { getPOJOClassClass() }, 
-				new Object[] { pojoClassTarget });
+				new Class[] { Map.class, getPOJOClassClass() }, 
+				new Object[] { map, pojoClassTarget });
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractPersistentClassFacade.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractPersistentClassFacade.java
@@ -263,11 +263,11 @@ implements IPersistentClass {
 	}
 
 	@Override
-	public void setAbstract(boolean b) {
+	public void setAbstract(Boolean b) {
 		Util.invokeMethod(
 				getTarget(), 
 				"setAbstract", 
-				new Class[] { boolean.class }, 
+				new Class[] { Boolean.class }, 
 				new Object[] { b });
 	}
 

--- a/plugins/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IPersistentClass.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IPersistentClass.java
@@ -27,7 +27,7 @@ public interface IPersistentClass {
 	void setClassName(String className);
 	void setEntityName(String entityName);
 	void setDiscriminatorValue(String value);
-	void setAbstract(boolean b);
+	void setAbstract(Boolean b);
 	void addProperty(IProperty property);
 	boolean isInstanceOfJoinedSubclass();
 	void setTable(ITable table);


### PR DESCRIPTION
Multiple issues found while looking into this.

. `IPersistentClass` had setAbstract(boolean) instead of
setAbstract(Boolean)
. Call to `exportPojo` was done with wrong argument types and count.

I fear there might be more but this patch seem to at least make the
situation better as opposed to worse since the code could never have
worked with the current logic.



Signed-off-by: Max Rydahl Andersen <manderse@redhat.com>