### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Disable CoreMappingTest completely

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+// TODO BIDE-25553 - Reenable the test 
+@Ignore
 @RunWith(Parameterized.class)
 public class CoreMappingTest {
 	
@@ -175,8 +177,6 @@ public class CoreMappingTest {
 		mappingTestHelper.testCheckConsoleConfiguration();
 	}
 
-	// TODO BIDE-25553 - Reenable the test 
-	@Ignore
 	@Test
 	public void testOpenMappingDiagram() {
 		mappingTestHelper.testOpenMappingDiagram();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>