### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.generatedkeys.select' and 'core.optlock'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -59,8 +59,8 @@ public class CoreMappingTest {
         		{"core.filter"},
         		{"core.formulajoin"},
         		{"core.generatedkeys.identity"},
+        		{"core.generatedkeys.select"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.generatedkeys.select"},
 //        		{"core.generatedkeys.seqidentity"},
 //        		{"core.id"},
 //        		{"core.idbag"},
@@ -96,7 +96,7 @@ public class CoreMappingTest {
 //        		{"core.onetoone.optional"},
 //        		{"core.onetoone.singletable"},
 //        		{"core.ops"},
-//        		{"core.optlock"},
+        		{"core.optlock"},
         		{"core.ordered"},
         		{"core.orphan"},
         		{"core.pagination"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>