### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.v_4_0/.gitignore' file

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.v_4_0/.gitignore
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.v_4_0/.gitignore
@@ -1,4 +1,0 @@
-.classpath
-.project
-.settings/
-lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>