### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.collection.original' and 'core.typedonetoon'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -35,8 +35,8 @@ public class CoreMappingTest {
         		{"core.collection.idbag"},
         		{"core.collection.list"},
         		{"core.collection.map"},
+        		{"core.collection.original"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.collection.original"},
 //        		{"core.collection.set"},
 //        		{"core.component.basic"},
 //        		{"core.component.cascading.collection"},
@@ -119,7 +119,7 @@ public class CoreMappingTest {
 //        		{"core.timestamp"},
 //        		{"core.tool"},
 //        		{"core.typedmanytoone"},
-//        		{"core.typedonetoone"},
+        		{"core.typedonetoone"},
         		{"core.typeparameters"},
         		{"core.unconstrained"},
         		{"core.unidir"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>