### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.any' and 'core.version.db'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -23,8 +23,8 @@ public class CoreMappingTest {
         return Arrays.asList(new Object[][]{
     			{"core.abstractembeddedcomponents.cid"},
     			{"core.abstractembeddedcomponents.propertyref"},
+    			{"core.any"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.any"},
 //    			{"core.array"},
 //    			{"core.batch"},
 //    			{"core.batchfetch"},
@@ -131,7 +131,7 @@ public class CoreMappingTest {
 //        		{"core.value.type.collection.list"},
 //        		{"core.value.type.collection.map"},
 //        		{"core.value.type.collection.set"},
-//        		{"core.version.db"},
+        		{"core.version.db"},
         		{"core.version.nodb"},
         		{"core.where"} 
         });


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>