### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.compositeelement' and 'core.subselectfetch'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -40,8 +40,8 @@ public class CoreMappingTest {
         		{"core.component.basic"},
         		{"core.component.cascading.collection"},
         		{"core.component.cascading.toone"},
+        		{"core.compositeelement"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.compositeelement"},
 //    			{"core.connections"},
 //        		{"core.criteria"},
 //        		{"core.cuk"},
@@ -114,7 +114,7 @@ public class CoreMappingTest {
 //        		{"core.sql.check"},
 //        		{"core.stateless"},
 //        		{"core.subselect"},
-//        		{"core.subselectfetch"},
+        		{"core.subselectfetch"},
         		{"core.ternary"},
         		{"core.timestamp"},
         		{"core.tool"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>