### PR TITLE
JBIDE-25132: Remove interface 'org.jboss.tools.hibernate.runtime.spi.IMappings' - Remove unused 'mappings' instance variable from 'org.jboss.tools.hibernate.runtime.v_5_0.internal.ConfigurationFacadeImpl'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ConfigurationFacadeImpl.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ConfigurationFacadeImpl.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.util.MetadataHelper;
 import org.jboss.tools.hibernate.runtime.common.AbstractConfigurationFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
@@ -40,7 +39,6 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	EntityResolver entityResolver = null;
 	
 	INamingStrategy namingStrategy = null;
-	IMappings mappings = null;
 	ArrayList<IPersistentClass> addedClasses = new ArrayList<IPersistentClass>();
 
 	public ConfigurationFacadeImpl(IFacadeFactory facadeFactory, Object target) {
@@ -103,7 +101,6 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	@Override 
 	public void buildMappings() {
 		getMetadata();
-		mappings = new MappingsFacadeImpl(this);
 	}
 	
 	@Override

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ConfigurationFacadeTest.java
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ConfigurationFacadeTest.java
@@ -152,12 +152,7 @@ public class ConfigurationFacadeTest {
 	
 	@Test
 	public void testBuildMappings() throws Exception {
-		ConfigurationFacadeImpl facade = (ConfigurationFacadeImpl)configurationFacade;
-		Assert.assertNull(facade.mappings);
 		configurationFacade.buildMappings();
-		Assert.assertNotNull(facade.mappings);
-		MappingsFacadeImpl mappings = (MappingsFacadeImpl)facade.mappings;
-		Assert.assertSame(configurationFacade, mappings.configuration);
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>