### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Remove unused field 'ConfigurableTestProject#filterFoldersOnlyCore'

### DIFF
--- a/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/project/ConfigurableTestProject.java
+++ b/tests/org.hibernate.eclipse.console.test/src/org/hibernate/eclipse/console/test/project/ConfigurableTestProject.java
@@ -29,8 +29,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.osgi.util.NLS;
 import org.hibernate.eclipse.console.test.ConsoleTestMessages;
 import org.hibernate.eclipse.console.test.mappingproject.Customization;
-import org.hibernate.eclipse.console.test.mappingproject.MappingTestsAnnotations;
-import org.hibernate.eclipse.console.test.mappingproject.MappingTestsJpa;
 import org.hibernate.eclipse.console.test.utils.FilesTransfer;
 
 /**
@@ -140,15 +138,6 @@ public class ConfigurableTestProject extends TestProject {
 		return true;
 	}
 
-	public static final FileFilter filterFoldersOnlyCore = new FileFilter() {
-		public boolean accept(File f) {
-			return f.exists() && f.isDirectory() && !f.isHidden() &&
-				(!f.getAbsolutePath().toLowerCase().contains(MappingTestsAnnotations.annotationsMarkerStr)) &&
-				(!f.getAbsolutePath().toLowerCase().contains(MappingTestsJpa.jpaMarkerStr)) && 
-				(!f.getAbsolutePath().toLowerCase().contains(MappingTestsJpa.jpaMarkerMetaInf));
-		}
-	};
-	
 	public boolean useAllSources() {
 		activePackage = -1;
 		foldersList = new ArrayList<String>();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>