### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.generatedkeys.identity' and 'core.ordered'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -58,8 +58,8 @@ public class CoreMappingTest {
         		{"core.extralazy"},
         		{"core.filter"},
         		{"core.formulajoin"},
+        		{"core.generatedkeys.identity"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.generatedkeys.identity"},
 //        		{"core.generatedkeys.select"},
 //        		{"core.generatedkeys.seqidentity"},
 //        		{"core.id"},
@@ -97,7 +97,7 @@ public class CoreMappingTest {
 //        		{"core.onetoone.singletable"},
 //        		{"core.ops"},
 //        		{"core.optlock"},
-//        		{"core.ordered"},
+        		{"core.ordered"},
         		{"core.orphan"},
         		{"core.pagination"},
         		{"core.propertyref.basic"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>