### PR TITLE
JBIDE-27579: Implement functionality of IDatabaseReader directly in IService - Replace use of IService#newDatabaseReader(...).collectDatabaseTables(...) by new method IService#collectDatabaseTables(...) in LazyDatabaseSchemaWorkbenchAdapter

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractService.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractService.java
@@ -7,5 +7,5 @@ public abstract class AbstractService implements IService {
 	protected UsageTracker getUsageTracker() {
 		return UsageTracker.getInstance();
 	}
-
+	
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IService.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IService.java
@@ -57,6 +57,11 @@ public interface IService {
 	IDatabaseReader newDatabaseReader(
 			Properties properties,
 			IReverseEngineeringStrategy strategy);
+	
+	Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy, 
+			IProgressListener progressListener);
 
 	IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName, 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/ServiceImpl.java
@@ -69,6 +69,7 @@ import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -420,6 +421,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 	
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ServiceImpl.java
@@ -68,6 +68,7 @@ import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -428,4 +429,12 @@ public class ServiceImpl extends AbstractService {
 		return ServiceImpl.class.getClassLoader();
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
+	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/ServiceImpl.java
@@ -73,6 +73,7 @@ import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -435,5 +436,13 @@ public class ServiceImpl extends AbstractService {
 		return ServiceImpl.class.getClassLoader();
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
+	}
 
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ServiceImpl.java
@@ -75,6 +75,7 @@ import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -465,6 +466,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ServiceImpl.java
@@ -74,6 +74,7 @@ import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -436,6 +437,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/ServiceImpl.java
@@ -63,15 +63,16 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -430,6 +431,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
@@ -63,15 +63,16 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -432,6 +433,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/ServiceImpl.java
@@ -62,15 +62,16 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -439,6 +440,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImpl.java
@@ -62,15 +62,16 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -89,7 +90,7 @@ import org.xml.sax.EntityResolver;
 
 public class ServiceImpl extends AbstractService {
 
-	private static final String HIBERNATE_VERSION = "5.3";
+	private static final String HIBERNATE_VERSION = "5.4";
 	
 	private IFacadeFactory facadeFactory = new FacadeFactoryImpl();
 
@@ -439,6 +440,15 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
+		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/spi/internal/TestService.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/spi/internal/TestService.java
@@ -19,6 +19,7 @@ import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -259,6 +260,13 @@ public class TestService implements IService {
 
 	@Override
 	public ClassLoader getClassLoader() {
+		return null;
+	}
+
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(Properties properties, IReverseEngineeringStrategy strategy,
+			IProgressListener progressListener) {
+		// TODO Auto-generated method stub
 		return null;
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>