### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.collection.set' and 'core.typedmanytoone'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -36,8 +36,8 @@ public class CoreMappingTest {
         		{"core.collection.list"},
         		{"core.collection.map"},
         		{"core.collection.original"},
+        		{"core.collection.set"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.collection.set"},
 //        		{"core.component.basic"},
 //        		{"core.component.cascading.collection"},
 //        		{"core.component.cascading.toone"},
@@ -118,7 +118,7 @@ public class CoreMappingTest {
 //        		{"core.ternary"},
 //        		{"core.timestamp"},
 //        		{"core.tool"},
-//        		{"core.typedmanytoone"},
+        		{"core.typedmanytoone"},
         		{"core.typedonetoone"},
         		{"core.typeparameters"},
         		{"core.unconstrained"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>