### PR TITLE
JBIDE-27579: Implement functionality of IDatabaseReader directly in IService - Remove declaration and uses of IFacadeFactory#createDatabaseReader(Object)

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractFacadeFactory.java
@@ -195,11 +195,6 @@ public abstract class AbstractFacadeFactory implements IFacadeFactory {
 	}
 
 	@Override
-	public IDatabaseReader createDatabaseReader(Object target) {
-		return new AbstractDatabaseReaderFacade(this, target) {};
-	}
-
-	@Override
 	public ISessionFactory createSessionFactory(Object target) {
 		return new AbstractSessionFactoryFacade(this, target) {};
 	}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacadeFactory.java
@@ -66,7 +66,6 @@ public interface IFacadeFactory {
 	IHQLCodeAssist createHQLCodeAssist(Object target);
 	IHQLCompletionProposal createHQLCompletionProposal(Object target);
 	IHQLQueryPlan createHQLQueryPlan(Object target);
-	IDatabaseReader createDatabaseReader(Object target);
 	IJoin createJoin(Object target);
 	IPersistentClass createPersistentClass(Object target);
 	IPOJOClass createPOJOClass(Object target);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
@@ -15,7 +15,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -107,12 +106,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 
 	@Override
 	public IHQLQueryPlan createHQLQueryPlan(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public IDatabaseReader createDatabaseReader(Object target) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/FacadeFactoryTest.java
@@ -14,8 +14,6 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Mappings;
 import org.hibernate.cfg.NamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -67,7 +65,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -316,13 +313,6 @@ public class FacadeFactoryTest {
 		HQLQueryPlan hqlQueryPlan = new HQLQueryPlan("from foo", false, Collections.emptyMap(), sfi);
 		IHQLQueryPlan facade = facadeFactory.createHQLQueryPlan(hqlQueryPlan);
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/FacadeFactoryTest.java
@@ -13,8 +13,6 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Mappings;
 import org.hibernate.cfg.NamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -66,7 +64,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -317,13 +314,6 @@ public class FacadeFactoryTest {
 		HQLQueryPlan hqlQueryPlan = new HQLQueryPlan("from foo", false, Collections.emptyMap(), sfi);
 		IHQLQueryPlan facade = facadeFactory.createHQLQueryPlan(hqlQueryPlan);
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/FacadeFactoryTest.java
@@ -13,8 +13,6 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Mappings;
 import org.hibernate.cfg.NamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -67,7 +65,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -324,13 +321,6 @@ public class FacadeFactoryTest {
 		HQLQueryPlan hqlQueryPlan = new HQLQueryPlan("from foo", false, Collections.emptyMap(), sfi);
 		IHQLQueryPlan facade = facadeFactory.createHQLQueryPlan(hqlQueryPlan);
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/FacadeFactoryTest.java
@@ -15,8 +15,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Mappings;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -68,7 +66,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -327,13 +324,6 @@ public class FacadeFactoryTest {
 		HQLQueryPlan hqlQueryPlan = new HQLQueryPlan("from foo", false, filters, sfi);
 		IHQLQueryPlan facade = facadeFactory.createHQLQueryPlan(hqlQueryPlan);
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/FacadeFactoryTest.java
@@ -22,8 +22,6 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -77,7 +75,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -371,13 +368,6 @@ public class FacadeFactoryTest {
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
 	}
 
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
-	}
-	
 	@Test
 	public void testCreateJoin() {
 		Join join = new Join();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/FacadeFactoryTest.java
@@ -22,8 +22,6 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -77,7 +75,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -372,13 +369,6 @@ public class FacadeFactoryTest {
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
 	}
 
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
-	}
-	
 	@Test
 	public void testCreateJoin() {
 		Join join = new Join();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/FacadeFactoryTest.java
@@ -21,8 +21,6 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -77,7 +75,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -374,13 +371,6 @@ public class FacadeFactoryTest {
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
 	}
 
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
-	}
-	
 	@Test
 	public void testCreateJoin() {
 		Join join = new Join();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/FacadeFactoryTest.java
@@ -21,8 +21,6 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -76,7 +74,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -370,13 +367,6 @@ public class FacadeFactoryTest {
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
 	}
 
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
-	}
-	
 	@Test
 	public void testCreateJoin() {
 		Join join = new Join();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/FacadeFactoryTest.java
@@ -23,8 +23,6 @@ import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
-import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
-import org.hibernate.cfg.reveng.JDBCReader;
 import org.hibernate.cfg.reveng.OverrideRepository;
 import org.hibernate.cfg.reveng.ReverseEngineeringSettings;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
@@ -78,7 +76,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
@@ -373,13 +370,6 @@ public class FacadeFactoryTest {
 		Assert.assertSame(hqlQueryPlan, ((IFacade)facade).getTarget());		
 	}
 
-	@Test
-	public void testCreateDatabaseReader() {
-		JDBCReader jdbcReader = new JDBCReader(null, null, null, null, null, new DefaultReverseEngineeringStrategy());
-		IDatabaseReader databaseReaderFacade = facadeFactory.createDatabaseReader(jdbcReader);
-		Assert.assertSame(jdbcReader, ((IFacade)databaseReaderFacade).getTarget());		
-	}
-	
 	@Test
 	public void testCreateJoin() {
 		Join join = new Join();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>