### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.runtime.v_5_1/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_1/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_1/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>