### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.ecid' and 'core.propertyref.inheritence.joined'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -51,8 +51,8 @@ public class CoreMappingTest {
         		{"core.discriminator"},
         		{"core.dynamicentity.interceptor"},
         		{"core.dynamicentity.tuplizer"},
+        		{"core.ecid"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.ecid"},
 //        		{"core.entitymode.dom4j.many2one"},
 //        		{"core.entitymode.multi"},
 //        		{"core.exception"},
@@ -104,7 +104,7 @@ public class CoreMappingTest {
 //        		{"core.propertyref.component.complete"},
 //        		{"core.propertyref.component.partial"},
 //        		{"core.propertyref.inheritence.discrim"},
-//        		{"core.propertyref.inheritence.joined"},
+        		{"core.propertyref.inheritence.joined"},
         		{"core.propertyref.inheritence.union"},
         		{"core.proxy"},
         		{"core.querycache"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>