### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of HibernateMappingExporterFacadeTest#testGetOutputDirectory()

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
@@ -1,5 +1,9 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
+import java.io.File;
+
+import org.hibernate.tool.api.export.Exporter;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.jboss.tools.hibernate.runtime.common.AbstractHibernateMappingExporterFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 
@@ -7,6 +11,11 @@ public class HibernateMappingExporterFacadeImpl extends AbstractHibernateMapping
 
 	public HibernateMappingExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
 		super(facadeFactory, target);
+	}
+
+	@Override
+	public File getOutputDirectory() {
+		return (File)((Exporter)getTarget()).getProperties().get(ExporterConstants.DESTINATION_FOLDER);
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -31,6 +31,7 @@ import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.DummyMetadataBuildingContext;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -92,6 +93,14 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(fooHbmXml.exists());
 		assertTrue(fooHbmXml.delete());
 		assertTrue(outputDir.exists());
+	}
+	
+	@Test
+	public void testGetOutputDirectory() {
+		Assert.assertNull(hibernateMappingExporterFacade.getOutputDirectory());
+		File file = new File("testGetOutputDirectory");
+		hibernateMappingExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, file);
+		Assert.assertSame(file, hibernateMappingExporterFacade.getOutputDirectory());
 	}
 	
 	private class TestMetadataDescriptor implements MetadataDescriptor {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>