### PR TITLE
JBIDE-26543: Reorganize plugins and test plugins in a more coherent module hierarchy - Move OrmDiagramTest from org.jboss.tools.hibernate.ui.test to org.jboss.tools.hibernate.orm.test

### DIFF
--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -3,7 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.test;singleton:=true
 Bundle-Version: 5.4.9.qualifier
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ lib/jmock-2.5.1.jar,
+ lib/jmock-legacy-2.5.1.jar,
+ lib/cglib-nodep-2.1_3.jar,
+ lib/objenesis-1.0.jar,
+ lib/hamcrest-all-1.1.jar
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
 Require-Bundle: org.hibernate.eclipse,

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/build.properties
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                plugin.properties,\
-               .
+               .,\
+               lib/

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
@@ -16,7 +16,13 @@
 		<emma.instrument.bundles>org.hibernate.eclipse.console</emma.instrument.bundles>
 		<hsqldb.version>2.4.0</hsqldb.version>
 		<javax.persistence-api.version>2.2</javax.persistence-api.version>
+		<jmock.version>2.5.1</jmock.version>
+		<cglib.version>2.1_3</cglib.version>
+		<objenesis.version>1.0</objenesis.version>
+		<hamcrest.version>1.1</hamcrest.version>
 	</properties>
+	
+	
 
 	<build>
 		<plugins>
@@ -43,6 +49,31 @@
 							<groupId>javax.persistence</groupId>
 							<artifactId>javax.persistence-api</artifactId>
 							<version>${javax.persistence-api.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.jmock</groupId>
+							<artifactId>jmock</artifactId>
+							<version>${jmock.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.jmock</groupId>
+							<artifactId>jmock-legacy</artifactId>
+							<version>${jmock.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>cglib</groupId>
+							<artifactId>cglib-nodep</artifactId>
+							<version>${cglib.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.objenesis</groupId>
+							<artifactId>objenesis</artifactId>
+							<version>${objenesis.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.hamcrest</groupId>
+							<artifactId>hamcrest-all</artifactId>
+							<version>${hamcrest.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/OrmDiagramTest.java
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/OrmDiagramTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2009 Red Hat, Inc.
+ * Copyright (c) 2007-220 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -8,7 +8,9 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.hibernate.ui.diagram.editors.model.test;
+package org.jboss.tools.hibernate.orm.test;
+
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -22,15 +24,15 @@ import org.jboss.tools.hibernate.ui.diagram.editors.model.OrmDiagram;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * for OrmDiagram class functionality test
  * 
  * @author Vitali Yemialyanchyk
+ * @author koen
  */
-public class OrmDiagramTest extends TestCase {
+public class OrmDiagramTest {
 	
 	public Mockery context = new Mockery() {
 		{
@@ -38,6 +40,7 @@ public class OrmDiagramTest extends TestCase {
 		}
 	};
 
+	@Test
 	public void testLoadAndSave() {
 		
 		final ConsoleConfiguration consoleConfig = context.mock(ConsoleConfiguration.class);

--- a/orm/test/core/org.jboss.tools.hibernate.ui.test/src/org/jboss/tools/hibernate/ui/test/HibernateUiTestSuite.java
+++ b/orm/test/core/org.jboss.tools.hibernate.ui.test/src/org/jboss/tools/hibernate/ui/test/HibernateUiTestSuite.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.hibernate.ui.test;
 
 import org.jboss.tools.hibernate.ui.diagram.editors.actions.test.ExportImageActionTest;
-import org.jboss.tools.hibernate.ui.diagram.editors.model.test.OrmDiagramTest;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -24,7 +23,6 @@ public class HibernateUiTestSuite {
 	public static Test suite() {
 		TestSuite suite = new TestSuite();
 		suite.addTestSuite(ExportImageActionTest.class);
-		suite.addTestSuite(OrmDiagramTest.class);
 		return suite;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>