### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Edit 'org.hibernate.eclipse.help/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.hibernate.eclipse.help/.gitignore
+++ b/plugins/org.hibernate.eclipse.help/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 help.jar


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>