### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'ForeignKeyFacadeTest#testGetReferencedTable()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ForeignKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ForeignKeyFacadeTest.java
@@ -1,0 +1,36 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import static org.junit.Assert.assertSame;
+
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
+import org.jboss.tools.hibernate.runtime.common.AbstractForeignKeyFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IForeignKey;
+import org.jboss.tools.hibernate.runtime.spi.ITable;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ForeignKeyFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private IForeignKey foreignKeyFacade = null; 
+	private ForeignKey foreignKey = null;
+	
+	@Before
+	public void before() {
+		foreignKey = new ForeignKey();
+		foreignKeyFacade = new AbstractForeignKeyFacade(FACADE_FACTORY, foreignKey) {};
+	}
+	
+	@Test
+	public void testGetReferencedTable() {
+		Table tableTarget = new Table();
+		foreignKey.setReferencedTable(tableTarget);
+		ITable table = foreignKeyFacade.getReferencedTable();
+		assertSame(tableTarget, ((IFacade)table).getTarget());
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>