### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PersistentClassFacadeTest#testGetDiscriminatorValue()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
@@ -618,6 +618,13 @@ public class PersistentClassFacadeTest {
 		assertEquals("foo", persistentClassFacade.getCustomSQLUpdate());
 	}
 	
+	@Test
+	public void testGetDiscriminatorValue() {
+		assertNotEquals("bar", persistentClassFacade.getDiscriminatorValue());
+		((RootClass)persistentClassTarget).setDiscriminatorValue("bar");
+		assertEquals("bar", persistentClassFacade.getDiscriminatorValue());
+	}
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>