### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'ServiceImpl#newJDBCMetaDataConfiguration()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImpl.java
@@ -33,6 +33,7 @@ import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.ITableFilter;
 import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
+import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JdbcMetadataConfiguration;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JpaConfiguration;
 import org.xml.sax.EntityResolver;
 
@@ -92,8 +93,7 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IConfiguration newJDBCMetaDataConfiguration() {
-		// TODO Auto-generated method stub
-		return null;
+		return facadeFactory.createConfiguration(new JdbcMetadataConfiguration());
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ServiceImplTest.java
@@ -15,6 +15,7 @@ import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
+import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JdbcMetadataConfiguration;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.JpaConfiguration;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,6 +83,15 @@ public class ServiceImplTest {
 		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());
 		IHQLCodeAssist hqlCodeAssist = service.newHQLCodeAssist(configuration);
 		assertNotNull(hqlCodeAssist);
+	}
+	
+	@Test
+	public void testNewJDBCMetaDataConfiguration() {
+		IConfiguration configuration = service.newJDBCMetaDataConfiguration();
+		assertNotNull(configuration);
+		Object target = ((IFacade)configuration).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof JdbcMetadataConfiguration);
 	}
 	
 	public static class TestDialect extends Dialect {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>