### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.exception' and 'core.propertyref.component.complete'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -54,8 +54,8 @@ public class CoreMappingTest {
         		{"core.ecid"},
         		{"core.entitymode.dom4j.many2one"},
         		{"core.entitymode.multi"},
+        		{"core.exception"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.exception"},
 //        		{"core.extralazy"},
 //        		{"core.filter"},
 //        		{"core.formulajoin"},
@@ -101,7 +101,7 @@ public class CoreMappingTest {
 //        		{"core.orphan"},
 //        		{"core.pagination"},
 //        		{"core.propertyref.basic"},
-//        		{"core.propertyref.component.complete"},
+        		{"core.propertyref.component.complete"},
         		{"core.propertyref.component.partial"},
         		{"core.propertyref.inheritence.discrim"},
         		{"core.propertyref.inheritence.joined"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>