### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.idbag' and 'core.onetoone.optional'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -62,8 +62,8 @@ public class CoreMappingTest {
         		{"core.generatedkeys.select"},
         		{"core.generatedkeys.seqidentity"},
         		{"core.id"},
+        		{"core.idbag"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.idbag"},
 //        		{"core.idclass"},
 //        		{"core.idprops"},
 //        		{"core.immutable"},
@@ -93,7 +93,7 @@ public class CoreMappingTest {
 //        		{"core.onetoone.formula"},
 //        		{"core.onetoone.joined"},
 //        		{"core.onetoone.link"},
-//        		{"core.onetoone.optional"},
+        		{"core.onetoone.optional"},
         		{"core.onetoone.singletable"},
         		{"core.ops"},
         		{"core.optlock"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>