### PR TITLE
JBIDE-25132: Remove interface 'org.jboss.tools.hibernate.runtime.spi.IMappings' - Remove unused method IFacadeFactory#createMappings(Object)

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractFacadeFactory.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractFacadeFactory.java
@@ -20,7 +20,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -89,10 +88,6 @@ public abstract class AbstractFacadeFactory implements IFacadeFactory {
 	
 	public IExporter createExporter(Object target) {
 		return new AbstractExporterFacade(this, target) {};
-	}
-	
-	public IMappings createMappings(Object target) {
-		return new AbstractMappingsFacade(this, target) {};
 	}
 	
 	@Override

--- a/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacadeFactory.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacadeFactory.java
@@ -20,7 +20,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -56,7 +55,6 @@ public interface IFacadeFactory {
 	IQueryExporter createQueryExporter(Object target);
 	ITableFilter createTableFilter(Object target);
 	IExporter createExporter(Object target);
-	IMappings createMappings(Object target);
 	IClassMetadata createClassMetadata(Object target);
 	ICollectionMetadata createCollectionMetadata(Object target);
 	IColumn createColumn(Object target);

--- a/tests/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/FacadeFactoryTest.java
@@ -71,7 +71,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -200,16 +199,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Mappings mappings = (Mappings)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Mappings.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/FacadeFactoryTest.java
@@ -70,7 +70,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -199,16 +198,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Mappings mappings = (Mappings)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Mappings.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/FacadeFactoryTest.java
@@ -71,7 +71,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -200,16 +199,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Mappings mappings = (Mappings)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Mappings.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/FacadeFactoryTest.java
@@ -72,7 +72,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -201,16 +200,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Mappings mappings = (Mappings)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Mappings.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/FacadeFactoryTest.java
@@ -13,7 +13,6 @@ import org.hibernate.Filter;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
 import org.hibernate.boot.internal.SessionFactoryOptionsImpl;
@@ -82,7 +81,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -217,16 +215,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Metadata mappings = (Metadata)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Metadata.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/FacadeFactoryTest.java
@@ -13,7 +13,6 @@ import org.hibernate.Filter;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
 import org.hibernate.boot.internal.SessionFactoryOptionsImpl;
@@ -82,7 +81,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -217,16 +215,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Metadata mappings = (Metadata)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Metadata.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/FacadeFactoryTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/FacadeFactoryTest.java
@@ -13,7 +13,6 @@ import org.hibernate.Filter;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
 import org.hibernate.boot.internal.SessionFactoryOptionsImpl;
@@ -82,7 +81,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJDBCReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -217,16 +215,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IExporter facade = facadeFactory.createExporter(exporter);
 		Assert.assertSame(exporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateMappings() {
-		Metadata mappings = (Metadata)Proxy.newProxyInstance(
-				facadeFactory.getClassLoader(), 
-				new Class[] { Metadata.class }, 
-				new TestInvocationHandler());
-		IMappings facade = facadeFactory.createMappings(mappings);
-		Assert.assertSame(mappings, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>