### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Create 'org.jboss.tools.hibernate.search.runtime.common/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.common/.gitignore
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.common/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>