### PR TITLE
JBIDE-27823: Replace uses of 'org.jboss.tools.hibernate.runtime.spi.IType#getReturnedClass()' - Add method 'org.jboss.tools.hibernate.runtime.spi.IType#getReturnedClassName()' and default implementation in 'org.jboss.tools.hibernate.runtime.common.AbstractTypeFacade#getReturnedClassName()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractTypeFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractTypeFacade.java
@@ -108,6 +108,16 @@ implements IType {
 	}
 	
 	@Override
+	public String getReturnedClassName() {
+		Class<?> returnedClass = getReturnedClass();
+		if (returnedClass != null) {
+			return returnedClass.getName();
+		} else {
+			return null;
+		}
+	}
+	
+	@Override
 	public String getAssociatedEntityName() {
 		String result = null;
 		if (isEntityType()) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IType.java
@@ -17,5 +17,6 @@ public interface IType {
 	boolean isInstanceOfPrimitiveType();
 	Class<?> getPrimitiveClass();
 	String getRole();
+	String getReturnedClassName();
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>