### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.collection.list' and 'core.unconstrained'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -33,8 +33,8 @@ public class CoreMappingTest {
     			{"core.cid"},
         		{"core.collection.bag"},
         		{"core.collection.idbag"},
+        		{"core.collection.list"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.collection.list"},
 //        		{"core.collection.map"},
 //        		{"core.collection.original"},
 //        		{"core.collection.set"},
@@ -121,7 +121,7 @@ public class CoreMappingTest {
 //        		{"core.typedmanytoone"},
 //        		{"core.typedonetoone"},
 //        		{"core.typeparameters"},
-//        		{"core.unconstrained"},
+        		{"core.unconstrained"},
         		{"core.unidir"},
         		{"core.unionsubclass"},
         		{"core.unionsubclass2"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>