### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'JdbcMetadataConfiguration#preferBasicCompositeIds()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
@@ -2,6 +2,7 @@ package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
 import java.util.Properties;
 
+import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 
 public class JdbcMetadataConfiguration {
@@ -35,6 +36,11 @@ public class JdbcMetadataConfiguration {
 
 	public void setReverseEngineeringStrategy(RevengStrategy strategy) {
 		this.revengStrategy = strategy;
+	}
+
+	public boolean preferBasicCompositeIds() {
+		Object preferBasicCompositeIds = properties.get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
+		return preferBasicCompositeIds == null ? false : ((Boolean)preferBasicCompositeIds).booleanValue();
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
@@ -1,13 +1,16 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
+import org.hibernate.tool.api.metadata.MetadataConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.junit.Before;
@@ -77,7 +80,13 @@ public class JdbcMetadataConfigurationTest {
 		assertNull(jdbcMetadataConfiguration.revengStrategy);
 		jdbcMetadataConfiguration.setReverseEngineeringStrategy(strategy);
 		assertSame(strategy, jdbcMetadataConfiguration.revengStrategy);
-		
+	}
+	
+	@Test
+	public void testPreferBasicCompositeIds() {
+		assertFalse(jdbcMetadataConfiguration.preferBasicCompositeIds());
+		jdbcMetadataConfiguration.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, true);
+		assertTrue(jdbcMetadataConfiguration.preferBasicCompositeIds());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>