### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.entitymode.multi' and 'core.propertyref.component.partial'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -53,8 +53,8 @@ public class CoreMappingTest {
         		{"core.dynamicentity.tuplizer"},
         		{"core.ecid"},
         		{"core.entitymode.dom4j.many2one"},
+        		{"core.entitymode.multi"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.entitymode.multi"},
 //        		{"core.exception"},
 //        		{"core.extralazy"},
 //        		{"core.filter"},
@@ -102,7 +102,7 @@ public class CoreMappingTest {
 //        		{"core.pagination"},
 //        		{"core.propertyref.basic"},
 //        		{"core.propertyref.component.complete"},
-//        		{"core.propertyref.component.partial"},
+        		{"core.propertyref.component.partial"},
         		{"core.propertyref.inheritence.discrim"},
         		{"core.propertyref.inheritence.joined"},
         		{"core.propertyref.inheritence.union"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>