### PR TITLE
JBIDE-26498 - coretests failing because of an hibernate dependency missing

### DIFF
--- a/features/org.hibernate.eclipse.test.feature/feature.xml
+++ b/features/org.hibernate.eclipse.test.feature/feature.xml
@@ -123,6 +123,14 @@
          unpack="false"/>
 
    <plugin
+         id="org.jboss.tools.hibernate.runtime.v_5_4.test"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+		 <plugin
          id="org.jboss.tools.hibernate.orm.test"
          download-size="0"
          install-size="0"

--- a/tests/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Hibernate Runtime 5.3 Tests
+Bundle-Name: Hibernate Runtime 5.4 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4.test
 Bundle-Version: 5.4.3.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_4


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>