### PR TITLE
Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.runtime.v_4_0/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_4_0/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_4_0/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>