### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Add 'ConfigurationFacadeTest#testSetPreferBasicCompositeIds()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeImpl.java
@@ -131,4 +131,8 @@ public class ConfigurationFacadeImpl extends AbstractConfigurationFacade {
 		setClassMappings(classMappings);
 	}
 
+	protected String getJDBCConfigurationClassName() {
+		return "org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JdbcMetadataConfiguration";
+	}
+	
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfiguration.java
@@ -43,7 +43,7 @@ public class JdbcMetadataConfiguration {
 
 	public boolean preferBasicCompositeIds() {
 		Object preferBasicCompositeIds = properties.get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
-		return preferBasicCompositeIds == null ? false : ((Boolean)preferBasicCompositeIds).booleanValue();
+		return preferBasicCompositeIds == null ? true : ((Boolean)preferBasicCompositeIds).booleanValue();
 	}
 
 	public void setPreferBasicCompositeIds(boolean preferBasicCompositeIds) {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
@@ -313,6 +313,16 @@ public class ConfigurationFacadeTest {
 		assertSame(iterator.next(), persistentClassFacade);		
 	}
 	
+	@Test
+	public void testSetPreferBasicCompositeIds() {
+		JdbcMetadataConfiguration configuration = new JdbcMetadataConfiguration();
+		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
+		// the default is true
+		Assert.assertTrue(configuration.preferBasicCompositeIds());
+		configurationFacade.setPreferBasicCompositeIds(false);
+		Assert.assertFalse(configuration.preferBasicCompositeIds());
+	}
+	
 	private static class NativeTestConfiguration extends Configuration {
 		static Metadata METADATA = createMetadata();
 		@SuppressWarnings("unused")

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JdbcMetadataConfigurationTest.java
@@ -92,9 +92,9 @@ public class JdbcMetadataConfigurationTest {
 	
 	@Test
 	public void testPreferBasicCompositeIds() {
-		assertFalse(jdbcMetadataConfiguration.preferBasicCompositeIds());
-		jdbcMetadataConfiguration.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, true);
 		assertTrue(jdbcMetadataConfiguration.preferBasicCompositeIds());
+		jdbcMetadataConfiguration.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, false);
+		assertFalse(jdbcMetadataConfiguration.preferBasicCompositeIds());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>