### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtension#setDelegate(IExportPOJODelegate)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -5,10 +5,13 @@ import java.io.File;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.ConfigurationMetadataDescriptor;
 
 public class HibernateMappingExporterExtension extends HbmExporter {
 	
+	private IExportPOJODelegate delegateExporter;
+
 	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
@@ -18,4 +21,8 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		}
 	}
 	
+	public void setDelegate(IExportPOJODelegate delegate) {
+		delegateExporter = delegate;
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -1,8 +1,14 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
+import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,8 +24,16 @@ public class HibernateMappingExporterExtensionTest {
 	}
 	
 	@Test
-	public void testConstructor() {
-		assertNotNull(hibernateMappingExporterExtension);
+	public void testSetDelegate() throws Exception {
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+		};
+		assertNull(delegateField.get(hibernateMappingExporterExtension));
+		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
+		assertSame(exportPojoDelegate, delegateField.get(hibernateMappingExporterExtension));
 	}
 	
 }	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>