### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Add '.gitignore' to 'org.jboss.tools.hibernate.search.test.feature' ignoring generated '.project' and '.settings/'

### DIFF
--- a/features/org.jboss.tools.hibernate.search.test.feature/.gitignore
+++ b/features/org.jboss.tools.hibernate.search.test.feature/.gitignore
@@ -1,0 +1,2 @@
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>