### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.join and 'core.mapcompelem'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -71,8 +71,8 @@ public class CoreMappingTest {
         		{"core.interceptor"},
         		{"core.interfaceproxy"},
         		{"core.iterate"},
+        		{"core.join"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.join"},
 //        		{"core.joinedsubclass"},
 //        		{"core.joinfetch"},
 //        		{"core.jpa"},
@@ -84,7 +84,7 @@ public class CoreMappingTest {
 //        		{"core.manytomany"},
 //        		{"core.manytomany.ordered"},
 //        		{"core.map"},
-//        		{"core.mapcompelem"},
+        		{"core.mapcompelem"},
         		{"core.mapelemformula"},
         		{"core.mixed"},
         		{"core.naturalid"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>