### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'JdbcMetadataConfiguration#setPreferBasicCompositeIds(boolean)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
@@ -42,5 +42,11 @@ public class JdbcMetadataConfiguration {
 		Object preferBasicCompositeIds = properties.get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
 		return preferBasicCompositeIds == null ? false : ((Boolean)preferBasicCompositeIds).booleanValue();
 	}
+
+	public void setPreferBasicCompositeIds(boolean preferBasicCompositeIds) {
+		properties.put(
+				MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, 
+				Boolean.valueOf(preferBasicCompositeIds));
+	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
@@ -88,5 +88,17 @@ public class JdbcMetadataConfigurationTest {
 		jdbcMetadataConfiguration.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, true);
 		assertTrue(jdbcMetadataConfiguration.preferBasicCompositeIds());
 	}
+	
+	@Test
+	public void testSetPreferBasicCompositeIds() {
+		assertNull(
+				jdbcMetadataConfiguration.properties.get(
+						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
+		jdbcMetadataConfiguration.setPreferBasicCompositeIds(true);
+		assertEquals(
+				true, 
+				jdbcMetadataConfiguration.properties.get(
+						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
+	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>