### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.search.runtime.v_5_3/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.v_5_3/.gitignore
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.v_5_3/.gitignore
@@ -1,1 +1,4 @@
-/lib/
+.classpath
+.project
+.settings/
+lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>