### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PersistentClassFacadeTest#testGetParentProperty()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractPersistentClassFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractPersistentClassFacade.java
@@ -324,7 +324,7 @@ implements IPersistentClass {
 
 	@Override
 	public IProperty getParentProperty() {
-		throw new RuntimeException("getProperty() is only allowed on SpecialRootClass"); //$NON-NLS-1$
+		throw new RuntimeException("getParentProperty() is only allowed on SpecialRootClass"); //$NON-NLS-1$
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
@@ -369,6 +369,16 @@ public class PersistentClassFacadeTest {
 		assertFalse(persistentClassFacade.isInstanceOfSpecialRootClass());
 	}
 	
+	@Test
+	public void testGetParentProperty() {
+		try {
+			persistentClassFacade.getParentProperty();
+			fail();
+		} catch (RuntimeException e) {
+			assertEquals("getParentProperty() is only allowed on SpecialRootClass", e.getMessage());
+		}
+	}
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>