### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of HibernateMappingExporterFacadeTest#testSetOutputDirectory()

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeImpl.java
@@ -17,5 +17,11 @@ public class HibernateMappingExporterFacadeImpl extends AbstractHibernateMapping
 	public File getOutputDirectory() {
 		return (File)((Exporter)getTarget()).getProperties().get(ExporterConstants.DESTINATION_FOLDER);
 	}
+	
+	@Override
+	public void setOutputDirectory(File directory) {
+		((Exporter)getTarget()).getProperties().put(ExporterConstants.DESTINATION_FOLDER, directory);
+	}
+
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -1,6 +1,8 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -31,7 +33,6 @@ import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.DummyMetadataBuildingContext;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,10 +98,18 @@ public class HibernateMappingExporterFacadeTest {
 	
 	@Test
 	public void testGetOutputDirectory() {
-		Assert.assertNull(hibernateMappingExporterFacade.getOutputDirectory());
+		assertNull(hibernateMappingExporterFacade.getOutputDirectory());
 		File file = new File("testGetOutputDirectory");
 		hibernateMappingExporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, file);
-		Assert.assertSame(file, hibernateMappingExporterFacade.getOutputDirectory());
+		assertSame(file, hibernateMappingExporterFacade.getOutputDirectory());
+	}
+	
+	@Test
+	public void testSetOutputDirectory() {
+		assertNull(hibernateMappingExporter.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
+		File file = new File("testSetOutputDirectory");
+		hibernateMappingExporterFacade.setOutputDirectory(file);
+		assertSame(file, hibernateMappingExporter.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
 	}
 	
 	private class TestMetadataDescriptor implements MetadataDescriptor {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>