### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'hibernate-search-plugins/.gitignore' file

### DIFF
--- a/hibernate-search-plugins/.gitignore
+++ b/hibernate-search-plugins/.gitignore
@@ -1,2 +1,0 @@
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>