### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.formulajoin' and 'core.orphan'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -57,8 +57,8 @@ public class CoreMappingTest {
         		{"core.exception"},
         		{"core.extralazy"},
         		{"core.filter"},
+        		{"core.formulajoin"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.formulajoin"},
 //        		{"core.generatedkeys.identity"},
 //        		{"core.generatedkeys.select"},
 //        		{"core.generatedkeys.seqidentity"},
@@ -98,7 +98,7 @@ public class CoreMappingTest {
 //        		{"core.ops"},
 //        		{"core.optlock"},
 //        		{"core.ordered"},
-//        		{"core.orphan"},
+        		{"core.orphan"},
         		{"core.pagination"},
         		{"core.propertyref.basic"},
         		{"core.propertyref.component.complete"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>