### PR TITLE
Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.runtime.v_4_3/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/tests/org.jboss.tools.hibernate.runtime.v_4_3.test/.gitignore
+++ b/tests/org.jboss.tools.hibernate.runtime.v_4_3.test/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>