### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.iterate' and 'core.mapelemformula'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -70,8 +70,8 @@ public class CoreMappingTest {
         		{"core.instrument.domain"},
         		{"core.interceptor"},
         		{"core.interfaceproxy"},
+        		{"core.iterate"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.iterate"},
 //        		{"core.join"},
 //        		{"core.joinedsubclass"},
 //        		{"core.joinfetch"},
@@ -85,7 +85,7 @@ public class CoreMappingTest {
 //        		{"core.manytomany.ordered"},
 //        		{"core.map"},
 //        		{"core.mapcompelem"},
-//        		{"core.mapelemformula"},
+        		{"core.mapelemformula"},
         		{"core.mixed"},
         		{"core.naturalid"},
         		{"core.ondelete"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>