### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of 'DummyMetadataDescriptorTest#testCreateMetadata()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptor.java
@@ -1,5 +1,9 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
@@ -7,15 +11,30 @@ import org.hibernate.tool.api.metadata.MetadataDescriptor;
 
 public class DummyMetadataDescriptor implements MetadataDescriptor {
 
+	private static final MetadataInvocationHandler HANDLER = new MetadataInvocationHandler();	
+	private static final Class<?>[] INTERFACES = new Class[] { Metadata.class };
+	private static final ClassLoader LOADER = Metadata.class.getClassLoader();
+
 	@Override
 	public Metadata createMetadata() {
-		// TODO Auto-generated method stub
-		return null;
+		return (Metadata)Proxy.newProxyInstance(LOADER, INTERFACES, HANDLER);
 	}
 
 	@Override
 	public Properties getProperties() {
 		return null;
+	}
+
+	private static class MetadataInvocationHandler implements InvocationHandler {
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ("getEntityBindings".equals(method.getName()) || 
+					"collectTableMappings".equals(method.getName())) {
+				return Collections.emptySet();
+			} else {
+				return null;
+			}
+		}		
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/DummyMetadataDescriptorTest.java
@@ -1,8 +1,13 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
+
+import org.hibernate.boot.Metadata;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.junit.Test;
 
@@ -16,6 +21,14 @@ public class DummyMetadataDescriptorTest {
 	@Test
 	public void testGetProperties() {
 		assertNull(new DummyMetadataDescriptor().getProperties());
+	}
+	
+	@Test
+	public void testCreateMetadata() {
+		Metadata metadata = new DummyMetadataDescriptor().createMetadata();
+		assertNotNull(metadata);
+		assertEquals(Collections.emptySet(), metadata.getEntityBindings());
+		assertEquals(Collections.emptySet(), metadata.collectTableMappings());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>