### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.joinedsubclass' and 'core.map'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -72,8 +72,8 @@ public class CoreMappingTest {
         		{"core.interfaceproxy"},
         		{"core.iterate"},
         		{"core.join"},
+        		{"core.joinedsubclass"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.joinedsubclass"},
 //        		{"core.joinfetch"},
 //        		{"core.jpa"},
 //        		{"core.jpa.cascade"},
@@ -83,7 +83,7 @@ public class CoreMappingTest {
 //        		{"core.lob"},
 //        		{"core.manytomany"},
 //        		{"core.manytomany.ordered"},
-//        		{"core.map"},
+        		{"core.map"},
         		{"core.mapcompelem"},
         		{"core.mapelemformula"},
         		{"core.mixed"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>