### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.cid' and 'core.unionsubclass2'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -30,8 +30,8 @@ public class CoreMappingTest {
     			{"core.bytecode"},
     			{"core.cache"},
     			{"core.cascade"},
+    			{"core.cid"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//    			{"core.cid"},
 //        		{"core.collection.bag"},
 //        		{"core.collection.idbag"},
 //        		{"core.collection.list"},
@@ -124,7 +124,7 @@ public class CoreMappingTest {
 //        		{"core.unconstrained"},
 //        		{"core.unidir"},
 //        		{"core.unionsubclass"},
-//        		{"core.unionsubclass2"},
+        		{"core.unionsubclass2"},
         		{"core.usercollection.basic"},
         		{"core.usercollection.parameterized"},
         		{"core.value.type.basic"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>