### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initial implementation of org.jboss.tools.hibernate.runtime.v_6_0.internal.util.MetadataHelper.java

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MetadataHelper.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MetadataHelper.java
@@ -1,0 +1,46 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import java.lang.reflect.Field;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.cfg.Configuration;
+
+public class MetadataHelper {
+	
+	public static MetadataSources getMetadataSources(Configuration configuration) {
+		MetadataSources result = null;
+		Field metadataSourcesField = getField("metadataSources", configuration);
+		if (metadataSourcesField != null) {
+			try {
+				metadataSourcesField.setAccessible(true);
+				result = 
+						(MetadataSources)metadataSourcesField.get(configuration);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		if (result == null) {
+			result = new MetadataSources();
+		}
+		return result;
+	}
+	
+	private static Field getField(String fieldName, Object target) {
+		Field result = null;
+		Class<?> clazz = target.getClass();
+		while (clazz != null) {
+			try {
+				result = clazz.getDeclaredField(fieldName);
+				// if it exists, exit the while loop
+				break;
+			} catch (NoSuchFieldException e) {
+				// if it doesn't exist, look in the superclass
+				clazz = clazz.getSuperclass();
+			} catch (SecurityException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MetadataHelperTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MetadataHelperTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.cfg.Configuration;
+import org.junit.Test;
+
+public class MetadataHelperTest {
+	
+	@Test
+	public void testGetMetadataSources() {
+		MetadataSources mds1 = new MetadataSources();
+		Configuration configuration = new Configuration();
+		MetadataSources mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertNotSame(mds1, mds2);
+		configuration = new Configuration(mds1);
+		mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertSame(mds1, mds2);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>