### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'ServiceImpl#newHibernateMappingExporter(IConfiguration,File)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImpl.java
@@ -61,9 +61,13 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
-	public IHibernateMappingExporter newHibernateMappingExporter(IConfiguration hcfg, File file) {
-		// TODO Auto-generated method stub
-		return null;
+	public IHibernateMappingExporter newHibernateMappingExporter(
+			IConfiguration hcfg, File file) {
+		return facadeFactory.createHibernateMappingExporter(
+				new HibernateMappingExporterExtension(
+						facadeFactory,
+						hcfg,
+						file));
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImplTest.java
@@ -4,10 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+
 import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.api.export.ExporterConstants;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JpaConfiguration;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,4 +51,23 @@ public class ServiceImplTest {
 		assertTrue(((IFacade)defaultConfiguration).getTarget() instanceof Configuration);
 	}
 
+	@Test
+	public void testNewHibernateMappingExporter() {
+		IConfiguration configuration = service.newDefaultConfiguration();
+		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());
+		File file = new File("");
+		IHibernateMappingExporter hibernateMappingExporter = 
+				service.newHibernateMappingExporter(configuration, file);
+		HibernateMappingExporterExtension hmee = 
+				(HibernateMappingExporterExtension)((IFacade)hibernateMappingExporter).getTarget();
+		Assert.assertSame(file, hmee.getProperties().get(ExporterConstants.OUTPUT_FILE_NAME));
+		Assert.assertSame(
+				((ConfigurationFacadeImpl)configuration).getMetadata(), 
+				hmee.getMetadata());
+	}
+	
+	public static class TestDialect extends Dialect {
+		@Override public int getVersion() { return 0; }	
+	}
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>