### PR TITLE
JBIDE-25749: Replace uses of deprecated field AST.JLS8 by AST.JLS9 in class org.eclipse.jdt.core.dom.AST

### DIFF
--- a/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/utils/ProjectUtils.java
+++ b/plugins/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/utils/ProjectUtils.java
@@ -330,7 +330,7 @@ public class ProjectUtils {
 	
 	static public org.eclipse.jdt.core.dom.CompilationUnit getCompilationUnit(
 			ICompilationUnit source, boolean bindings) {
-		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		ASTParser parser = ASTParser.newParser(AST.JLS9);
 		parser.setSource(source);
 		parser.setResolveBindings(bindings);
 		org.eclipse.jdt.core.dom.CompilationUnit result = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(null);

--- a/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/HQLExpressionCompilerParticipant.java
+++ b/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/HQLExpressionCompilerParticipant.java
@@ -21,7 +21,7 @@ public class HQLExpressionCompilerParticipant extends CompilationParticipant {
 	}
 
 	protected CompilationUnit parse(ICompilationUnit unit) {
-		ASTParser parser = ASTParser.newParser(AST.JLS8); 
+		ASTParser parser = ASTParser.newParser(AST.JLS9); 
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(unit); 
 		parser.setResolveBindings(false); 
@@ -33,7 +33,7 @@ public class HQLExpressionCompilerParticipant extends CompilationParticipant {
 			BuildContext context = files[i];
 			ConsoleConfiguration consoleConfiguration = getConsoleConfiguration( ProjectUtils.findJavaProject( context.getFile().getProject().getName() ) );
 			if(consoleConfiguration!=null && consoleConfiguration.isSessionFactoryCreated()) {
-				ASTParser parser = ASTParser.newParser( AST.JLS8 );
+				ASTParser parser = ASTParser.newParser( AST.JLS9 );
 				parser.setKind( ASTParser.K_COMPILATION_UNIT );
 				parser.setSource( context.getContents() );
 				parser.setResolveBindings( false );

--- a/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/jpa/actions/JPAMapToolActor.java
+++ b/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/jpa/actions/JPAMapToolActor.java
@@ -240,7 +240,7 @@ public class JPAMapToolActor {
 						sDocument = (SynchronizableDocument)fDocument;
 					}
 					if (sDocument != null) {
-						ASTParser parser = ASTParser.newParser(AST.JLS8);
+						ASTParser parser = ASTParser.newParser(AST.JLS9);
 						parser.setSource(sDocument.get().toCharArray());
 						parser.setResolveBindings(false);
 						resultCU = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(null);

--- a/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/jpa/common/Utils.java
+++ b/plugins/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/internal/jpa/common/Utils.java
@@ -37,7 +37,7 @@ public class Utils {
 
 	static public org.eclipse.jdt.core.dom.CompilationUnit getCompilationUnit(
 			ICompilationUnit source, boolean bindings) {
-		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		ASTParser parser = ASTParser.newParser(AST.JLS9);
 		parser.setSource(source);
 		parser.setResolveBindings(bindings);
 		org.eclipse.jdt.core.dom.CompilationUnit result = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(null);

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/JPAMapTest.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/JPAMapTest.java
@@ -179,7 +179,7 @@ public class JPAMapTest extends TestCase {
 		ICompilationUnit icu = Utils.findCompilationUnit(project.getIJavaProject(),
 				"test.annotated." + testSelection + //$NON-NLS-1$ 
 				"." + strName); //$NON-NLS-1$
-		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		ASTParser parser = ASTParser.newParser(AST.JLS9);
 		parser.setSource(icu);
 		ASTNode astNode = parser.createAST(null);
 		return astNode;
@@ -194,7 +194,7 @@ public class JPAMapTest extends TestCase {
 		if (!resourceFile.exists()) {
 			return null;
 		}
-		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		ASTParser parser = ASTParser.newParser(AST.JLS9);
 		StringBuffer cbuf = new StringBuffer((int) resourceFile.length());
 		try {
 			String ls = System.getProperties().getProperty("line.separator", "\n");  //$NON-NLS-1$//$NON-NLS-2$


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>