### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.common/.gitignore' file

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.common/.gitignore
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.common/.gitignore
@@ -1,3 +1,0 @@
-.classpath
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>