### PR TITLE
JBIDE-27621: For JBIDE 4.19.0.AM1: Prepare for 4.19.0.AM1 / 12.19.0.AM1 [hibernate] - Bump version identifier to 5.4.12-SNAPSHOT

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.activation.v_1_2_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.activation.v_1_2_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Activation API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.activation.v_1_2_0
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/javax.activation-api-1.2.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.activation.v_1_2_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.activation.v_1_2_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.activation.v_1_2_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Antlr for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.antlr.v_2_7_7
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/antlr-2.7.7.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.antlr.v_2_7_7</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Beanshell for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.bsh.v_2_0_b4
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/bsh-core-2.0b4.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.bsh.v_2_0_b4</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Dom4j for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1
 Bundle-Vendor: Red Hat
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/dom4j-1.6.1.jar,
  .

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.dom4j.v_1_6_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3_23/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3_23/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Freemarker for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.freemarker.v_2_3_23
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/freemarker-2.3.23.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3_23/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3_23/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.freemarker.v_2_3_23</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Activation API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/jaxb-api-2.3.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Activation API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/jaxb-core-2.3.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JTidy for JBoss Tools Hibernate
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/jtidy-r8-20060801.jar
 Export-Package: org.w3c.tidy,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801</artifactId>

--- a/common/plugin/lib/pom.xml
+++ b/common/plugin/lib/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 	<artifactId>lib</artifactId>

--- a/common/plugin/pom.xml
+++ b/common/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>common</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common</groupId>
 	<artifactId>plugin</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>common</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>docs</artifactId>

--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.eclipse.feature"
       label="%featureName"
-      version="5.4.11.qualifier"
+      version="5.4.12.qualifier"
       provider-name="%providerName"
       plugin="org.hibernate.eclipse"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.hibernate.eclipse.feature/pom.xml
+++ b/features/org.hibernate.eclipse.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.features</groupId>
 	<artifactId>org.hibernate.eclipse.feature</artifactId> 

--- a/features/org.hibernate.eclipse.test.feature/feature.xml
+++ b/features/org.hibernate.eclipse.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.eclipse.test.feature"
       label="%featureName"
-      version="5.4.11.qualifier"
+      version="5.4.12.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/features/org.hibernate.eclipse.test.feature/pom.xml
+++ b/features/org.hibernate.eclipse.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.plugins</groupId>
 	<artifactId>org.hibernate.eclipse.test.feature</artifactId> 

--- a/features/org.hibernate.search.eclipse.feature/feature.xml
+++ b/features/org.hibernate.search.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.search.eclipse.feature"
       label="%featureName"
-      version="5.4.11.qualifier"
+      version="5.4.12.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.hibernate.search"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.hibernate.search.eclipse.feature/pom.xml
+++ b/features/org.hibernate.search.eclipse.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
   <groupId>org.jboss.tools.hibernatesearchtools.features</groupId>
   <artifactId>org.hibernate.search.eclipse.feature</artifactId>

--- a/features/org.jboss.tools.hibernate.search.test.feature/feature.xml
+++ b/features/org.jboss.tools.hibernate.search.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.hibernate.search.test.feature"
       label="%featureName"
-      version="5.4.11.qualifier"
+      version="5.4.12.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/features/org.jboss.tools.hibernate.search.test.feature/pom.xml
+++ b/features/org.jboss.tools.hibernate.search.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatesearchtools.features</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>features</artifactId>

--- a/itests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
+++ b/itests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate UI tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.ui.bot.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/itests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/itests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>itests</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.itests</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui.bot.test</artifactId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>itests</artifactId>

--- a/orm/plugin/core/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.console; singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.hibernate.eclipse.console.HibernateConsolePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.console/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.console/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.console</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.help/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.help; singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.hibernate.eclipse.help.HelpPlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.help/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.help/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.help</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.jdt.ui;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.hibernate.eclipse.jdt.ui.Activator
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.jdt.ui</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.mapper/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.mapper/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.mapper; singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.hibernate.eclipse.mapper.MapperPlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.mapper/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.mapper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.mapper</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.hibernate.eclipse.HibernatePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.core;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.wst.validation;bundle-version="1.2.501",

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.core</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Jdt UI
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.ui;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.jpt.ui.HibernateJptUIPlugin
 Require-Bundle: 
  org.hibernate.eclipse.console;bundle-version="5.0.0",

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.ui/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  org.eclipse.jdt.ui;bundle-version="3.10.100",
  org.hibernate.eclipse.console;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Export-Package: org.jboss.tools.hibernate.ui.diagram,
  org.jboss.tools.hibernate.ui.diagram.editors,
  org.jboss.tools.hibernate.ui.diagram.editors.actions,

--- a/orm/plugin/core/org.jboss.tools.hibernate.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.100",
  org.jboss.tools.common.model.ui;bundle-version="3.7.0",
  org.jboss.tools.hibernate.xml;bundle-version="5.0.0",
  org.eclipse.wst.xml.ui;bundle-version="1.1.500"
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.xml.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.100",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.jboss.tools.common;bundle-version="3.7.0",
  org.jboss.tools.common.model;bundle-version="3.7.0"
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.xml</artifactId> 

--- a/orm/plugin/core/pom.xml
+++ b/orm/plugin/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 	<artifactId>core</artifactId>

--- a/orm/plugin/pom.xml
+++ b/orm/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>orm</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 	<artifactId>plugin</artifactId>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Tools Service Provider Interface
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.common;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.common</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Tools Service Provider Interface
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.spi;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.tools.hibernate.runtime.spi
 Require-Bundle: org.eclipse.core.runtime

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.spi</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 3.5 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_5</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 3.6 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_6;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_6</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 4.0 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_0</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 4.3 libraries
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.0.0",

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_3</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.0 libraries
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_0;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_0</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.1 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_1;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/classmate-1.3.1.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_1</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.2 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_2;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: lib/classmate-1.3.1.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_2</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.3 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_3;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_3</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.4 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_4</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.0 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
  lib/antlr4-runtime-4.8-1.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_0</artifactId> 

--- a/orm/plugin/runtime/pom.xml
+++ b/orm/plugin/runtime/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 	<artifactId>runtime</artifactId>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.hibernatetools</groupId>

--- a/orm/test/core/org.hibernate.eclipse.jdt.ui.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.hibernate.eclipse.jdt.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.jdt.ui.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.hibernate.eclipse.console;bundle-version="5.0.0",

--- a/orm/test/core/org.hibernate.eclipse.jdt.ui.test/pom.xml
+++ b/orm/test/core/org.hibernate.eclipse.jdt.ui.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.hibernate.eclipse.jdt.ui.test</artifactId> 

--- a/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.core.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.wst.common.project.facet.ui;bundle-version="1.4.500",
  org.eclipse.jpt.jpa.core;bundle-version="3.4.0",

--- a/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/pom.xml
+++ b/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.core.test</artifactId> 

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.test;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-ClassPath: .,
  lib/jmock-2.5.1.jar,
  lib/jmock-legacy-2.5.1.jar,

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.test</artifactId> 

--- a/orm/test/core/pom.xml
+++ b/orm/test/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 	<artifactId>core</artifactId>

--- a/orm/test/pom.xml
+++ b/orm/test/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>orm</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 	<artifactId>test</artifactId>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Service Plugin Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.spi.test;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.spi
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.spi.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 3.5 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_5;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_5.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime Version 3.6 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_6.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_6;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_6.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 4.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_0;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_0.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 4.3 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_3.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_0.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_0.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.1 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_1.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_1.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.2 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_2.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_2.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.3 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_3.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_3
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_3.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.4 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_4
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_4.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 6.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0.test
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_0.test</artifactId> 

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>

--- a/orm/test/util/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
+++ b/orm/test/util/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Hibernate UI Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.reddeer
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/orm/test/util/org.jboss.tools.hibernate.reddeer/pom.xml
+++ b/orm/test/util/org.jboss.tools.hibernate.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>util</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.jboss.tools.hibernate.reddeer</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/orm/test/util/pom.xml
+++ b/orm/test/util/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 	<artifactId>util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	</parent>
 	<artifactId>hibernatetools</artifactId>
 	<name>jbosstools-hibernate</name>
-	<version>5.4.11-SNAPSHOT</version>
+	<version>5.4.12-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-hibernate.git</tycho.scmUrl>

--- a/search/plugin/core/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
+++ b/search/plugin/core/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: jbosstools-hibernate-search
 Bundle-SymbolicName: org.jboss.tools.hibernate.search;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: bdshadow
 Export-Package: org.jboss.tools.hibernate.search,

--- a/search/plugin/core/org.jboss.tools.hibernate.search/pom.xml
+++ b/search/plugin/core/org.jboss.tools.hibernate.search/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.search</artifactId>

--- a/search/plugin/core/pom.xml
+++ b/search/plugin/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 	<artifactId>core</artifactId>

--- a/search/plugin/pom.xml
+++ b/search/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>search</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search</groupId>
 	<artifactId>plugin</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Search Tools Service Provider Interface
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.common;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Vendor: bdshadow
 Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.hibernate.search.runtime.spi;bundle-version="2.0.0",

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.common</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.spi
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.spi;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.search.runtime.spi.internal.HibernateSearchServicePlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.spi</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_4_0
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_4_0;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_0;bundle-version="5.1.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.v_4_0</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_3
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_3;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.v_5_3</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_5.1
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_5.1;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/pom.xml
@@ -6,7 +6,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_5
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_5;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_7
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_7;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
   </parent>
   
 	<groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>

--- a/search/plugin/runtime/pom.xml
+++ b/search/plugin/runtime/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 	<artifactId>runtime</artifactId>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>search</artifactId>

--- a/search/test/core/org.jboss.tools.hibernate.search.test/META-INF/MANIFEST.MF
+++ b/search/test/core/org.jboss.tools.hibernate.search.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Search Plugin Test
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.test;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.hibernate.eclipse,

--- a/search/test/core/org.jboss.tools.hibernate.search.test/pom.xml
+++ b/search/test/core/org.jboss.tools.hibernate.search.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatesearchtools.search.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.test</artifactId>

--- a/search/test/core/pom.xml
+++ b/search/test/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.test</groupId>
 	<artifactId>core</artifactId>

--- a/search/test/pom.xml
+++ b/search/test/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>search</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search</groupId>
 	<artifactId>test</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>hibernatetools.site</artifactId> 

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>test-framework</artifactId>

--- a/tests/org.jboss.tools.hibernate.dummy.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.hibernate.dummy.test/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Dummy Test
 Bundle-SymbolicName: org.jboss.tools.hibernate.dummy.test;singleton:=true
-Bundle-Version: 5.4.11.qualifier
+Bundle-Version: 5.4.12.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/tests/org.jboss.tools.hibernate.dummy.test/pom.xml
+++ b/tests/org.jboss.tools.hibernate.dummy.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>tests</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.tests</groupId>
 	<artifactId>org.jboss.tools.hibernate.dummy.test</artifactId> 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.11-SNAPSHOT</version>
+		<version>5.4.12-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>