### PR TITLE
JBIDE-25827: Update plugin execution environment of 'org.jboss.tools.hibernate.runtime.v_5_0.test' to 'JavaSE-1.8'

### DIFF
--- a/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Hibernate Runtime 5.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_0.test
 Bundle-Version: 5.2.3.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
 Bundle-ClassPath: lib/h2-1.4.190.jar,
  .


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>