### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'DummyMetadataDescriptorTest#testGetProperties()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
@@ -15,7 +15,6 @@ public class DummyMetadataDescriptor implements MetadataDescriptor {
 
 	@Override
 	public Properties getProperties() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
@@ -1,5 +1,6 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
@@ -10,6 +11,11 @@ public class DummyMetadataDescriptorTest {
 	@Test
 	public void testConstruction() {
 		assertTrue(new DummyMetadataDescriptor() instanceof MetadataDescriptor);
+	}
+	
+	@Test
+	public void testGetProperties() {
+		assertNull(new DummyMetadataDescriptor().getProperties());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>