### PR TITLE
JBIDE-16503 - Empty Hibernate Console Configuration dialog

### DIFF
--- a/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/ConsoleConfigurationWizardPage.java
+++ b/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/ConsoleConfigurationWizardPage.java
@@ -207,6 +207,7 @@ public class ConsoleConfigurationWizardPage extends WizardPage implements
 		sc.setMinSize(tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 		setControl(sc);
 		dialogChanged();
+		parent.layout(true, false);
 	}
 
 	protected void initTabs(CTabFolder folder) {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16503
Empty Hibernate Console Configuration dialog