### PR TITLE
Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.runtime.spi.test/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/tests/org.jboss.tools.hibernate.runtime.spi.test/.gitignore
+++ b/tests/org.jboss.tools.hibernate.runtime.spi.test/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>