### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.collection.idbag' and 'core.unidir'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -32,8 +32,8 @@ public class CoreMappingTest {
     			{"core.cascade"},
     			{"core.cid"},
         		{"core.collection.bag"},
+        		{"core.collection.idbag"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.collection.idbag"},
 //        		{"core.collection.list"},
 //        		{"core.collection.map"},
 //        		{"core.collection.original"},
@@ -122,7 +122,7 @@ public class CoreMappingTest {
 //        		{"core.typedonetoone"},
 //        		{"core.typeparameters"},
 //        		{"core.unconstrained"},
-//        		{"core.unidir"},
+        		{"core.unidir"},
         		{"core.unionsubclass"},
         		{"core.unionsubclass2"},
         		{"core.usercollection.basic"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>