### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Move CompositeIdMappingTest from org.jboss.tools.hibernate.orm.test to org.jboss.tools.hibernate.orm.test.mapping

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/mapping/CompositeIdMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/mapping/CompositeIdMappingTest.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.hibernate.orm.test;
+package org.jboss.tools.hibernate.orm.test.mapping;
 
 import org.jboss.tools.hibernate.orm.test.utils.MappingTestHelper;
 import org.junit.After;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>