### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Add '.gitignore' to 'org.jboss.tools.hibernate.xml' ignoring generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.xml/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.xml/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>