### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PrimaryKeyFacadeTest#testGetColumn()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PrimaryKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PrimaryKeyFacadeTest.java
@@ -72,4 +72,17 @@ public class PrimaryKeyFacadeTest {
 		assertSame(columnTarget, ((IFacade)columnFacades.get(0)).getTarget());
 	}
 	
+	@Test
+	public void testGetColumn() throws Exception {
+		Field field = AbstractPrimaryKeyFacade.class.getDeclaredField("columns");
+		field.setAccessible(true);
+		assertNull(field.get(primaryKeyFacade));
+		Column columnTarget = new Column();
+		primaryKeyTarget.addColumn(columnTarget);
+		IColumn columnFacade = primaryKeyFacade.getColumn(0);
+		assertNotNull(field.get(primaryKeyFacade));
+		assertNotNull(columnFacade);
+		assertSame(columnTarget, ((IFacade)columnFacade).getTarget());
+	}
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>