### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'plugins/org.hibernate.eclipse/.gitignore' file

### DIFF
--- a/plugins/org.hibernate.eclipse/.gitignore
+++ b/plugins/org.hibernate.eclipse/.gitignore
@@ -1,4 +1,0 @@
-.classpath
-.project
-.settings/
-org.hibernate.eclipse.jar


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>