### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initial implementation of class 'org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JpaConfigurationTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JpaConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JpaConfiguration.java
@@ -1,0 +1,25 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import java.util.Map;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.Configuration;
+
+public class JpaConfiguration extends Configuration {
+
+	Metadata metadata = null;
+	SessionFactory sessionFactory;
+	
+	String persistenceUnit;
+	
+	public JpaConfiguration(
+			String persistenceUnit, 
+			Map<Object, Object> properties) {
+		this.persistenceUnit = persistenceUnit;
+		if (properties != null) {
+			getProperties().putAll(properties);
+		}
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JpaConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/JpaConfigurationTest.java
@@ -1,0 +1,22 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class JpaConfigurationTest {
+	
+	@Test
+	public void testConstruction() {
+		Properties properties = new Properties();
+		properties.put("foo", "bar");
+		JpaConfiguration jpaConfiguration = new JpaConfiguration("barfoo", properties);
+		assertNotNull(jpaConfiguration);
+		assertEquals("barfoo", jpaConfiguration.persistenceUnit);
+		assertEquals("bar", jpaConfiguration.getProperties().get("foo"));
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>