### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implement 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtension#exportPOJO(Map,POJOClass)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -13,8 +13,10 @@ import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.ConfigurationMetada
 public class HibernateMappingExporterExtension extends HbmExporter {
 	
 	private IExportPOJODelegate delegateExporter;
+	private IFacadeFactory facadeFactory;
 
 	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
+		this.facadeFactory = facadeFactory;
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
 				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)cfg));
@@ -31,4 +33,15 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		super.exportPOJO(map, pojoClass);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	protected void exportPOJO(Map map, POJOClass pojoClass) {
+		if (delegateExporter == null) {
+			super.exportPOJO(map, pojoClass);
+		} else {
+			delegateExporter.exportPOJO(
+					(Map<Object, Object>)map, 
+					facadeFactory.createPOJOClass(pojoClass));
+		}
+	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -25,6 +25,7 @@ import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
@@ -58,13 +59,7 @@ public class HibernateMappingExporterExtensionTest {
 	
 	@Test
 	public void testSuperExportPOJO() throws Exception {
-		Method setTemplateHelperMethod = AbstractExporter.class.getDeclaredMethod(
-				"setTemplateHelper", 
-				new Class[] { TemplateHelper.class });
-		setTemplateHelperMethod.setAccessible(true);
-		TemplateHelper templateHelper = new TemplateHelper();
-		templateHelper.init(null, new String[0]);
-		setTemplateHelperMethod.invoke(hibernateMappingExporterExtension, new Object[] { templateHelper });
+		initializeTemplateHelper();
 		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
 		hibernateMappingExporterExtension.getProperties().put(
 				ExporterConstants.ARTIFACT_COLLECTOR, 
@@ -84,6 +79,54 @@ public class HibernateMappingExporterExtensionTest {
 		assertTrue(new File("foo" + File.separator + "Bar.hbm.xml").exists());
 	}
 	
+	@Test
+	public void testExportPOJO() throws Exception {
+		initializeTemplateHelper();
+		POJOClass pojoClass = createPojoClass();
+		// first without a delegate exporter
+		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Map<Object, Object> additionalContext = new HashMap<Object, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.CURRENT_VERSION);
+		additionalContext.put("c2h", c2h);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals("foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		// then with a delegate exporter
+		artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+				arguments.put("map", map);
+				arguments.put("pojoClass", pojoClass);
+			}
+		};
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		delegateField.set(hibernateMappingExporterExtension, exportPojoDelegate);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertNull(arguments.get("map"));
+		assertNull(arguments.get("pojoClass"));
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertSame(additionalContext, arguments.get("map"));
+		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+	}
+	
 	@After
 	public void tearDown() {
 		new File("foo" + File.separator + "Bar.hbm.xml").delete();
@@ -98,6 +141,18 @@ public class HibernateMappingExporterExtensionTest {
 		persistentClass.setEntityName("Bar");
 		persistentClass.setClassName("foo.Bar");
 		return new EntityPOJOClass(persistentClass, new Cfg2JavaTool());		
+	}
+	
+	private void initializeTemplateHelper() throws Exception {
+		Method setTemplateHelperMethod = AbstractExporter.class.getDeclaredMethod(
+				"setTemplateHelper", 
+				new Class[] { TemplateHelper.class });
+		setTemplateHelperMethod.setAccessible(true);
+		TemplateHelper templateHelper = new TemplateHelper();
+		templateHelper.init(null, new String[0]);
+		setTemplateHelperMethod.invoke(
+				hibernateMappingExporterExtension, 
+				new Object[] { templateHelper });		
 	}
 	
 }	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>