### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.collection.map' and 'core.typeparameters'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -34,8 +34,8 @@ public class CoreMappingTest {
         		{"core.collection.bag"},
         		{"core.collection.idbag"},
         		{"core.collection.list"},
+        		{"core.collection.map"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.collection.map"},
 //        		{"core.collection.original"},
 //        		{"core.collection.set"},
 //        		{"core.component.basic"},
@@ -120,7 +120,7 @@ public class CoreMappingTest {
 //        		{"core.tool"},
 //        		{"core.typedmanytoone"},
 //        		{"core.typedonetoone"},
-//        		{"core.typeparameters"},
+        		{"core.typeparameters"},
         		{"core.unconstrained"},
         		{"core.unidir"},
         		{"core.unionsubclass"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>