### PR TITLE
JBIDE-25202: Remove the Eclipse related files from git - Remove unneeded 'tests/org.jboss.tools.hibernate.runtime.v_5_0.test/.gitignore' file

### DIFF
--- a/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/.gitignore
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/.gitignore
@@ -1,4 +1,0 @@
-.classpath
-.project
-.settings/
-lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>