### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'JdbcMetadataConfiguration#getProperty(String)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
@@ -14,4 +14,8 @@ public class JdbcMetadataConfiguration {
 		this.properties = properties;
 	}
 	
+	public Object getProperty(String key) {
+		return this.properties.get(key);
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
@@ -1,7 +1,9 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.Properties;
@@ -34,6 +36,13 @@ public class JdbcMetadataConfigurationTest {
 		assertNotSame(properties,  jdbcMetadataConfiguration.getProperties());
 		jdbcMetadataConfiguration.setProperties(properties);
 		assertSame(properties, jdbcMetadataConfiguration.getProperties());
+	}
+	
+	@Test
+	public void testGetProperty() {
+		assertNull(jdbcMetadataConfiguration.getProperty("foo"));
+		jdbcMetadataConfiguration.properties.put("foo", "bar");
+		assertEquals("bar", jdbcMetadataConfiguration.getProperty("foo"));
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>