### PR TITLE
JBIDE-25132: Remove interface 'org.jboss.tools.hibernate.runtime.spi.IMappings' - Remove unused 'mappings' instance variable from 'org.jboss.tools.hibernate.runtime.v_5_0.internal.ConfigurationFacadeImpl'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ConfigurationFacadeImpl.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ConfigurationFacadeImpl.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.util.MetadataHelper;
 import org.jboss.tools.hibernate.runtime.common.AbstractConfigurationFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
@@ -41,7 +40,6 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	Metadata metadata = null;
 	
 	INamingStrategy namingStrategy = null;
-	IMappings mappings = null;
 	ArrayList<IPersistentClass> addedClasses = new ArrayList<IPersistentClass>();
 
 	public ConfigurationFacadeImpl(IFacadeFactory facadeFactory, Object target) {
@@ -104,7 +102,6 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	@Override 
 	public void buildMappings() {
 		getMetadata();
-		mappings = new MappingsFacadeImpl(this);
 	}
 	
 	@Override

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ConfigurationFacadeTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ConfigurationFacadeTest.java
@@ -185,10 +185,8 @@ public class ConfigurationFacadeTest {
 		barWriter.close();
 		configuration.addFile(barFile);
 		ConfigurationFacadeImpl facade = (ConfigurationFacadeImpl)configurationFacade;
-		Assert.assertNull(facade.mappings);
 		Assert.assertNull(facade.metadata);
 		configurationFacade.buildMappings();
-		Assert.assertNotNull(facade.mappings);
 		String collectionName = 
 				"org.jboss.tools.hibernate.runtime.v_5_0.internal.ConfigurationFacadeTest$Bar.fooSet";
 		Collection collection = facade.metadata.getCollectionBinding(collectionName);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>