### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Implementation of helper class 'org.jboss.tools.hibernate.runtime.v_6_0.internal.util.MappingFileHelper'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MappingFileHelper.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MappingFileHelper.java
@@ -1,0 +1,24 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
+import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
+
+public class MappingFileHelper {
+
+	public static List<String> findMappingFiles(String persistenceUnitName) {
+		List<String> result = new ArrayList<String>();
+		List<ParsedPersistenceXmlDescriptor> persistenceUnits = 
+				PersistenceXmlParser.locatePersistenceUnits(new Properties());
+		for (ParsedPersistenceXmlDescriptor descriptor : persistenceUnits) {
+			if (descriptor.getName().equals(persistenceUnitName)) {
+				result.addAll(descriptor.getMappingFileNames());
+			}
+		}
+		return result;
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MappingFileHelperTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/MappingFileHelperTest.java
@@ -1,0 +1,61 @@
+package org.jboss.tools.hibernate.runtime.v_6_0.internal.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class MappingFileHelperTest {
+
+	private static final String PERSISTENCE_XML = 
+			"<persistence version='2.2'" +
+	        "  xmlns='http://xmlns.jcp.org/xml/ns/persistence'" +
+		    "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
+	        "  xsi:schemaLocation='http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd'>" +
+	        "  <persistence-unit name='foo'>" +
+	        "    <mapping-file>bar</mapping-file>" +
+	        "  </persistence-unit>" +
+			"</persistence>";
+	
+	private ClassLoader original = null;
+	
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+	
+	@Before
+	public void before() throws Exception {
+		tempFolder.create();
+		File tempRoot = tempFolder.getRoot();
+		File metaInf = new File(tempRoot, "META-INF");
+		metaInf.mkdirs();
+		File persistenceXml = new File(metaInf, "persistence.xml");
+		persistenceXml.createNewFile();
+		FileWriter fileWriter = new FileWriter(persistenceXml);
+		fileWriter.write(PERSISTENCE_XML);
+		fileWriter.close();
+		original = Thread.currentThread().getContextClassLoader();
+		ClassLoader urlCl = URLClassLoader.newInstance(
+				new URL[] { new URL(tempRoot.toURI().toURL().toString())} , 
+				original);
+		Thread.currentThread().setContextClassLoader(urlCl);
+	}
+	
+	@After
+	public void after() {
+		Thread.currentThread().setContextClassLoader(original);
+	}
+	
+	@Test
+	public void testFindMappingFiles() {
+		assertTrue(MappingFileHelper.findMappingFiles("bar").isEmpty());
+		assertTrue(MappingFileHelper.findMappingFiles("foo").contains("bar"));
+	}
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>