### PR TITLE
JBIDE-19323: add check if dialect exists in jdbc services

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ConfigurationFacadeImpl.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ConfigurationFacadeImpl.java
@@ -1,8 +1,11 @@
 package org.jboss.tools.hibernate.runtime.v_4_3.internal;
 
+import java.sql.SQLException;
+
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
+import org.hibernate.exception.GenericJDBCException;
 import org.hibernate.service.ServiceRegistry;
 import org.jboss.tools.hibernate.runtime.common.AbstractConfigurationFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
@@ -20,6 +23,9 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	protected Object buildTargetSessionFactory() {
 		if (serviceRegistry == null) {
 			buildServiceRegistry();
+		}
+		if (serviceRegistry.getService(org.hibernate.engine.jdbc.spi.JdbcServices.class).getDialect() == null) {
+			throw new GenericJDBCException("Could not open connection", new SQLException());
 		}
 		return ((Configuration)getTarget()).buildSessionFactory(serviceRegistry);
 	}


### PR DESCRIPTION
The NPE happens [here](https://github.com/hibernate/hibernate-orm/blob/4.3/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java#L1888), because it can't get dialect when the jdbc connection is broken. It only happens in 4.3 version.  In 4.0 it throws "org.hibernate.exception.GenericJDBCException: Could not open connection". So i fixed it to run the same way.
I'm not not sure if it is the right kind of fix, so ready for your comments and advises.
