### PR TITLE
JBIDE-25386: Consolidate tests from 'org.hibernate.eclipse.console.test' into new test plugin 'org.jboss.tools.hibernate.orm.test' - Change 'org.hibernate.eclipse.console.test' into eclipse-plugin instead of eclipse-test-plugin

### DIFF
--- a/features/org.hibernate.eclipse.test.feature/feature.xml
+++ b/features/org.hibernate.eclipse.test.feature/feature.xml
@@ -32,12 +32,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.hibernate.eclipse.console.test"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.hibernate.eclipse.jdt.ui.test"
          download-size="0"
          install-size="0"

--- a/tests/org.hibernate.eclipse.console.test/pom.xml
+++ b/tests/org.hibernate.eclipse.console.test/pom.xml
@@ -9,29 +9,6 @@
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.hibernate.eclipse.console.test</artifactId> 
 	
-	<packaging>eclipse-test-plugin</packaging>
+	<packaging>eclipse-plugin</packaging>
 
-	<properties>
-		<coverage.filter>org.hibernate.eclipse*</coverage.filter>
-		<emma.instrument.bundles>org.hibernate.eclipse.console</emma.instrument.bundles>
-		<surefire.timeout>3600</surefire.timeout>
-	</properties>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-surefire-plugin</artifactId>
-				<configuration>
-					<product>org.hibernate.eclipse.console.test.product</product>
-					<explodedBundles>
-						<bundle>org.hibernate.eclipse.console.test</bundle>
-						<bundle>org.hibernate.eclipse</bundle>
-						<bundle>org.hibernate.eclipse.libs</bundle>
-					</explodedBundles>
-					<skip>${skipTests}</skip>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>	
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>