### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Create initial implementation of 'DdlExporterFacadeTest', add 'DdlExporterFacadeTest#testGetProperties()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/DdlExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/DdlExporterFacadeTest.java
@@ -1,0 +1,29 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractHbm2DDLExporterFacade;
+import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DdlExporterFacadeTest {
+	
+	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private IHbm2DDLExporter ddlExporterFacade = null;
+	private DdlExporter ddlExporterTarget = null;
+	
+	@Before
+	public void before() {
+		ddlExporterTarget = new DdlExporter();
+		ddlExporterFacade = new AbstractHbm2DDLExporterFacade(FACADE_FACTORY, ddlExporterTarget) {};
+	}
+	
+	@Test 
+	public void testGetProperties() {
+		assertNotNull(ddlExporterFacade.getProperties());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>