### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'tests/org.hibernate.eclipse.jdt.ui.test/.gitignore' file

### DIFF
--- a/tests/org.hibernate.eclipse.jdt.ui.test/.gitignore
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/.gitignore
@@ -1,3 +1,0 @@
-.classpath
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>