### PR TITLE
JBIDE-25764: Remove warning in build.properties of org.jboss.tools.hibernate.runtime.spi.test

### DIFF
--- a/tests/org.jboss.tools.hibernate.runtime.spi.test/build.properties
+++ b/tests/org.jboss.tools.hibernate.runtime.spi.test/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
                fragment.xml


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>