### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/docs/reference/en-US/Book_Info.xml
+++ b/docs/reference/en-US/Book_Info.xml
@@ -4,7 +4,7 @@
 <bookinfo>
 	<title>Hibernate Tools Reference Guide</title>
 	<subtitle>Provides information relating to the Hibernate Tools set.</subtitle>
-	<productname>Red Hat Developer Studio</productname>
+	<productname>Red Hat CodeReady Studio</productname>
 	<productnumber>7.1</productnumber>
 	<abstract>
 		<para>

--- a/docs/reference/en-US/Preface.xml
+++ b/docs/reference/en-US/Preface.xml
@@ -6,7 +6,7 @@
 <preface id="pref-Cloud_Tools_Reference_Guide-Preface">
 	<title>Preface</title>
 	<para>
-		For a detailed listing of all documentation available for the Red Hat Developer Studio, see the <ulink url="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/">Red Hat Developer Studio Documentation</ulink> page.
+		For a detailed listing of all documentation available for the Red Hat CodeReady Studio, see the <ulink url="https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio/">Red Hat CodeReady Studio Documentation</ulink> page.
 	</para>
 </preface>
 


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>