### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Create initial implementation of 'Hbm2DDLFacadeImpl', add 'DdlExporterFacadeTest#testSetExport()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
@@ -51,12 +51,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
-	public IHbm2DDLExporter createHbm2DDLExporter(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public IQueryExporter createQueryExporter(Object target) {
 		// TODO Auto-generated method stub
 		return null;

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/DdlExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/DdlExporterFacadeTest.java
@@ -1,9 +1,12 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
-import org.jboss.tools.hibernate.runtime.common.AbstractHbm2DDLExporterFacade;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,12 +21,21 @@ public class DdlExporterFacadeTest {
 	@Before
 	public void before() {
 		ddlExporterTarget = new DdlExporter();
-		ddlExporterFacade = new AbstractHbm2DDLExporterFacade(FACADE_FACTORY, ddlExporterTarget) {};
+		ddlExporterFacade = new Hbm2DDLExporterFacadeImpl(FACADE_FACTORY, ddlExporterTarget) {};
 	}
 	
 	@Test 
 	public void testGetProperties() {
 		assertNotNull(ddlExporterFacade.getProperties());
+	}
+	
+	@Test
+	public void testSetExport() {
+		assertNull(ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+		ddlExporterFacade.setExport(false);
+		assertFalse((Boolean)ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+		ddlExporterFacade.setExport(true);
+		assertTrue((Boolean)ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
@@ -1,5 +1,8 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -15,12 +18,14 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -44,12 +49,12 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testFacadeFactoryCreation() {
-		Assert.assertNotNull(facadeFactory);
+		assertNotNull(facadeFactory);
 	}
 	
 	@Test
 	public void testGetClassLoader() {
-		Assert.assertSame(
+		assertSame(
 				FacadeFactoryImpl.class.getClassLoader(), 
 				facadeFactory.getClassLoader());
 	}
@@ -58,28 +63,28 @@ public class FacadeFactoryTest {
 	public void testCreateArtifactCollector() {
 		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
 		IArtifactCollector facade = facadeFactory.createArtifactCollector(artifactCollector);
-		Assert.assertSame(artifactCollector, ((IFacade)facade).getTarget());
+		assertSame(artifactCollector, ((IFacade)facade).getTarget());
 	}
 	
 	@Test
 	public void testCreateCfg2HbmTool() {
 		Cfg2HbmTool cfg2HbmTool = new Cfg2HbmTool();
 		ICfg2HbmTool facade = facadeFactory.createCfg2HbmTool(cfg2HbmTool);
-		Assert.assertSame(cfg2HbmTool,  ((IFacade)facade).getTarget());
+		assertSame(cfg2HbmTool,  ((IFacade)facade).getTarget());
 	}
 	
 	@Test
 	public void testCreateNamingStrategy() {
 		DefaultNamingStrategy namingStrategy = new DefaultNamingStrategy();
 		INamingStrategy facade = facadeFactory.createNamingStrategy(namingStrategy);
-		Assert.assertSame(namingStrategy, ((IFacade)facade).getTarget());
+		assertSame(namingStrategy, ((IFacade)facade).getTarget());
 	}
 	
 	@Test
 	public void testCreateReverseEngineeringSettings() {
 		RevengSettings res = new RevengSettings(null);
 		IReverseEngineeringSettings facade = facadeFactory.createReverseEngineeringSettings(res);
-		Assert.assertSame(res, ((IFacade)facade).getTarget());		
+		assertSame(res, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test
@@ -89,14 +94,14 @@ public class FacadeFactoryTest {
 				new Class[] { RevengStrategy.class }, 
 				new TestInvocationHandler());
 		IReverseEngineeringStrategy facade = facadeFactory.createReverseEngineeringStrategy(res);
-		Assert.assertSame(res, ((IFacade)facade).getTarget());		
+		assertSame(res, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test
 	public void testCreateOverrideRepository() {
 		OverrideRepository overrideRepository = new OverrideRepository();
 		IOverrideRepository facade = facadeFactory.createOverrideRepository(overrideRepository);
-		Assert.assertSame(overrideRepository, ((IFacade)facade).getTarget());		
+		assertSame(overrideRepository, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test
@@ -104,14 +109,21 @@ public class FacadeFactoryTest {
 		SchemaExport schemaExport = new SchemaExport();
 		ISchemaExport facade = facadeFactory.createSchemaExport(schemaExport);
 		Assert.assertTrue(facade instanceof SchemaExportFacadeImpl);
-		Assert.assertSame(schemaExport, ((IFacade)facade).getTarget());		
+		assertSame(schemaExport, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test
 	public void testCreateGenericExporter() {
 		GenericExporter genericExporter = new GenericExporter();
 		IGenericExporter facade = facadeFactory.createGenericExporter(genericExporter);
-		Assert.assertSame(genericExporter, ((IFacade)facade).getTarget());		
+		assertSame(genericExporter, ((IFacade)facade).getTarget());		
+	}
+	
+	@Test
+	public void testCreateHbm2DDLExporter() {
+		DdlExporter ddlExporter = new DdlExporter();
+		IHbm2DDLExporter facade = facadeFactory.createHbm2DDLExporter(ddlExporter);
+		assertSame(ddlExporter, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test
@@ -121,21 +133,21 @@ public class FacadeFactoryTest {
 				new Class[] { SessionFactory.class }, 
 				new TestInvocationHandler());
 		ISessionFactory facade = facadeFactory.createSessionFactory(sessionFactory);
-		Assert.assertSame(sessionFactory, ((IFacade)facade).getTarget());
+		assertSame(sessionFactory, ((IFacade)facade).getTarget());
 	}
 	
 	@Test
 	public void testCreatePersistentClass() {
 		PersistentClass persistentClass = new RootClass(null);
 		IPersistentClass facade = facadeFactory.createPersistentClass(persistentClass);
-		Assert.assertSame(persistentClass, ((IFacade)facade).getTarget());
+		assertSame(persistentClass, ((IFacade)facade).getTarget());
 	}
 	
 	@Test
 	public void testCreateTable() {
 		Table table = new Table();
 		ITable facade = facadeFactory.createTable(table);
-		Assert.assertSame(table, ((IFacade)facade).getTarget());
+		assertSame(table, ((IFacade)facade).getTarget());
 	}
 	
 	private class TestInvocationHandler implements InvocationHandler {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/Hbm2DDLExporterFacadeImpl.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/Hbm2DDLExporterFacadeImpl.java
@@ -1,0 +1,18 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractHbm2DDLExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+
+public class Hbm2DDLExporterFacadeImpl extends AbstractHbm2DDLExporterFacade {
+
+	public Hbm2DDLExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
+		super(facadeFactory, target);
+	}
+	
+	public void setExport(boolean b) {
+		((DdlExporter)getTarget()).getProperties().put(ExporterConstants.EXPORT_TO_DATABASE, b);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>