### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Add dependency for Hibernate Tools ORM 6.0.0.Alpha1

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.0 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0;singleton:=true
 Bundle-Version: 5.4.10.qualifier
-Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ lib/hibernate-tools-orm-6.0.0.Alpha1.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/build.properties
@@ -1,4 +1,6 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = .,\
-               META-INF/
+               META-INF/,\
+               lib/
+               

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -11,4 +11,47 @@
 	
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<hibernate.tools.version>6.0.0.Alpha1</hibernate.tools.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>get-libs</id>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<phase>generate-resources</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.hibernate.tool</groupId>
+							<artifactId>hibernate-tools-orm</artifactId>
+							<version>${hibernate.tools.version}</version>
+						</artifactItem>
+					</artifactItems>
+					<skip>false</skip>
+					<outputDirectory>${basedir}/lib</outputDirectory>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/lib</directory>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>