### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.search/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search/.gitignore
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search/.gitignore
@@ -1,5 +1,5 @@
-bin/
-target/
-build/
+.classpath
+.project
+.settings/
 lib/
 org.jboss.tools.hibernate.search.jar


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>