### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Move 'org.hibernate.eclipse.hqleditor.HQLEditorTest' to 'org.jboss.tools.hibernate.orm.test.HQLEditorTest'

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ConfigurationFacadeImpl.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ConfigurationFacadeImpl.java
@@ -172,7 +172,7 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 	}
 	
 	private Metadata metadata = null;
-	private Metadata getMetadata() {
+	Metadata getMetadata() {
 		if (metadata == null) {
 			metadata = MetadataHelper.getMetadata((Configuration)getTarget());
 		}

--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
@@ -136,9 +136,9 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public IHQLCodeAssist newHQLCodeAssist(IConfiguration hcfg) {
 		IHQLCodeAssist result = null;
-		if (hcfg instanceof IFacade) {
+		if (hcfg instanceof ConfigurationFacadeImpl) {
 			result = facadeFactory.createHQLCodeAssist(
-					new HQLCodeAssist((Configuration)((IFacade)hcfg).getTarget()));
+					new HQLCodeAssist(((ConfigurationFacadeImpl)hcfg).getMetadata()));
 		}
 		return result;
 	}

--- a/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/ConsolePluginAllTests.java
+++ b/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/ConsolePluginAllTests.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.hibernate.eclipse.console.test.mappingproject.MappingTestsAnnotations;
 import org.hibernate.eclipse.console.test.mappingproject.MappingTestsCore;
 import org.hibernate.eclipse.console.test.mappingproject.MappingTestsJpa;
-import org.hibernate.eclipse.hqleditor.HQLEditorTest;
 import org.hibernate.eclipse.mapper.HBMInfoExtractorTest;
 
 import junit.framework.Test;
@@ -17,7 +16,6 @@ public class ConsolePluginAllTests {
 		TestSuite suite = new TestSuite(
 				ConsoleTestMessages.ConsolePluginAllTests_test_for );
 
-		suite.addTestSuite(HQLEditorTest.class);		
 		suite.addTestSuite(MappingTestsCore.class);
 		suite.addTestSuite(MappingTestsJpa.class);
 		suite.addTestSuite(MappingTestsAnnotations.class);

--- a/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -25,7 +25,9 @@ Require-Bundle: org.hibernate.eclipse,
  org.jboss.tools.hibernate.libs.bsh.v_2_0_b4,
  org.eclipse.jface.text,
  org.apache.ant,
- org.eclipse.debug.ui
+ org.eclipse.debug.ui,
+ org.eclipse.ui.editors;bundle-version="3.11.0",
+ org.eclipse.jdt.apt.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util

--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/HQLEditorTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/HQLEditorTest.java
@@ -8,13 +8,12 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.hibernate.eclipse.hqleditor;
+package org.jboss.tools.hibernate.orm.test;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -36,82 +35,103 @@ import org.hibernate.console.KnownConfigurations;
 import org.hibernate.console.QueryInputModel;
 import org.hibernate.eclipse.console.HibernateConsoleMessages;
 import org.hibernate.eclipse.console.HibernateConsolePlugin;
-import org.hibernate.eclipse.console.test.launchcfg.TestConsoleConfigurationPreferences;
-import org.hibernate.eclipse.console.test.project.SimpleTestProject;
-import org.hibernate.eclipse.console.test.project.SimpleTestProjectWithMapping;
-import org.hibernate.eclipse.console.test.project.TestProject;
-import org.hibernate.eclipse.console.test.utils.ConsoleConfigUtils;
 import org.hibernate.eclipse.console.views.QueryParametersPage;
 import org.hibernate.eclipse.console.views.QueryParametersView;
+import org.hibernate.eclipse.hqleditor.HQLCompletionProcessor;
+import org.hibernate.eclipse.hqleditor.HQLEditor;
+import org.jboss.tools.hibernate.orm.test.utils.ConsoleConfigUtils;
+import org.jboss.tools.hibernate.orm.test.utils.TestConsoleConfigurationPreferences;
+import org.jboss.tools.hibernate.orm.test.utils.project.SimpleTestProject;
+import org.jboss.tools.hibernate.orm.test.utils.project.SimpleTestProjectWithMapping;
+import org.jboss.tools.hibernate.orm.test.utils.project.TestProject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Dmitry Geraskov
  *
  */
-public class HQLEditorTest extends TestCase {
+public class HQLEditorTest {
 	
+	private static final String HIBERNATE_CFG_XML = 
+			"<!DOCTYPE hibernate-configuration PUBLIC                               " +
+			"	'-//Hibernate/Hibernate Configuration DTD 3.0//EN'                  " +
+			"	'http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd'> " +
+			"                                                                       " +
+			"<hibernate-configuration>                                              " +
+			"	<session-factory/>                                                  " + 
+			"</hibernate-configuration>                                             " ;		
+		
 	private static final String PROJ_NAME = "HQLEditorTest"; //$NON-NLS-1$
 	private static final String CONSOLE_NAME = PROJ_NAME;
 	
-	private SimpleTestProjectWithMapping project = null;
-	
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+		
+	private File cfgXmlFile = null;
+	private SimpleTestProjectWithMapping project = null;	
 	private TestConsoleConfigurationPreferences consolePrefs;
 	private ConsoleConfiguration consoleConfiguration;
 	
-	protected void setUp() throws Exception {
-		consolePrefs = new TestConsoleConfigurationPreferences();
+	@Before
+	public void setUp() throws Exception {
+		cfgXmlFile = new File(temporaryFolder.getRoot(), "hibernate.cfg.xml");
+		FileWriter fw = new FileWriter(cfgXmlFile);
+		fw.write(HIBERNATE_CFG_XML);
+		fw.close();
+		consolePrefs = new TestConsoleConfigurationPreferences(cfgXmlFile);
 		consoleConfiguration = new ConsoleConfiguration(consolePrefs);
 		KnownConfigurations.getInstance().addConfiguration(consoleConfiguration, false);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		consolePrefs = null;
 		consoleConfiguration = null;
 		KnownConfigurations.getInstance().removeAllConfigurations();
 		cleanUpProject();
 	}
 	
-	protected void cleanUpProject() {
-		if (project != null) {
-			project.deleteIProject();
-			project = null;
-		}
-	}
-
+	@Test
 	public void testHQLEditorOpen(){
 		IEditorPart editorPart = HibernateConsolePlugin.getDefault()
 			.openScratchHQLEditor(consoleConfiguration.getName(), ""); //$NON-NLS-1$
-		assertNotNull("Editor was not opened", editorPart); //$NON-NLS-1$
-		assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
+		Assert.assertNotNull("Editor was not opened", editorPart); //$NON-NLS-1$
+		Assert.assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
 		
 		HQLEditor editor = (HQLEditor)editorPart;		
 		QueryInputModel model = editor.getQueryInputModel();
-		assertNotNull("Model is NULL", model); //$NON-NLS-1$
+		Assert.assertNotNull("Model is NULL", model); //$NON-NLS-1$
 	}
 	
+	@Test
 	public void testSingleLineCommentsCutOff() throws PartInitException{
 		String query = "from pack.Article a\n" + //$NON-NLS-1$
 				"where a.articleid in (:a, :b) --or a.articleid = :c"; //$NON-NLS-1$
 		IEditorPart editorPart = HibernateConsolePlugin.getDefault()
 			.openScratchHQLEditor(consoleConfiguration.getName(), query);
-		assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
+		Assert.assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
 		
 		HQLEditor editor = (HQLEditor)editorPart;
-		assertEquals(editor.getEditorText(), query);
-		assertFalse("Comments were not cut off", editor.getQueryString().contains("--")); //$NON-NLS-1$ //$NON-NLS-2$
+		Assert.assertEquals(editor.getEditorText(), query);
+		Assert.assertFalse("Comments were not cut off", editor.getQueryString().contains("--")); //$NON-NLS-1$ //$NON-NLS-2$
 		
 		QueryInputModel model = editor.getQueryInputModel();
-		assertTrue(model.getParameterCount() == 0);
+		Assert.assertTrue(model.getParameterCount() == 0);
 		
 		IViewPart view = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
 			.getActivePage().showView("org.hibernate.eclipse.console.views.QueryParametersView"); //$NON-NLS-1$
-		assertNotNull("View was not opened", view); //$NON-NLS-1$
-		assertTrue("Opened view is not QueryParametersView", view instanceof QueryParametersView); //$NON-NLS-1$
+		Assert.assertNotNull("View was not opened", view); //$NON-NLS-1$
+		Assert.assertTrue("Opened view is not QueryParametersView", view instanceof QueryParametersView); //$NON-NLS-1$
 		
 		QueryParametersView paramView = (QueryParametersView)view;
 		IPage ipage = paramView.getCurrentPage();
-		assertNotNull("Current Page is NULL", ipage); //$NON-NLS-1$
-		assertTrue("Page is not Query Parameters Page", ipage instanceof QueryParametersPage); //$NON-NLS-1$
+		Assert.assertNotNull("Current Page is NULL", ipage); //$NON-NLS-1$
+		Assert.assertTrue("Page is not Query Parameters Page", ipage instanceof QueryParametersPage); //$NON-NLS-1$
 		
 		QueryParametersPage page = (QueryParametersPage)ipage;
 		IToolBarManager manager = page.getSite().getActionBars().getToolBarManager();
@@ -124,14 +144,15 @@ public class HQLEditorTest extends TestCase {
 				break;
 			}
 		}
-		assertNotNull(HibernateConsoleMessages.QueryParametersPage_add_query_parameter_tooltip
+		Assert.assertNotNull(HibernateConsoleMessages.QueryParametersPage_add_query_parameter_tooltip
 				+ " item not found", addParamItem); //$NON-NLS-1$
 		
 		addParamItem.getAction().run();//add query parameters automatically
-		assertTrue(model.getParameterCount() == 2);//a and b
+		Assert.assertTrue(model.getParameterCount() == 2);//a and b
 		
 	}
 
+	@Test
 	public void testHQLEditorCodeCompletionWithTabs() throws CoreException, NoSuchFieldException, IllegalAccessException{
 		cleanUpProject();
 		project = new SimpleTestProjectWithMapping(PROJ_NAME);
@@ -148,7 +169,7 @@ public class HQLEditorTest extends TestCase {
 			TestProject.SRC_FOLDER + File.separator + ConsoleConfigUtils.CFG_FILE_NAME);
 		ConsoleConfigUtils.createConsoleConfig(PROJ_NAME, cfgFilePath, CONSOLE_NAME);
 		ConsoleConfiguration cc = KnownConfigurations.getInstance().find(CONSOLE_NAME);
-		assertNotNull("Console Configuration not found", cc); //$NON-NLS-1$
+		Assert.assertNotNull("Console Configuration not found", cc); //$NON-NLS-1$
 		cc.build();
 
 		final String codeCompletionPlaceMarker = " from "; //$NON-NLS-1$
@@ -156,13 +177,13 @@ public class HQLEditorTest extends TestCase {
 			project.getFullyQualifiedTestClassName() + " t1"; //$NON-NLS-1$
 		IEditorPart editorPart = HibernateConsolePlugin.getDefault()
 			.openScratchHQLEditor(CONSOLE_NAME, query);
-		assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
+		Assert.assertTrue("Opened editor is not HQLEditor", editorPart instanceof HQLEditor); //$NON-NLS-1$
 		
 		HQLEditor editor = (HQLEditor)editorPart;
-		assertEquals(editor.getEditorText(), query);
+		Assert.assertEquals(editor.getEditorText(), query);
 		
 		QueryInputModel model = editor.getQueryInputModel();
-		assertTrue(model.getParameterCount() == 0);
+		Assert.assertTrue(model.getParameterCount() == 0);
 		
 		editor.setConsoleConfigurationName(CONSOLE_NAME);
 		IDocument doc = editor.getDocumentProvider().getDocument(editor.getEditorInput());
@@ -171,7 +192,15 @@ public class HQLEditorTest extends TestCase {
 		
 		int position = query.indexOf(codeCompletionPlaceMarker);
 		ICompletionProposal[] proposals = processor.computeCompletionProposals(doc, position);
-		assertTrue(proposals.length > 0);
+		Assert.assertTrue(proposals.length > 0);
 		cc.reset();
 	}
+	
+	private void cleanUpProject() {
+		if (project != null) {
+			project.deleteIProject();
+			project = null;
+		}
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>