### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'plugins/org.jboss.tools.libs.dom4j.v_1_6_1/.gitignore' file

### DIFF
--- a/plugins/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/.gitignore
@@ -1,4 +1,0 @@
-.classpath
-.project
-.settings/
-lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>