### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initial implementation of 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterFacadeImpl'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
@@ -1,0 +1,12 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import org.jboss.tools.hibernate.runtime.common.AbstractHibernateMappingExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+
+public class HibernateMappingExporterFacadeImpl extends AbstractHibernateMappingExporterFacade {
+
+	public HibernateMappingExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
+		super(facadeFactory, target);
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -1,0 +1,39 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class HibernateMappingExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	
+	private IHibernateMappingExporter hibernateMappingExporterFacade = null; 
+	private HibernateMappingExporterExtension hibernateMappingExporter = null;
+	
+	private File outputDir = null;
+	
+	@Before
+	public void setUp() throws Exception {
+		hibernateMappingExporter = new HibernateMappingExporterExtension(FACADE_FACTORY, null, null);
+		hibernateMappingExporterFacade = 
+				new HibernateMappingExporterFacadeImpl(FACADE_FACTORY, hibernateMappingExporter);
+		outputDir = temporaryFolder.getRoot();
+	}
+	
+	@Test
+	public void testCreation() {
+		assertNotNull(hibernateMappingExporterFacade);
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>