### PR TITLE
JBIDE-26543: Reorganize plugins and test plugins in a more coherent module hierarchy - Move ELTransformerTest from org.hibernate.eclipse.jdt.ui.test to org.jboss.tools.hibernate.orm.test

### DIFF
--- a/orm/test/core/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/JDTuiAllTests.java
+++ b/orm/test/core/org.hibernate.eclipse.jdt.ui.test/src/org/hibernate/eclipse/jdt/ui/test/JDTuiAllTests.java
@@ -14,7 +14,6 @@ public class JDTuiAllTests {
 		//suite.addTestSuite(HibernateErrorsTest.class);
 		//suite.addTestSuite(HibernateErrorsTest2.class);
 		suite.addTestSuite(HQLQueryValidatorTest.class);
-		suite.addTestSuite(ELTransformerTest.class);
 		suite.addTestSuite(HbmExporterTest.class);
 		suite.addTestSuite(JPAMapMockTests.class);
 		suite.addTestSuite(JPAMapTest.class);

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.hibernate.eclipse,
  org.eclipse.ui.workbench,
  org.hibernate.eclipse.mapper,
  org.jboss.tools.hibernate.runtime.v_5_4,
- org.eclipse.gef
+ org.eclipse.gef,
+ org.hibernate.eclipse.jdt.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ELTransformerTest.java
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/src/org/jboss/tools/hibernate/orm/test/ELTransformerTest.java
@@ -1,11 +1,13 @@
-package org.hibernate.eclipse.jdt.ui.test;
+package org.jboss.tools.hibernate.orm.test;
+
+import static org.junit.Assert.assertEquals;
 
 import org.hibernate.eclipse.jdt.ui.internal.ELTransformer;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class ELTransformerTest {
 
-public class ELTransformerTest extends TestCase {
-
+	@Test
 	public void testTransformer() {
 		
 		assertEquals("from Test", ELTransformer.removeEL("from Test"));  //$NON-NLS-1$//$NON-NLS-2$


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>