### PR TITLE
JBIDE-26511: Update byte buddy version to 1.9.5 in org.jboss.tools.hibernate.runtime.v_5_4

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 5.4.3.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
- lib/byte-buddy-1.8.0.jar,
+ lib/byte-buddy-1.9.5.jar,
  lib/classmate-1.3.4.jar,
  lib/geronimo-jta_1.1_spec-1.1.1.jar,
  lib/hibernate-commons-annotations-5.1.0.Final.jar,

--- a/plugins/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -19,7 +19,7 @@
 		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 		<javassist.version>3.20.0-GA</javassist.version>
 	    <jaxb.version>2.3.0</jaxb.version>
-		<bytebuddy.version>1.8.0</bytebuddy.version>
+		<bytebuddy.version>1.9.5</bytebuddy.version>
 		<jboss-logging.version>3.3.0.Final</jboss-logging.version>
 		<slf4j.version>1.6.1</slf4j.version>
 	</properties>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>