### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.immutable' and 'core.onetoone.formula'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -65,8 +65,8 @@ public class CoreMappingTest {
         		{"core.idbag"},
         		{"core.idclass"},
         		{"core.idprops"},
+        		{"core.immutable"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.immutable"},
 //        		{"core.insertordering"},
 //        		{"core.instrument.domain"},
 //        		{"core.interceptor"},
@@ -90,7 +90,7 @@ public class CoreMappingTest {
 //        		{"core.naturalid"},
 //        		{"core.ondelete"},
 //        		{"core.onetomany"},
-//        		{"core.onetoone.formula"},
+        		{"core.onetoone.formula"},
         		{"core.onetoone.joined"},
         		{"core.onetoone.link"},
         		{"core.onetoone.optional"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>