### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement class 'DummyMetadataBuildingContext'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContext.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContext.java
@@ -1,0 +1,38 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import org.hibernate.boot.internal.BootstrapContextImpl;
+import org.hibernate.boot.internal.InFlightMetadataCollectorImpl;
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.internal.MetadataBuildingContextRootImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.boot.spi.InFlightMetadataCollector;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.dialect.Dialect;
+
+public class DummyMetadataBuildingContext {
+	
+	public static MetadataBuildingContext INSTANCE = createInstance();
+	
+	private static MetadataBuildingContext createInstance() {
+		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+		ssrb.applySetting("hibernate.dialect", DummyDialect.class.getName());
+		StandardServiceRegistry serviceRegistry = ssrb.build();
+		MetadataBuildingOptions metadataBuildingOptions = new MetadataBuilderImpl.MetadataBuildingOptionsImpl(serviceRegistry);
+		BootstrapContext bootstrapContext = new BootstrapContextImpl(serviceRegistry, metadataBuildingOptions);
+		InFlightMetadataCollector inflightMetadataCollector = new InFlightMetadataCollectorImpl(bootstrapContext, metadataBuildingOptions);
+		return new MetadataBuildingContextRootImpl(bootstrapContext, metadataBuildingOptions, inflightMetadataCollector);
+	}
+
+	public static class DummyDialect extends Dialect {
+
+		@Override
+		public int getVersion() {
+			return 0;
+		}
+		
+	}
+
+}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContext.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContext.java
@@ -27,12 +27,7 @@ public class DummyMetadataBuildingContext {
 	}
 
 	public static class DummyDialect extends Dialect {
-
-		@Override
-		public int getVersion() {
-			return 0;
-		}
-		
+		@Override public int getVersion() {return 0;}		
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
@@ -276,15 +276,6 @@ public class ConfigurationFacadeTest {
 	}
 	
 	@Test
-	public void testGetNamingStrategy() {
-		INamingStrategy strategy = FACADE_FACTORY.createNamingStrategy(new DefaultNamingStrategy());
-		ConfigurationFacadeImpl facade = (ConfigurationFacadeImpl)configurationFacade;
-		Assert.assertNull(facade.getNamingStrategy());
-		facade.namingStrategy = strategy;
-		Assert.assertSame(strategy, facade.getNamingStrategy());
-	}
-	
-	@Test
 	public void testGetClassMappings() {
 		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());
 		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
@@ -361,6 +352,15 @@ public class ConfigurationFacadeTest {
 		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
 		((ConfigurationFacadeImpl)configurationFacade).addedClasses.add(persistentClassFacade);
 		assertSame(configurationFacade.getClassMapping("Foo"), persistentClassFacade);
+	}
+	
+	@Test
+	public void testGetNamingStrategy() {
+		INamingStrategy strategy = FACADE_FACTORY.createNamingStrategy(new DefaultNamingStrategy());
+		ConfigurationFacadeImpl facade = (ConfigurationFacadeImpl)configurationFacade;
+		Assert.assertNull(facade.getNamingStrategy());
+		facade.namingStrategy = strategy;
+		Assert.assertSame(strategy, facade.getNamingStrategy());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContextTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataBuildingContextTest.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.junit.Test;
+
+public class DummyMetadataBuildingContextTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DummyMetadataBuildingContext.INSTANCE);
+		StandardServiceRegistry serviceRegistry = DummyMetadataBuildingContext.INSTANCE
+				.getBootstrapContext().getServiceRegistry();
+		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
+		Dialect dialect = jdbcServices.getDialect();
+		assertTrue(dialect instanceof DummyMetadataBuildingContext.DummyDialect);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>