### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'features/org.jboss.tools.hibernate.search.test.feature/.gitignore' file

### DIFF
--- a/features/org.jboss.tools.hibernate.search.test.feature/.gitignore
+++ b/features/org.jboss.tools.hibernate.search.test.feature/.gitignore
@@ -1,2 +1,0 @@
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>