### PR TITLE
JBIDE-27580: Update dependency of the runtime tests on H2 to version 1.4.200 - Fix runtime for org.jboss.tools.hibernate.runtime.v_5_4.test

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_4
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
 Bundle-ClassPath: .,
- lib/h2-1.4.190.jar
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/build.properties
@@ -2,5 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.190.jar
-
+               lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>