### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Move class 'org.hibernate.eclipse.console.test.project.xpl.JavaProjectHelper' to plugin 'org.hibernate.eclipse.jdt.ui.test'

### DIFF
--- a/tests/org.hibernate.eclipse.console.test/META-INF/MANIFEST.MF
+++ b/tests/org.hibernate.eclipse.console.test/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Bundle-ClassPath: .,
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
 Export-Package: org.hibernate.eclipse.console.test,
- org.hibernate.eclipse.console.test.project.xpl,
  org.hibernate.eclipse.console.test.utils,
  org.jmock,
  org.jmock.api,

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/console/test/project/JavaProjectHelper.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/console/test/project/JavaProjectHelper.java
@@ -10,7 +10,7 @@
  *     Ferenc Hechler, ferenc_hechler@users.sourceforge.net - 83258 [jar exporter] Deploy java application as executable jar
  *     Max Rydahl Andersen, made more general for usage in Hibernate tests.
  *******************************************************************************/
-package org.hibernate.eclipse.console.test.project.xpl;
+package org.hibernate.eclipse.console.test.project;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,7 +55,6 @@ import org.eclipse.ui.dialogs.IOverwriteQuery;
 import org.eclipse.ui.wizards.datatransfer.ImportOperation;
 import org.eclipse.ui.wizards.datatransfer.ZipFileStructureProvider;
 import org.hibernate.eclipse.console.test.HibernateConsoleTestPlugin;
-
 /**
  * Helper methods to set up a IJavaProject.
  */

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/console/test/project/TestProject.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/console/test/project/TestProject.java
@@ -37,7 +37,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.osgi.util.NLS;
 import org.hibernate.eclipse.console.test.ConsoleTestMessages;
 import org.hibernate.eclipse.console.test.HibernateConsoleTestPlugin;
-import org.hibernate.eclipse.console.test.project.xpl.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.utils.FilesTransfer;
 
 /**

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HQLQueryValidatorTest.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HQLQueryValidatorTest.java
@@ -27,8 +27,8 @@ import org.hibernate.console.preferences.ConsoleConfigurationPreferences.Configu
 import org.hibernate.eclipse.console.EclipseConsoleConfiguration;
 import org.hibernate.eclipse.console.EclipseConsoleConfigurationPreferences;
 import org.hibernate.eclipse.console.test.HibernateConsoleTest;
+import org.hibernate.eclipse.console.test.project.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.project.SimpleTestProject;
-import org.hibernate.eclipse.console.test.project.xpl.JavaProjectHelper;
 import org.hibernate.eclipse.console.utils.ProjectUtils;
 import org.hibernate.eclipse.jdt.ui.internal.HQLDetector;
 import org.hibernate.eclipse.jdt.ui.internal.HQLProblem;

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HibernateErrorsTest.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HibernateErrorsTest.java
@@ -18,8 +18,8 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.hibernate.eclipse.console.test.HibernateConsoleTest;
+import org.hibernate.eclipse.console.test.project.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.project.SimpleTestProject;
-import org.hibernate.eclipse.console.test.project.xpl.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.utils.FilesTransfer;
 
 public class HibernateErrorsTest extends HibernateConsoleTest {

--- a/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HibernateErrorsTest2.java
+++ b/tests/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/HibernateErrorsTest2.java
@@ -27,8 +27,8 @@ import org.hibernate.console.preferences.ConsoleConfigurationPreferences.Configu
 import org.hibernate.eclipse.console.EclipseConsoleConfiguration;
 import org.hibernate.eclipse.console.EclipseConsoleConfigurationPreferences;
 import org.hibernate.eclipse.console.test.HibernateConsoleTest;
+import org.hibernate.eclipse.console.test.project.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.project.SimpleTestProject;
-import org.hibernate.eclipse.console.test.project.xpl.JavaProjectHelper;
 import org.hibernate.eclipse.console.test.utils.FilesTransfer;
 import org.hibernate.eclipse.console.utils.ProjectUtils;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>