### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.cascade' and 'core.usercollection.basic'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -29,8 +29,8 @@ public class CoreMappingTest {
     			{"core.batchfetch"},
     			{"core.bytecode"},
     			{"core.cache"},
+    			{"core.cascade"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.cascade"},
 //    			{"core.cid"},
 //        		{"core.collection.bag"},
 //        		{"core.collection.idbag"},
@@ -125,7 +125,7 @@ public class CoreMappingTest {
 //        		{"core.unidir"},
 //        		{"core.unionsubclass"},
 //        		{"core.unionsubclass2"},
-//        		{"core.usercollection.basic"},
+        		{"core.usercollection.basic"},
         		{"core.usercollection.parameterized"},
         		{"core.value.type.basic"},
         		{"core.value.type.collection.list"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>