### PR TITLE
Remove the Eclipse related files from git - Edit 'org.jboss.tools.hibernate.jpt.ui/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.jpt.ui/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.jpt.ui/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>