### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'JdbcMetadataConfiguration#addProperties(Properties)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
@@ -22,4 +22,8 @@ public class JdbcMetadataConfiguration {
 		properties.put(key, value);
 	}
 
+	public void addProperties(Properties properties) {
+		this.properties.putAll(properties);
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
@@ -51,5 +51,15 @@ public class JdbcMetadataConfigurationTest {
 		jdbcMetadataConfiguration.setProperty("foo", "bar");
 		assertEquals("bar", jdbcMetadataConfiguration.properties.get("foo"));
 	}
+	
+	@Test
+	public void testAddProperties() {
+		Properties properties = new Properties();
+		properties.put("foo", "bar");
+		assertNull(jdbcMetadataConfiguration.properties.get("foo"));
+		jdbcMetadataConfiguration.addProperties(properties);
+		assertEquals("bar", jdbcMetadataConfiguration.properties.get("foo"));
+		
+	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>