### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.criteria' and 'core.stateless'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -42,8 +42,8 @@ public class CoreMappingTest {
         		{"core.component.cascading.toone"},
         		{"core.compositeelement"},
     			{"core.connections"},
+        		{"core.criteria"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.criteria"},
 //        		{"core.cuk"},
 //        		{"core.cut"},
 //        		{"core.deletetransient"},
@@ -112,7 +112,7 @@ public class CoreMappingTest {
 //        		{"core.rowid"},
 //        		{"core.sorted"},
 //        		{"core.sql.check"},
-//        		{"core.stateless"},
+        		{"core.stateless"},
         		{"core.subselect"},
         		{"core.subselectfetch"},
         		{"core.ternary"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>