### PR TITLE
JBIDE-25284: Use default plugin classpath in 'org.jboss.tools.hibernate.search'

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
@@ -26,6 +26,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.1.2",
  org.jboss.tools.hibernate.search.runtime.spi;bundle-version="2.0.0",
  org.eclipse.ui;bundle-version="3.109.0"
-Bundle-ClassPath: org.jboss.tools.hibernate.search.jar
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.jboss.tools.hibernate.search.HibernateSearchConsolePlugin

--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search/build.properties
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search/build.properties
@@ -1,7 +1,5 @@
-output.. = bin/
+source.. = src/
+output.. = target/classes/
 bin.includes = META-INF/,\
-               plugin.xml,\
-               org.jboss.tools.hibernate.search.jar
-jars.compile.order = org.jboss.tools.hibernate.search.jar
-output.org.jboss.tools.hibernate.search.jar = bin/
-source.org.jboss.tools.hibernate.search.jar = src/
+               .,\
+               plugin.xml


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>