### PR TITLE
Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>