### PR TITLE
JBIDE-27579: Implement functionality of IDatabaseReader directly in IService - Reimplement 'org.jboss.tools.hibernate.runtime.v_x_y.internal.ServiceImpl#collectDatabaseTables(...)' without using IDatabaseReader

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/ServiceImpl.java
@@ -3,24 +3,32 @@ package org.jboss.tools.hibernate.runtime.v_3_5.internal;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.AnnotationConfiguration;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.NamingStrategy;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.connection.DriverManagerConnectionProvider;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.resolver.DialectFactory;
@@ -241,6 +249,42 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						new Configuration().setProperties(properties).buildSettings(), 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget());
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
+	@Override
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName, IReverseEngineeringStrategy delegate) {
 		assert delegate instanceof IFacade;
@@ -423,13 +467,4 @@ public class ServiceImpl extends AbstractService {
 		return ServiceImpl.class.getClassLoader();
 	}
 
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
-	}
-	
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/ServiceImpl.java
@@ -3,24 +3,32 @@ package org.jboss.tools.hibernate.runtime.v_4_0.internal;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.cfg.Settings;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.ejb.Ejb3Configuration;
 import org.hibernate.engine.query.spi.HQLQueryPlan;
@@ -250,6 +258,47 @@ public class ServiceImpl extends AbstractService {
 		return facadeFactory.createDatabaseReader(target);
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		Configuration cfg = new Configuration();
+		cfg.setProperties(properties);
+		ServiceRegistry serviceRegistry = buildServiceRegistry(properties);
+		Settings settings = cfg.buildSettings(serviceRegistry);
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						settings, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						serviceRegistry);
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
 	private ServiceRegistry buildServiceRegistry(Properties properties) {
 		ServiceRegistryBuilder builder = new ServiceRegistryBuilder();
 		builder.applySettings(properties);
@@ -434,15 +483,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/ServiceImpl.java
@@ -6,9 +6,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
@@ -16,14 +20,18 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.common.util.StandardClassLoaderDelegateImpl;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter;
@@ -267,6 +275,42 @@ public class ServiceImpl extends AbstractService {
 		return facadeFactory.createDatabaseReader(target);
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						buildServiceRegistry(properties));
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
 	private ServiceRegistry buildServiceRegistry(Properties properties) {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySettings(properties);
@@ -466,15 +510,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/ServiceImpl.java
@@ -4,9 +4,13 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
@@ -14,14 +18,18 @@ import org.hibernate.Hibernate;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter;
@@ -65,12 +73,12 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -227,6 +235,42 @@ public class ServiceImpl extends AbstractService {
 		return facadeFactory.createDatabaseReader(target);
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						buildServiceRegistry(properties));
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
 	@Override
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
@@ -437,15 +481,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ServiceImpl.java
@@ -4,23 +4,31 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCMetaDataConfiguration;
 import org.hibernate.cfg.JDBCReaderFactory;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter;
@@ -223,6 +231,42 @@ public class ServiceImpl extends AbstractService {
 		return facadeFactory.createDatabaseReader(target);
 	}
 
+	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						buildServiceRegistry(properties));
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
 	@Override
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
@@ -433,15 +477,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/ServiceImpl.java
@@ -4,22 +4,30 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCReaderFactory;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter;
@@ -231,6 +239,42 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						buildServiceRegistry(properties));
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
+	@Override
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
 			IReverseEngineeringStrategy delegate) {
@@ -440,15 +484,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImpl.java
@@ -4,22 +4,30 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JDBCReaderFactory;
+import org.hibernate.cfg.reveng.DefaultDatabaseCollector;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
+import org.hibernate.cfg.reveng.ProgressListener;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.TableFilter;
+import org.hibernate.cfg.reveng.dialect.MetaDataDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionInfoAdapter;
@@ -231,6 +239,42 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
+	public Map<String, List<ITable>> collectDatabaseTables(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy,
+			final IProgressListener progressListener) {
+		Map<String, List<ITable>> result = new HashMap<String, List<ITable>>();
+		JDBCReader jdbcReader = 
+				JDBCReaderFactory.newJDBCReader(
+						properties, 
+						(ReverseEngineeringStrategy)((IFacade)strategy).getTarget(),
+						buildServiceRegistry(properties));
+		MetaDataDialect metadataDialect = jdbcReader.getMetaDataDialect();
+		DefaultDatabaseCollector databaseCollector = new DefaultDatabaseCollector(metadataDialect);
+		ProgressListener progressListenerWrapper = new ProgressListener() {			
+			@Override
+			public void startSubTask(String name) {
+				progressListener.startSubTask(name);
+			}
+		};
+		jdbcReader.readDatabaseSchema(
+				databaseCollector, 
+				properties.getProperty(Environment.DEFAULT_CATALOG), 
+				properties.getProperty(Environment.DEFAULT_SCHEMA),
+				progressListenerWrapper);
+		Iterator<?> iterator = databaseCollector.getQualifierEntries();
+		while (iterator.hasNext()) {
+			Entry<?, ?> entry = (Entry<?, ?>)iterator.next();
+			ArrayList<ITable> list = new ArrayList<ITable>();
+			for (Object table : (Iterable<?>)entry.getValue()) {
+				list.add(facadeFactory.createTable(table));
+			}
+			result.put((String)entry.getKey(), list);
+		}
+		return result;
+	}
+	
+	@Override
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
 			IReverseEngineeringStrategy delegate) {
@@ -440,15 +484,6 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
-	}
-
-	@Override
-	public Map<String, List<ITable>> collectDatabaseTables(
-			Properties properties, 
-			IReverseEngineeringStrategy strategy,
-			IProgressListener progressListener) {
-		IDatabaseReader databaseReader = newDatabaseReader(properties, strategy);
-		return databaseReader.collectDatabaseTables(progressListener);
 	}
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>