### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.dynamicentity.interceptor' and 'core.proxy'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -49,8 +49,8 @@ public class CoreMappingTest {
         		{"core.dialect.functional.cache"},
         		{"core.discriminator"},
         		{"core.discriminator"},
+        		{"core.dynamicentity.interceptor"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.dynamicentity.interceptor"},
 //        		{"core.dynamicentity.tuplizer"},
 //        		{"core.ecid"},
 //        		{"core.entitymode.dom4j.many2one"},
@@ -106,7 +106,7 @@ public class CoreMappingTest {
 //        		{"core.propertyref.inheritence.discrim"},
 //        		{"core.propertyref.inheritence.joined"},
 //        		{"core.propertyref.inheritence.union"},
-//        		{"core.proxy"},
+        		{"core.proxy"},
         		{"core.querycache"},
         		{"core.readonly"},
         		{"core.reattachment"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>