### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PropertyFacadeTest#testGetPropetyAccessorName()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
@@ -100,6 +100,13 @@ public class PropertyFacadeTest {
 		propertyTarget.setValue(component);
 		assertTrue(propertyFacade.isComposite());
 	}
+	
+	@Test
+	public void testGetPropetyAccessorName() {
+		assertNotEquals("foo", propertyFacade.getPropertyAccessorName());
+		propertyTarget.setPropertyAccessorName("foo");
+		assertEquals("foo", propertyFacade.getPropertyAccessorName());
+	}
 
 	private Value createValue() {
 		return (Value)Proxy.newProxyInstance(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>