### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.abstractembeddedcomponents.propertyref' and 'core.version.nodb'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -22,8 +22,8 @@ public class CoreMappingTest {
     public static Collection<Object[]> packages() {
         return Arrays.asList(new Object[][]{
     			{"core.abstractembeddedcomponents.cid"},
+    			{"core.abstractembeddedcomponents.propertyref"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.abstractembeddedcomponents.propertyref"},
 //    			{"core.any"},
 //    			{"core.array"},
 //    			{"core.batch"},
@@ -132,7 +132,7 @@ public class CoreMappingTest {
 //        		{"core.value.type.collection.map"},
 //        		{"core.value.type.collection.set"},
 //        		{"core.version.db"},
-//        		{"core.version.nodb"},
+        		{"core.version.nodb"},
         		{"core.where"} 
         });
     }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>