### PR TITLE
JBIDE-27571: Merge functionality of IJDBCReader and IDatabaseCollector - Explicitly set the database collector, remove the IDatabaseCollector argument from IJDBCReader#readDatabaseSchema(...)'

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/workbench/LazyDatabaseSchemaWorkbenchAdapter.java
+++ b/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/workbench/LazyDatabaseSchemaWorkbenchAdapter.java
@@ -128,9 +128,8 @@ public class LazyDatabaseSchemaWorkbenchAdapter extends BasicWorkbenchAdapter {
 				try {
 					IService service = consoleConfiguration.getHibernateExtension().getHibernateService();
 					IJDBCReader reader = service.newJDBCReader(configuration, strategy);
-					db = reader.readDatabaseSchema(
-							service.newDatabaseCollector(reader), 
-							new ProgressListener(monitor));
+					reader.setDatabaseCollector(service.newDatabaseCollector(reader));
+					db = reader.readDatabaseSchema(new ProgressListener(monitor));
 				} catch (UnsupportedOperationException he) {
 					throw new HibernateException(he);
 				} catch (Exception he) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractJDBCReaderFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractJDBCReaderFacade.java
@@ -12,6 +12,8 @@ import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 public abstract class AbstractJDBCReaderFacade 
 extends AbstractFacade 
 implements IJDBCReader {
+	
+	private IDatabaseCollector databaseCollector = null;
 
 	public AbstractJDBCReaderFacade(
 			IFacadeFactory facadeFactory, 
@@ -20,9 +22,7 @@ implements IJDBCReader {
 	}
 
 	@Override
-	public IDatabaseCollector readDatabaseSchema(
-			IDatabaseCollector databaseCollector,
-			IProgressListener progressListener) {
+	public IDatabaseCollector readDatabaseSchema(IProgressListener progressListener) {
 		Object databaseCollectorTarget = Util.invokeMethod(
 				databaseCollector, 
 				"getTarget", 
@@ -56,6 +56,10 @@ implements IJDBCReader {
 						createProgressListener(progressListener)
 				});
 		return databaseCollector;
+	}
+	
+	public void setDatabaseCollector(IDatabaseCollector databaseCollector) {
+		this.databaseCollector = databaseCollector;
 	}
 	
 	public Class<?> getProgressListenerClass() {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IJDBCReader.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IJDBCReader.java
@@ -3,8 +3,8 @@ package org.jboss.tools.hibernate.runtime.spi;
 
 public interface IJDBCReader {
 
-	IDatabaseCollector readDatabaseSchema(
-			IDatabaseCollector databaseCollector,
-			IProgressListener progressListener);
+	IDatabaseCollector readDatabaseSchema(IProgressListener progressListener);
+	
+	void setDatabaseCollector(IDatabaseCollector databaseCollector);
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>