### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit '.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/hibernate-search-tests/org.jboss.tools.hibernate.search.test/.gitignore
+++ b/hibernate-search-tests/org.jboss.tools.hibernate.search.test/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 /lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>