### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtension#superExportPOJO(Map<String, Object>,POJOClass)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -23,4 +23,5 @@ Bundle-ClassPath: .,
 Require-Bundle: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
- org.jboss.tools.hibernate.libs.activation.v_1_2_0
+ org.jboss.tools.hibernate.libs.activation.v_1_2_0,
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3_23

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -1,8 +1,10 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
 import java.io.File;
+import java.util.Map;
 
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.internal.export.java.POJOClass;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
@@ -23,6 +25,10 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 	
 	public void setDelegate(IExportPOJODelegate delegate) {
 		delegateExporter = delegate;
+	}
+
+	public void superExportPOJO(Map<String, Object> map, POJOClass pojoClass) {
+		super.exportPOJO(map, pojoClass);
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -1,14 +1,34 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.version.Version;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
+import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.TemplateHelper;
+import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
+import org.hibernate.tool.internal.export.java.EntityPOJOClass;
+import org.hibernate.tool.internal.export.java.POJOClass;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +54,50 @@ public class HibernateMappingExporterExtensionTest {
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
 		assertSame(exportPojoDelegate, delegateField.get(hibernateMappingExporterExtension));
+	}
+	
+	@Test
+	public void testSuperExportPOJO() throws Exception {
+		Method setTemplateHelperMethod = AbstractExporter.class.getDeclaredMethod(
+				"setTemplateHelper", 
+				new Class[] { TemplateHelper.class });
+		setTemplateHelperMethod.setAccessible(true);
+		TemplateHelper templateHelper = new TemplateHelper();
+		templateHelper.init(null, new String[0]);
+		setTemplateHelperMethod.invoke(hibernateMappingExporterExtension, new Object[] { templateHelper });
+		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		Map<String, Object> additionalContext = new HashMap<String, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.CURRENT_VERSION);
+		additionalContext.put("c2h", c2h);
+		hibernateMappingExporterExtension.superExportPOJO(additionalContext, createPojoClass());
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals("foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+	}
+	
+	@After
+	public void tearDown() {
+		new File("foo" + File.separator + "Bar.hbm.xml").delete();
+		new File("foo").delete();
+	}
+		
+	private POJOClass createPojoClass() {
+		RootClass persistentClass = new RootClass(null);
+		Table rootTable = new Table();
+		rootTable.setName("table");
+		persistentClass.setTable(rootTable);
+		persistentClass.setEntityName("Bar");
+		persistentClass.setClassName("foo.Bar");
+		return new EntityPOJOClass(persistentClass, new Cfg2JavaTool());		
 	}
 	
 }	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>