### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit 'org.hibernate.eclipse.jdt.ui/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.hibernate.eclipse.jdt.ui/.gitignore
+++ b/plugins/org.hibernate.eclipse.jdt.ui/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>