### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'hibernate-search-tests/org.jboss.tools.hibernate.search.test/.gitignore' file

### DIFF
--- a/hibernate-search-tests/org.jboss.tools.hibernate.search.test/.gitignore
+++ b/hibernate-search-tests/org.jboss.tools.hibernate.search.test/.gitignore
@@ -1,4 +1,0 @@
-.classpath
-.project
-.settings/
-/lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>