### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.instrument.domain' and 'core.ondelete'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -67,8 +67,8 @@ public class CoreMappingTest {
         		{"core.idprops"},
         		{"core.immutable"},
         		{"core.insertordering"},
+        		{"core.instrument.domain"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.instrument.domain"},
 //        		{"core.interceptor"},
 //        		{"core.interfaceproxy"},
 //        		{"core.iterate"},
@@ -88,7 +88,7 @@ public class CoreMappingTest {
 //        		{"core.mapelemformula"},
 //        		{"core.mixed"},
 //        		{"core.naturalid"},
-//        		{"core.ondelete"},
+        		{"core.ondelete"},
         		{"core.onetomany"},
         		{"core.onetoone.formula"},
         		{"core.onetoone.joined"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>