### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.component.cascading.toone' and 'core.ternary'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -39,8 +39,8 @@ public class CoreMappingTest {
         		{"core.collection.set"},
         		{"core.component.basic"},
         		{"core.component.cascading.collection"},
+        		{"core.component.cascading.toone"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.component.cascading.toone"},
 //        		{"core.compositeelement"},
 //    			{"core.connections"},
 //        		{"core.criteria"},
@@ -115,7 +115,7 @@ public class CoreMappingTest {
 //        		{"core.stateless"},
 //        		{"core.subselect"},
 //        		{"core.subselectfetch"},
-//        		{"core.ternary"},
+        		{"core.ternary"},
         		{"core.timestamp"},
         		{"core.tool"},
         		{"core.typedmanytoone"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>