### PR TITLE
JBIDE-25132: Remove interface 'org.jboss.tools.hibernate.runtime.spi.IMappings' - Remove unused interface 'org.jboss.tools.hibernate.runtime.spi.IMappings'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IMappings.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IMappings.java
@@ -1,5 +1,0 @@
-package org.jboss.tools.hibernate.runtime.spi;
-
-public interface IMappings {
-
-}

--- a/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/ConsoleConfigurationTest.java
+++ b/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/ConsoleConfigurationTest.java
@@ -16,7 +16,6 @@ import org.hibernate.eclipse.console.test.launchcfg.TestConsoleConfigurationPref
 import org.hibernate.eclipse.console.views.QueryPageTabView;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
-import org.jboss.tools.hibernate.runtime.spi.IMappings;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IPrimaryKey;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>