### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.id' and 'core.onetoone.singletable'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -61,8 +61,8 @@ public class CoreMappingTest {
         		{"core.generatedkeys.identity"},
         		{"core.generatedkeys.select"},
         		{"core.generatedkeys.seqidentity"},
+        		{"core.id"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.id"},
 //        		{"core.idbag"},
 //        		{"core.idclass"},
 //        		{"core.idprops"},
@@ -94,7 +94,7 @@ public class CoreMappingTest {
 //        		{"core.onetoone.joined"},
 //        		{"core.onetoone.link"},
 //        		{"core.onetoone.optional"},
-//        		{"core.onetoone.singletable"},
+        		{"core.onetoone.singletable"},
         		{"core.ops"},
         		{"core.optlock"},
         		{"core.ordered"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>