### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Remove test plugin 'org.hibernate.eclipse.console.test' from the test cycle

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,7 +12,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	
 	<packaging>pom</packaging>
 	<modules>
-		<module>org.hibernate.eclipse.console.test</module>
 		<module>org.hibernate.eclipse.jdt.ui.test</module>
 		<module>org.jboss.tools.hibernate.ui.test</module>
 		<module>org.jboss.tools.hibernate.jpt.core.test</module>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>