### PR TITLE
JBIDE-26543: Reorganize plugins and test plugins in a more coherent module hierarchy - Add 'dummy' test to 'tests' to make sure at least one test remains after moving all the tests (otherwise the build breaks)

### DIFF
--- a/tests/org.jboss.tools.hibernate.dummy.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.dummy.test/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Hibernate Dummy Test
+Bundle-SymbolicName: org.jboss.tools.hibernate.dummy.test;singleton:=true
+Bundle-Version: 5.4.4.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/tests/org.jboss.tools.hibernate.dummy.test/build.properties
+++ b/tests/org.jboss.tools.hibernate.dummy.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .

--- a/tests/org.jboss.tools.hibernate.dummy.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.dummy.test/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion> 
+	<parent>
+		<groupId>org.jboss.tools.hibernatetools</groupId>
+		<artifactId>tests</artifactId>
+		<version>5.4.4-SNAPSHOT</version>
+	</parent>
+	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
+	<artifactId>org.jboss.tools.hibernate.dummy.test</artifactId> 
+	
+	<packaging>eclipse-test-plugin</packaging>
+	
+	<properties>
+		<coverage.filter>org.jboss.tools.hibernate.dummy*</coverage.filter>
+		<emma.instrument.bundles>org.jboss.tools.hibernate.dummy</emma.instrument.bundles>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+</project>

--- a/tests/org.jboss.tools.hibernate.dummy.test/src/org/jboss/tools/hibernate/dummy/DummyTest.java
+++ b/tests/org.jboss.tools.hibernate.dummy.test/src/org/jboss/tools/hibernate/dummy/DummyTest.java
@@ -1,0 +1,13 @@
+package org.jboss.tools.hibernate.dummy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DummyTest {
+
+	@Test
+	public void testDummy() {
+		Assert.assertNull(null);
+	}
+	
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,6 +12,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	
 	<packaging>pom</packaging>
 	<modules>
+        <module>org.jboss.tools.hibernate.dummy.test</module>
         <module>org.jboss.tools.hibernate.runtime.spi.test</module>
         <module>org.jboss.tools.hibernate.runtime.v_3_5.test</module>
         <module>org.jboss.tools.hibernate.runtime.v_3_6.test</module>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>