### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.joinfetch' and 'core.manytomany.ordered'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -73,8 +73,8 @@ public class CoreMappingTest {
         		{"core.iterate"},
         		{"core.join"},
         		{"core.joinedsubclass"},
+        		{"core.joinfetch"},
     			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.joinfetch"},
 //        		{"core.jpa"},
 //        		{"core.jpa.cascade"},
 //        		{"core.jpa.fetch"},
@@ -82,7 +82,7 @@ public class CoreMappingTest {
 //        		{"core.lazyonetoone"},
 //        		{"core.lob"},
 //        		{"core.manytomany"},
-//        		{"core.manytomany.ordered"},
+        		{"core.manytomany.ordered"},
         		{"core.map"},
         		{"core.mapcompelem"},
         		{"core.mapelemformula"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>