### PR TITLE
JBIDE-25824: Update the dependency of the 'org.jboss.tools.hibernate.orm.test' plugin to the new 5.3 Hibernate runtime

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -7,31 +7,31 @@ Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
 Require-Bundle: org.hibernate.eclipse,
- org.hibernate.eclipse.console;bundle-version="5.2.2",
- org.junit;bundle-version="4.12.0",
- org.jboss.tools.hibernate.runtime.spi;bundle-version="5.2.2",
- org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.2.2",
+ org.hibernate.eclipse.console,
+ org.junit,
+ org.jboss.tools.hibernate.runtime.spi,
  org.eclipse.core.resources,
  org.eclipse.jdt.core,
- org.eclipse.core.runtime;bundle-version="3.13.0",
+ org.eclipse.core.runtime,
  org.eclipse.jdt.ui,
- org.eclipse.ui.ide;bundle-version="3.13.0",
+ org.eclipse.ui.ide,
  org.eclipse.text,
  org.eclipse.debug.core,
  org.eclipse.jdt.launching,
- org.eclipse.jface;bundle-version="3.13.0",
+ org.eclipse.jface,
  org.eclipse.osgi,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.bsh.v_2_0_b4,
  org.eclipse.jface.text,
  org.apache.ant,
  org.eclipse.debug.ui,
- org.eclipse.ui.editors;bundle-version="3.11.0",
+ org.eclipse.ui.editors,
  org.eclipse.jdt.apt.core,
  org.eclipse.datatools.connectivity,
  org.jboss.tools.hibernate.ui,
  org.eclipse.ui.workbench,
- org.hibernate.eclipse.mapper
+ org.hibernate.eclipse.mapper,
+ org.jboss.tools.hibernate.runtime.v_5_3
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>