### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Remove unused method 'ConfigurableTestProject#createTestFoldersList()'

### DIFF
--- a/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/project/ConfigurableTestProject.java
+++ b/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/project/ConfigurableTestProject.java
@@ -149,10 +149,6 @@ public class ConfigurableTestProject extends TestProject {
 		}
 	};
 	
-	public boolean createTestFoldersList() {
-		return createTestFoldersList(FilesTransfer.filterFilesJava, filterFoldersOnlyCore);
-	}
-
 	public boolean useAllSources() {
 		activePackage = -1;
 		foldersList = new ArrayList<String>();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>