### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Create 'org.hibernate.eclipse.console.test/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/tests/org.hibernate.eclipse.console.test/.gitignore
+++ b/tests/org.hibernate.eclipse.console.test/.gitignore
@@ -1,0 +1,3 @@
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>