### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.array' and 'core.value.type.collection.set'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -24,8 +24,8 @@ public class CoreMappingTest {
     			{"core.abstractembeddedcomponents.cid"},
     			{"core.abstractembeddedcomponents.propertyref"},
     			{"core.any"},
+    			{"core.array"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.array"},
 //    			{"core.batch"},
 //    			{"core.batchfetch"},
 //    			{"core.bytecode"},
@@ -130,7 +130,7 @@ public class CoreMappingTest {
 //        		{"core.value.type.basic"},
 //        		{"core.value.type.collection.list"},
 //        		{"core.value.type.collection.map"},
-//        		{"core.value.type.collection.set"},
+        		{"core.value.type.collection.set"},
         		{"core.version.db"},
         		{"core.version.nodb"},
         		{"core.where"} 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>