### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PersistentClassFacadeTest#testGetRootTable()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
@@ -646,6 +646,18 @@ public class PersistentClassFacadeTest {
 		assertEquals("foo", persistentClassFacade.getWhere());
 	}
 	
+	@Test
+	public void testGetRootTable() throws Exception {
+		Field field = AbstractPersistentClassFacade.class.getDeclaredField("rootTable");
+		field.setAccessible(true);
+		assertNull(field.get(persistentClassFacade));
+		Table tableTarget = new Table();
+		((RootClass)persistentClassTarget).setTable(tableTarget);
+		ITable tableFacade = persistentClassFacade.getRootTable();
+		assertSame(tableTarget, ((IFacade)tableFacade).getTarget());
+		assertSame(tableFacade, field.get(persistentClassFacade));
+	}
+	
 	private KeyValue createValue() {
 		return (KeyValue)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>