### PR TITLE
JBIDE-25553: Cannot create Hibernate Console Configuration for projects with java 9 - Enable test for packages 'core.jpa.fetch', 'core.lazycache' and 'core.lazyonetoone'

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
+++ b/tests/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/CoreMappingTest.java
@@ -76,10 +76,9 @@ public class CoreMappingTest {
         		{"core.joinfetch"},
         		{"core.jpa"},
         		{"core.jpa.cascade"},
-    			// TODO BIDE-25553 - uncomment the commented parameters 
-//        		{"core.jpa.fetch"},
-//        		{"core.lazycache"},
-//        		{"core.lazyonetoone"},
+        		{"core.jpa.fetch"},
+        		{"core.lazycache"},
+        		{"core.lazyonetoone"},
         		{"core.lob"},
         		{"core.manytomany"},
         		{"core.manytomany.ordered"},


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>