### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'GenericExporterFacadeImpl#getTemplateName()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/GenericExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/GenericExporterFacadeImpl.java
@@ -36,5 +36,10 @@ public class GenericExporterFacadeImpl extends AbstractGenericExporterFacade {
 	public String getFilePattern() {
 		return ((GenericExporter)getTarget()).getProperties().getProperty(ExporterConstants.FILE_PATTERN);
 	}
+	
+	@Override
+	public String getTemplateName() {
+		return ((GenericExporter)getTarget()).getProperties().getProperty(ExporterConstants.TEMPLATE_NAME);
+	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/GenericExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/GenericExporterFacadeTest.java
@@ -52,4 +52,11 @@ public class GenericExporterFacadeTest {
 		Assert.assertEquals("foobar", genericExporterFacade.getFilePattern());
 	}
 	
+	@Test
+	public void testGetTemplateName() {
+		assertNull(genericExporterFacade.getTemplateName());
+		genericExporter.getProperties().put(ExporterConstants.TEMPLATE_NAME, "foobar");
+		Assert.assertEquals("foobar", genericExporterFacade.getTemplateName());
+	}
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>