### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PropertyFacadeTest#ttestSetPropertyAccessorName()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
@@ -149,6 +149,13 @@ public class PropertyFacadeTest {
 		assertSame(valueFacade, field.get(propertyFacade));
 		assertSame(valueTarget, propertyTarget.getValue());
 	}
+	
+	@Test
+	public void testSetPropertyAccessorName() {
+		assertNotEquals("foo", propertyTarget.getPropertyAccessorName());
+		propertyFacade.setPropertyAccessorName("foo");
+		assertEquals("foo", propertyTarget.getPropertyAccessorName());
+	}
 
 	private Value createValue() {
 		return (Value)Proxy.newProxyInstance(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>