### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'tests/org.jboss.tools.hibernate.jpt.core.test/.gitignore' file

### DIFF
--- a/tests/org.jboss.tools.hibernate.jpt.core.test/.gitignore
+++ b/tests/org.jboss.tools.hibernate.jpt.core.test/.gitignore
@@ -1,3 +1,0 @@
-.classpath
-.project
-.settings/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>