### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of HibernateMappingExporterFacadeTest#testSetExportPOJODelegate()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -112,6 +112,19 @@ public class HibernateMappingExporterFacadeTest {
 		assertSame(file, hibernateMappingExporter.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
 	}
 	
+	@Test
+	public void testSetExportPOJODelegate() throws Exception {
+		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+		};
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		assertNull(delegateField.get(hibernateMappingExporter));
+		hibernateMappingExporterFacade.setExportPOJODelegate(delegate);
+		assertSame(delegate, delegateField.get(hibernateMappingExporter));
+	}
+	
 	private class TestMetadataDescriptor implements MetadataDescriptor {
 		@Override
 		public Metadata createMetadata() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>