### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.component.basic' and 'core.tool'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -37,8 +37,8 @@ public class CoreMappingTest {
         		{"core.collection.map"},
         		{"core.collection.original"},
         		{"core.collection.set"},
+        		{"core.component.basic"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.component.basic"},
 //        		{"core.component.cascading.collection"},
 //        		{"core.component.cascading.toone"},
 //        		{"core.compositeelement"},
@@ -117,7 +117,7 @@ public class CoreMappingTest {
 //        		{"core.subselectfetch"},
 //        		{"core.ternary"},
 //        		{"core.timestamp"},
-//        		{"core.tool"},
+        		{"core.tool"},
         		{"core.typedmanytoone"},
         		{"core.typedonetoone"},
         		{"core.typeparameters"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>