### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.idprops' and 'core.onetoone.joined'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -64,8 +64,8 @@ public class CoreMappingTest {
         		{"core.id"},
         		{"core.idbag"},
         		{"core.idclass"},
+        		{"core.idprops"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.idprops"},
 //        		{"core.immutable"},
 //        		{"core.insertordering"},
 //        		{"core.instrument.domain"},
@@ -91,7 +91,7 @@ public class CoreMappingTest {
 //        		{"core.ondelete"},
 //        		{"core.onetomany"},
 //        		{"core.onetoone.formula"},
-//        		{"core.onetoone.joined"},
+        		{"core.onetoone.joined"},
         		{"core.onetoone.link"},
         		{"core.onetoone.optional"},
         		{"core.onetoone.singletable"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>