### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.interfaceproxy' and 'core.mixed'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -69,8 +69,8 @@ public class CoreMappingTest {
         		{"core.insertordering"},
         		{"core.instrument.domain"},
         		{"core.interceptor"},
+        		{"core.interfaceproxy"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.interfaceproxy"},
 //        		{"core.iterate"},
 //        		{"core.join"},
 //        		{"core.joinedsubclass"},
@@ -86,7 +86,7 @@ public class CoreMappingTest {
 //        		{"core.map"},
 //        		{"core.mapcompelem"},
 //        		{"core.mapelemformula"},
-//        		{"core.mixed"},
+        		{"core.mixed"},
         		{"core.naturalid"},
         		{"core.ondelete"},
         		{"core.onetomany"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>