### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Move 'org.hibernate.eclipse.console.test.ContentAssistTest' to 'org.jboss.tools.hibernate.orm.test.ContentAssistTest'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ContentAssistTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ContentAssistTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.eclipse.console.test;
+package org.jboss.tools.hibernate.orm.test;
 
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
@@ -7,18 +7,33 @@ import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.jdt.core.IJavaProject;
 import org.hibernate.eclipse.console.properties.HibernatePropertiesConstants;
 import org.hibernate.eclipse.console.utils.ProjectUtils;
+import org.jboss.tools.hibernate.orm.test.utils.HibernateConsoleTestHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
-public class ContentAssistTest extends HibernateConsoleTest {
-
-	public ContentAssistTest(String name) {
-		super( name ); 
+public class ContentAssistTest {
+	
+	private HibernateConsoleTestHelper hcth = null;
+	
+	@Before
+	public void setUp() throws Exception {
+		hcth = new HibernateConsoleTestHelper();
+		hcth.setUp();
 	}
 	
+	@After
+	public void tearDown() throws Exception {
+		hcth.tearDown();
+		hcth = null;
+	}
+
+	@Test
 	public void testEnableHibernateNature() throws BackingStoreException, CoreException {
 		
-		IJavaProject prj = getProject().getIJavaProject();
+		IJavaProject prj = hcth.getProject().getIJavaProject();
 		IScopeContext scope = new ProjectScope(prj.getProject() );
 		
 	

--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/utils/HibernateConsoleTestHelper.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/utils/HibernateConsoleTestHelper.java
@@ -55,5 +55,9 @@ public class HibernateConsoleTestHelper {
 		this.project = null;
 
 	}
+	
+	public SimpleTestProject getProject() {
+		return this.project;
+	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>