### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initial implementation of class 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtension'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
@@ -29,6 +29,7 @@ extends HibernateMappingExporter {
 	public void superExportPOJO(Map<String, Object> map, POJOClass pojoClass) {
 		super.exportPOJO(map, pojoClass);
 	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	protected void exportPOJO(Map map, POJOClass pojoClass) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import java.io.File;
+
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.ConfigurationMetadataDescriptor;
+
+public class HibernateMappingExporterExtension extends HbmExporter {
+	
+	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
+		getProperties().put(
+				METADATA_DESCRIPTOR, 
+				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)cfg));
+		if (file != null) {
+			getProperties().put(OUTPUT_FILE_NAME, file);
+		}
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -1,0 +1,25 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HibernateMappingExporterExtensionTest {
+
+	private static IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private HibernateMappingExporterExtension hibernateMappingExporterExtension;
+
+	@Before
+	public void setUp() throws Exception {
+		hibernateMappingExporterExtension = new HibernateMappingExporterExtension(FACADE_FACTORY, null, null);
+	}
+	
+	@Test
+	public void testConstructor() {
+		assertNotNull(hibernateMappingExporterExtension);
+	}
+	
+}	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>