### PR TITLE
JBIDE-25282: Clean up 'build.properties' in 'org.jboss.tools.hibernate.search.runtime.spi'

### DIFF
--- a/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.spi/build.properties
+++ b/hibernate-search-plugins/org.jboss.tools.hibernate.search.runtime.spi/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
                plugin.xml


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>