### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.dialect.functional.cache' and 'core.reattachment'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -46,8 +46,8 @@ public class CoreMappingTest {
         		{"core.cuk"},
         		{"core.cut"},
         		{"core.deletetransient"},
+        		{"core.dialect.functional.cache"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.dialect.functional.cache"},
 //        		{"core.discriminator"},
 //        		{"core.dynamicentity.interceptor"},
 //        		{"core.dynamicentity.tuplizer"},
@@ -108,7 +108,7 @@ public class CoreMappingTest {
 //        		{"core.proxy"},
 //        		{"core.querycache"},
 //        		{"core.readonly"},
-//        		{"core.reattachment"},
+        		{"core.reattachment"},
         		{"core.rowid"},
         		{"core.sorted"},
         		{"core.sql.check"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>