### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.filter' and 'core.pagination'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -56,8 +56,8 @@ public class CoreMappingTest {
         		{"core.entitymode.multi"},
         		{"core.exception"},
         		{"core.extralazy"},
+        		{"core.filter"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.filter"},
 //        		{"core.formulajoin"},
 //        		{"core.generatedkeys.identity"},
 //        		{"core.generatedkeys.select"},
@@ -99,7 +99,7 @@ public class CoreMappingTest {
 //        		{"core.optlock"},
 //        		{"core.ordered"},
 //        		{"core.orphan"},
-//        		{"core.pagination"},
+        		{"core.pagination"},
         		{"core.propertyref.basic"},
         		{"core.propertyref.component.complete"},
         		{"core.propertyref.component.partial"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>