### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'FacadeFactoryImpl#createGenericExporter(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
@@ -47,8 +47,7 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	
 	@Override
 	public IGenericExporter createGenericExporter(Object target) {
-		// TODO Auto-generated method stub
-		return null;
+		return new GenericExporterFacadeImpl(this, target);
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
@@ -14,11 +14,13 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
+import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -103,6 +105,13 @@ public class FacadeFactoryTest {
 		ISchemaExport facade = facadeFactory.createSchemaExport(schemaExport);
 		Assert.assertTrue(facade instanceof SchemaExportFacadeImpl);
 		Assert.assertSame(schemaExport, ((IFacade)facade).getTarget());		
+	}
+	
+	@Test
+	public void testCreateGenericExporter() {
+		GenericExporter genericExporter = new GenericExporter();
+		IGenericExporter facade = facadeFactory.createGenericExporter(genericExporter);
+		Assert.assertSame(genericExporter, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>