### PR TITLE
Add support for Hibernate 5.4 - Make the tests in 'org.jboss.tools.hibernate.orm.test' run with 5.4

### DIFF
--- a/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -31,7 +31,7 @@ Require-Bundle: org.hibernate.eclipse,
  org.jboss.tools.hibernate.ui,
  org.eclipse.ui.workbench,
  org.hibernate.eclipse.mapper,
- org.jboss.tools.hibernate.runtime.v_5_3
+ org.jboss.tools.hibernate.runtime.v_5_4
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>