### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.entitymode.dom4j.many2one' and 'core.propertyref.inheritence.discrim'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -52,8 +52,8 @@ public class CoreMappingTest {
         		{"core.dynamicentity.interceptor"},
         		{"core.dynamicentity.tuplizer"},
         		{"core.ecid"},
+        		{"core.entitymode.dom4j.many2one"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.entitymode.dom4j.many2one"},
 //        		{"core.entitymode.multi"},
 //        		{"core.exception"},
 //        		{"core.extralazy"},
@@ -103,7 +103,7 @@ public class CoreMappingTest {
 //        		{"core.propertyref.basic"},
 //        		{"core.propertyref.component.complete"},
 //        		{"core.propertyref.component.partial"},
-//        		{"core.propertyref.inheritence.discrim"},
+        		{"core.propertyref.inheritence.discrim"},
         		{"core.propertyref.inheritence.joined"},
         		{"core.propertyref.inheritence.union"},
         		{"core.proxy"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>