### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.idclass' and 'core.onetoone.link'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -63,8 +63,8 @@ public class CoreMappingTest {
         		{"core.generatedkeys.seqidentity"},
         		{"core.id"},
         		{"core.idbag"},
+        		{"core.idclass"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.idclass"},
 //        		{"core.idprops"},
 //        		{"core.immutable"},
 //        		{"core.insertordering"},
@@ -92,7 +92,7 @@ public class CoreMappingTest {
 //        		{"core.onetomany"},
 //        		{"core.onetoone.formula"},
 //        		{"core.onetoone.joined"},
-//        		{"core.onetoone.link"},
+        		{"core.onetoone.link"},
         		{"core.onetoone.optional"},
         		{"core.onetoone.singletable"},
         		{"core.ops"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>