### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.discriminator' and 'core.readonly'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -47,6 +47,7 @@ public class CoreMappingTest {
         		{"core.cut"},
         		{"core.deletetransient"},
         		{"core.dialect.functional.cache"},
+        		{"core.discriminator"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
 //        		{"core.discriminator"},
 //        		{"core.dynamicentity.interceptor"},
@@ -107,7 +108,7 @@ public class CoreMappingTest {
 //        		{"core.propertyref.inheritence.union"},
 //        		{"core.proxy"},
 //        		{"core.querycache"},
-//        		{"core.readonly"},
+        		{"core.readonly"},
         		{"core.reattachment"},
         		{"core.rowid"},
         		{"core.sorted"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>