### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.batch' and 'core.value.type.collection.map'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -25,8 +25,8 @@ public class CoreMappingTest {
     			{"core.abstractembeddedcomponents.propertyref"},
     			{"core.any"},
     			{"core.array"},
+    			{"core.batch"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.batch"},
 //    			{"core.batchfetch"},
 //    			{"core.bytecode"},
 //    			{"core.cache"},
@@ -129,7 +129,7 @@ public class CoreMappingTest {
 //        		{"core.usercollection.parameterized"},
 //        		{"core.value.type.basic"},
 //        		{"core.value.type.collection.list"},
-//        		{"core.value.type.collection.map"},
+        		{"core.value.type.collection.map"},
         		{"core.value.type.collection.set"},
         		{"core.version.db"},
         		{"core.version.nodb"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>