### PR TITLE
 JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.bytecode' and 'core.value.type.basic'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -27,8 +27,8 @@ public class CoreMappingTest {
     			{"core.array"},
     			{"core.batch"},
     			{"core.batchfetch"},
+    			{"core.bytecode"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.bytecode"},
 //    			{"core.cache"},
 //    			{"core.cascade"},
 //    			{"core.cid"},
@@ -127,7 +127,7 @@ public class CoreMappingTest {
 //        		{"core.unionsubclass2"},
 //        		{"core.usercollection.basic"},
 //        		{"core.usercollection.parameterized"},
-//        		{"core.value.type.basic"},
+        		{"core.value.type.basic"},
         		{"core.value.type.collection.list"},
         		{"core.value.type.collection.map"},
         		{"core.value.type.collection.set"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>