### PR TITLE
JBIDE-27580: Update dependency of the runtime tests on H2 to version 1.4.200 - Fix runtime for org.jboss.tools.hibernate.runtime.v_x_y.test

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_5;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-ClassPath: lib/h2-1.4.192.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.192.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_6;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-ClassPath: lib/h2-1.4.192.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.192.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_0;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-ClassPath: lib/h2-1.4.192.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.192.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-ClassPath: .,
- lib/h2-1.4.192.jar
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.192.jar
+               lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
-Bundle-ClassPath: lib/h2-1.4.190.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.190.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-ClassPath: lib/h2-1.4.190.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.190.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 5.4.11.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
-Bundle-ClassPath: lib/h2-1.4.190.jar,
- .
+Bundle-ClassPath: .,
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.190.jar
+               lib/

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_3
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
 Bundle-ClassPath: .,
- lib/h2-1.4.190.jar
+ lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/build.properties
@@ -2,5 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               lib/h2-1.4.190.jar
-
+               lib/


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>