### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Properly calculate the resource path under test in MappingTestHelper

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/utils/MappingTestHelper.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/utils/MappingTestHelper.java
@@ -337,7 +337,8 @@ public class MappingTestHelper {
 	}
 	
 	private void copyHbmXmlAndJavaFiles() throws Exception {
-		File source = ResourceReadUtils.getResourceItem("res/project/src/mapping/abstractembeddedcomponents/cid");
+		String path = "res/project/src/" + packageName.replace('.', '/');
+		File source = ResourceReadUtils.getResourceItem(path);
 		IFolder destination = createPackage(packageName);
 		FilesTransfer.copyFolder(source, destination);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>