### PR TITLE
JBIDE-25372: Remove 'plugin.properties' from 'src.includes' in plugin 'org.hibernate.eclipse.jdt.ui'

### DIFF
--- a/plugins/org.hibernate.eclipse.jdt.ui/build.properties
+++ b/plugins/org.hibernate.eclipse.jdt.ui/build.properties
@@ -6,5 +6,4 @@ bin.includes = META-INF/,\
                icons/,\
                plugin.properties,\
                about.html
-src.includes = icons/,\
-               plugin.properties
+src.includes = icons/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>