### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initial implementation of class 'org.jboss.tools.hibernate.runtime.v_6_0.internal.util.DummyMetadataDescriptor'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
@@ -1,0 +1,22 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+
+public class DummyMetadataDescriptor implements MetadataDescriptor {
+
+	@Override
+	public Metadata createMetadata() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Properties getProperties() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
@@ -1,0 +1,15 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import static org.junit.Assert.assertTrue;
+
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.junit.Test;
+
+public class DummyMetadataDescriptorTest {
+	
+	@Test
+	public void testConstruction() {
+		assertTrue(new DummyMetadataDescriptor() instanceof MetadataDescriptor);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>