### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.interceptor' and 'core..naturalid'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -68,8 +68,8 @@ public class CoreMappingTest {
         		{"core.immutable"},
         		{"core.insertordering"},
         		{"core.instrument.domain"},
+        		{"core.interceptor"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.interceptor"},
 //        		{"core.interfaceproxy"},
 //        		{"core.iterate"},
 //        		{"core.join"},
@@ -87,7 +87,7 @@ public class CoreMappingTest {
 //        		{"core.mapcompelem"},
 //        		{"core.mapelemformula"},
 //        		{"core.mixed"},
-//        		{"core.naturalid"},
+        		{"core.naturalid"},
         		{"core.ondelete"},
         		{"core.onetomany"},
         		{"core.onetoone.formula"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>