### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'test-framework/org.jboss.tools.hibernate.reddeer/.gitignore' file

### DIFF
--- a/test-framework/org.jboss.tools.hibernate.reddeer/.gitignore
+++ b/test-framework/org.jboss.tools.hibernate.reddeer/.gitignore
@@ -1,6 +1,0 @@
-screenshots/
-target/
-bin/
-/.classpath
-/.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>