### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.deletetransient' and 'core.rowid'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -45,8 +45,8 @@ public class CoreMappingTest {
         		{"core.criteria"},
         		{"core.cuk"},
         		{"core.cut"},
+        		{"core.deletetransient"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.deletetransient"},
 //        		{"core.dialect.functional.cache"},
 //        		{"core.discriminator"},
 //        		{"core.dynamicentity.interceptor"},
@@ -109,7 +109,7 @@ public class CoreMappingTest {
 //        		{"core.querycache"},
 //        		{"core.readonly"},
 //        		{"core.reattachment"},
-//        		{"core.rowid"},
+        		{"core.rowid"},
         		{"core.sorted"},
         		{"core.sql.check"},
         		{"core.stateless"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>