### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'plugins/org.jboss.tools.hibernate.runtime.spi/.gitignore' file

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.spi/.gitignore
+++ b/plugins/org.jboss.tools.hibernate.runtime.spi/.gitignore
@@ -1,3 +1,0 @@
-.classpath
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>