### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.insertordering' and 'core.onetomany'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -66,8 +66,8 @@ public class CoreMappingTest {
         		{"core.idclass"},
         		{"core.idprops"},
         		{"core.immutable"},
+        		{"core.insertordering"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.insertordering"},
 //        		{"core.instrument.domain"},
 //        		{"core.interceptor"},
 //        		{"core.interfaceproxy"},
@@ -89,7 +89,7 @@ public class CoreMappingTest {
 //        		{"core.mixed"},
 //        		{"core.naturalid"},
 //        		{"core.ondelete"},
-//        		{"core.onetomany"},
+        		{"core.onetomany"},
         		{"core.onetoone.formula"},
         		{"core.onetoone.joined"},
         		{"core.onetoone.link"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>