### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Create 'org.hibernate.eclipse.console/.gitignore' to include generated '.classpath', '.project' and '.settings/'

### DIFF
--- a/plugins/org.hibernate.eclipse.console/.gitignore
+++ b/plugins/org.hibernate.eclipse.console/.gitignore
@@ -1,1 +1,4 @@
+.classpath
+.project
+.settings/
 org.hibernate.eclipse.console.jar


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>