### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.generatedkeys.seqidentity' and 'core.ops'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -60,8 +60,8 @@ public class CoreMappingTest {
         		{"core.formulajoin"},
         		{"core.generatedkeys.identity"},
         		{"core.generatedkeys.select"},
+        		{"core.generatedkeys.seqidentity"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.generatedkeys.seqidentity"},
 //        		{"core.id"},
 //        		{"core.idbag"},
 //        		{"core.idclass"},
@@ -95,7 +95,7 @@ public class CoreMappingTest {
 //        		{"core.onetoone.link"},
 //        		{"core.onetoone.optional"},
 //        		{"core.onetoone.singletable"},
-//        		{"core.ops"},
+        		{"core.ops"},
         		{"core.optlock"},
         		{"core.ordered"},
         		{"core.orphan"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>