### PR TITLE
JBIDE-27775: Use JUnit Jupiter instead of JUnit 4 - Switch test class 'org.jboss.tools.hibernate.runtime.v_6_0.VersionTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0.test
 Bundle-Version: 5.4.12.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit
+Require-Bundle: org.junit,
+ org.junit.jupiter.api;bundle-version="5.7.1"
 Bundle-ClassPath: .,
  lib/h2-1.4.200.jar

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
@@ -1,15 +1,14 @@
 package org.jboss.tools.hibernate.runtime.v_6_0;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		Assert.assertEquals("6.0.0.Alpha2", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.0.0.Alpha2", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>