### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Add 'ExporterFacadeTest#testGetHbm2DDLExporter()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ExporterFacadeImpl.java
@@ -52,4 +52,9 @@ public class ExporterFacadeImpl extends AbstractExporterFacade {
 		return "org.hibernate.tool.internal.export.common.GenericExporter";
 	}
 
+	@Override
+	protected String getHbm2DDLExporterClassName() {
+		return "org.hibernate.tool.internal.export.ddl.DdlExporter";
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ExporterFacadeTest.java
@@ -18,10 +18,12 @@ import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractArtifactCollectorFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.ConfigurationMetadataDescriptor;
 import org.junit.Before;
 import org.junit.Test;
@@ -120,6 +122,17 @@ public class ExporterFacadeTest {
 		genericExporter = exporterFacade.getGenericExporter();
 		assertNotNull(genericExporter);
 		assertSame(exporterTarget, ((IFacade)genericExporter).getTarget());
+	}
+	
+	@Test
+	public void testGetHbm2DDLExporter() {
+		IHbm2DDLExporter hbm2DDLExporter = exporterFacade.getHbm2DDLExporter();
+		assertNull(hbm2DDLExporter);
+		exporterTarget = new DdlExporter();
+		exporterFacade = new ExporterFacadeImpl(FACADE_FACTORY, exporterTarget);
+		hbm2DDLExporter = exporterFacade.getHbm2DDLExporter();
+		assertNotNull(hbm2DDLExporter);
+		assertSame(exporterTarget, ((IFacade)hbm2DDLExporter).getTarget());
 	}
 	
 	private static class TestExporter implements Exporter {		


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>