### PR TITLE
JBIDE-26543: Reorganize plugins and test plugins in a more coherent module hierarchy - Move ExportImageActionTest from org.jboss.tools.hibernate.ui.test to org.jboss.tools.hibernate.orm.test

### DIFF
--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -36,7 +36,8 @@ Require-Bundle: org.hibernate.eclipse,
  org.jboss.tools.hibernate.ui,
  org.eclipse.ui.workbench,
  org.hibernate.eclipse.mapper,
- org.jboss.tools.hibernate.runtime.v_5_4
+ org.jboss.tools.hibernate.runtime.v_5_4,
+ org.eclipse.gef
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ExportImageActionTest.java
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ExportImageActionTest.java
@@ -8,7 +8,9 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.hibernate.ui.diagram.editors.actions.test;
+package org.jboss.tools.hibernate.orm.test;
+
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -24,12 +26,15 @@ import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.dialogs.SaveAsDialog;
-import org.hibernate.eclipse.console.test.project.TestProject;
+import org.jboss.tools.hibernate.orm.test.utils.project.TestProject;
 import org.jboss.tools.hibernate.ui.diagram.editors.DiagramViewer;
 import org.jboss.tools.hibernate.ui.diagram.editors.actions.ExportImageAction;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import junit.framework.TestCase;
 
@@ -38,17 +43,19 @@ import junit.framework.TestCase;
  * 
  * @author Vitali Yemialyanchyk
  */
-public class ExportImageActionTest extends TestCase {
+public class ExportImageActionTest {
 
 	public static final String PROJECT_NAME = "TestProject"; //$NON-NLS-1$
 	
 	protected TestProject project = null;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		project = new TestProject(PROJECT_NAME);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		project.deleteIProject();
 		project = null;
 	}
@@ -59,6 +66,7 @@ public class ExportImageActionTest extends TestCase {
 		}
 	};
 
+	@Test
 	public void testAction() {
 		
 		final DiagramViewer editor = context.mock(DiagramViewer.class);

--- a/orm/test/core/org.jboss.tools.hibernate.ui.test/src/org/jboss/tools/hibernate/ui/test/HibernateUiTestSuite.java
+++ b/orm/test/core/org.jboss.tools.hibernate.ui.test/src/org/jboss/tools/hibernate/ui/test/HibernateUiTestSuite.java
@@ -10,9 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.hibernate.ui.test;
 
-import org.jboss.tools.hibernate.ui.diagram.editors.actions.test.ExportImageActionTest;
-
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 /**
@@ -21,8 +20,10 @@ import junit.framework.TestSuite;
  */
 public class HibernateUiTestSuite {
 	public static Test suite() {
-		TestSuite suite = new TestSuite();
-		suite.addTestSuite(ExportImageActionTest.class);
-		return suite;
+		return new TestSuite(MyTest.class);
+	}
+	
+	public static class MyTest extends TestCase {
+		public void test() {}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>