### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Rename 'org.jboss.tools.hibernate.runtime.v_6_0.internal.DdlExporterFacadeTest' to 'org.jboss.tools.hibernate.runtime.v_6_0.internal.Hbm2DDLExporterFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/Hbm2DDLExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/Hbm2DDLExporterFacadeTest.java
@@ -11,7 +11,7 @@ import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DdlExporterFacadeTest {
+public class Hbm2DDLExporterFacadeTest {
 	
 	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>