### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.cache' and 'core.usercollection.parameterized'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -28,8 +28,8 @@ public class CoreMappingTest {
     			{"core.batch"},
     			{"core.batchfetch"},
     			{"core.bytecode"},
+    			{"core.cache"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.cache"},
 //    			{"core.cascade"},
 //    			{"core.cid"},
 //        		{"core.collection.bag"},
@@ -126,7 +126,7 @@ public class CoreMappingTest {
 //        		{"core.unionsubclass"},
 //        		{"core.unionsubclass2"},
 //        		{"core.usercollection.basic"},
-//        		{"core.usercollection.parameterized"},
+        		{"core.usercollection.parameterized"},
         		{"core.value.type.basic"},
         		{"core.value.type.collection.list"},
         		{"core.value.type.collection.map"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>