### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.batchfetch' and 'core.value.type.collection.list'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -26,8 +26,8 @@ public class CoreMappingTest {
     			{"core.any"},
     			{"core.array"},
     			{"core.batch"},
+    			{"core.batchfetch"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.batchfetch"},
 //    			{"core.bytecode"},
 //    			{"core.cache"},
 //    			{"core.cascade"},
@@ -128,7 +128,7 @@ public class CoreMappingTest {
 //        		{"core.usercollection.basic"},
 //        		{"core.usercollection.parameterized"},
 //        		{"core.value.type.basic"},
-//        		{"core.value.type.collection.list"},
+        		{"core.value.type.collection.list"},
         		{"core.value.type.collection.map"},
         		{"core.value.type.collection.set"},
         		{"core.version.db"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>