### PR TITLE
JBIDE-26513: Remove the dependency on 'org.hibernate.eclipse' from 'org.jboss.tools.hibernate.runtime.v_x_y' - Remove dependency from org.jboss.tools.hibernate.runtime.v_3_5

### DIFF
--- a/plugins/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5;singleton:=true
 Bundle-Version: 5.4.3.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
- org.hibernate.eclipse;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.1.0",
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>