### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.component.cascading.collection' and 'core.timestamp'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -38,8 +38,8 @@ public class CoreMappingTest {
         		{"core.collection.original"},
         		{"core.collection.set"},
         		{"core.component.basic"},
+        		{"core.component.cascading.collection"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.component.cascading.collection"},
 //        		{"core.component.cascading.toone"},
 //        		{"core.compositeelement"},
 //    			{"core.connections"},
@@ -116,7 +116,7 @@ public class CoreMappingTest {
 //        		{"core.subselect"},
 //        		{"core.subselectfetch"},
 //        		{"core.ternary"},
-//        		{"core.timestamp"},
+        		{"core.timestamp"},
         		{"core.tool"},
         		{"core.typedmanytoone"},
         		{"core.typedonetoone"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>