### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'SessionFactoryFacadeTest#testGetCollectionMetadata()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/SessionFactoryFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/SessionFactoryFacadeTest.java
@@ -106,6 +106,16 @@ public class SessionFactoryFacadeTest {
 		assertNotNull(field.get(sessionFactoryFacade));
 	}
 	
+	@Test
+	public void testGetCollectionMetadata() throws Exception {
+		Field field = AbstractSessionFactoryFacade.class.getDeclaredField("allCollectionMetadata");
+		field.setAccessible(true);
+		assertNull(field.get(sessionFactoryFacade));
+		assertSame(
+				sessionFactoryTarget.childCollectionMetadataTarget,
+				((IFacade)sessionFactoryFacade.getCollectionMetadata("child")).getTarget());
+		assertNotNull(field.get(sessionFactoryFacade));
+	}	
 	
 	private class TestSessionFactory extends SessionFactoryDelegatingImpl {
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>