### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.cuk' and 'core.sql.check'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -43,8 +43,8 @@ public class CoreMappingTest {
         		{"core.compositeelement"},
     			{"core.connections"},
         		{"core.criteria"},
+        		{"core.cuk"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.cuk"},
 //        		{"core.cut"},
 //        		{"core.deletetransient"},
 //        		{"core.dialect.functional.cache"},
@@ -111,7 +111,7 @@ public class CoreMappingTest {
 //        		{"core.reattachment"},
 //        		{"core.rowid"},
 //        		{"core.sorted"},
-//        		{"core.sql.check"},
+        		{"core.sql.check"},
         		{"core.stateless"},
         		{"core.subselect"},
         		{"core.subselectfetch"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>