### PR TITLE
JBIDE-25290: Use default plugin classpath in 'org.hibernate.eclipse.console'

### DIFF
--- a/plugins/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
+++ b/plugins/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.console; singleton:=true
 Bundle-Version: 5.2.1.qualifier
-Bundle-ClassPath: org.hibernate.eclipse.console.jar
 Bundle-Activator: org.hibernate.eclipse.console.HibernateConsolePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/plugins/org.hibernate.eclipse.console/build.properties
+++ b/plugins/org.hibernate.eclipse.console/build.properties
@@ -1,11 +1,9 @@
-source.org.hibernate.eclipse.console.jar = src/
-output.org.hibernate.eclipse.console.jar = target/classes/
+source.. = src/
+output.. = target/classes/
 bin.includes = plugin.xml,\
                icons/,\
-               org.hibernate.eclipse.console.jar,\
+               .,\
                doc/,\
                META-INF/,\
                about.html,\
                plugin.properties
-src.includes = icons/,\
-               doc/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>