### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'PropertyFacadeTest#ttestIsOptimisticLocked()'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PropertyFacadeTest.java
@@ -238,6 +238,14 @@ public class PropertyFacadeTest {
 		assertFalse(propertyFacade.isNaturalIdentifier());
 	}
 	
+	@Test
+	public void testIsOptimisticLocked() {
+		propertyTarget.setOptimisticLocked(true);
+		assertTrue(propertyFacade.isOptimisticLocked());
+		propertyTarget.setOptimisticLocked(false);
+		assertFalse(propertyFacade.isOptimisticLocked());
+	}
+	
 
 	private Value createValue() {
 		return (Value)Proxy.newProxyInstance(


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>