### PR TITLE
JBIDE-27823: Replace uses of 'org.jboss.tools.hibernate.runtime.spi.IType#getReturnedClass()' - Remove from runtime tests

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse/src/org/hibernate/console/node/PersistentCollectionNode.java
+++ b/orm/plugin/core/org.hibernate.eclipse/src/org/hibernate/console/node/PersistentCollectionNode.java
@@ -173,11 +173,11 @@ class PersistentCollectionNode extends BaseNode implements TypedNode{
 	}
 
 	private BaseNode createNode(int idx, Object element, IType type) { // TODO: use a common way to create these darn nodes!
-		return new ClassNode(factory, this,type.getReturnedClassName(), factory.getMetaData(type.getReturnedClass() ),element,objectGraph);
+		return new ClassNode(factory, this,type.getReturnedClassName(), factory.getMetaData(type.getReturnedClassName() ),element,objectGraph);
 	}
 
 	public String renderLabel(boolean b) {
-		return getLabel(getName(),b) + " : " + getLabel(type.getReturnedClassName(),b) + "<" + getLabel(elementType.getReturnedClass().getName(),b) + ">";  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+		return getLabel(getName(),b) + " : " + getLabel(type.getReturnedClassName(),b) + "<" + getLabel(elementType.getReturnedClassName(),b) + ">";  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 	public IType getType() {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractTypeFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractTypeFacade.java
@@ -99,17 +99,12 @@ implements IType {
 	}
 
 	@Override
-	public Class<?> getReturnedClass() {
-		return (Class<?>)Util.invokeMethod(
+	public String getReturnedClassName() {
+		Class<?> returnedClass = (Class<?>)Util.invokeMethod(
 				getTarget(), 
 				"getReturnedClass", 
 				new Class[] {}, 
 				new Object[] {});
-	}
-	
-	@Override
-	public String getReturnedClassName() {
-		Class<?> returnedClass = getReturnedClass();
 		if (returnedClass != null) {
 			return returnedClass.getName();
 		} else {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IType.java
@@ -10,7 +10,6 @@ public interface IType {
 	boolean isAnyType();
 	boolean isComponentType();
 	boolean isCollectionType();
-	Class<?> getReturnedClass();
 	String getAssociatedEntityName();
 	boolean isIntegerType();
 	boolean isArrayType();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/TypeFacadeTest.java
@@ -125,10 +125,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, String.class, false);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/TypeFacadeTest.java
@@ -127,10 +127,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class, false);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/TypeFacadeTest.java
@@ -127,10 +127,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class, false);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/TypeFacadeTest.java
@@ -127,10 +127,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/TypeFacadeTest.java
@@ -139,10 +139,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/TypeFacadeTest.java
@@ -139,10 +139,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		Assert.assertEquals(Class.class, typeFacade.getReturnedClass());
+		Assert.assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		Assert.assertEquals(String[].class, typeFacade.getReturnedClass());
+		Assert.assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/TypeFacadeTest.java
@@ -144,10 +144,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		assertEquals(Class.class, typeFacade.getReturnedClass());
+		assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		assertEquals(String[].class, typeFacade.getReturnedClass());
+		assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/TypeFacadeTest.java
@@ -148,10 +148,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		assertEquals(Class.class, typeFacade.getReturnedClass());
+		assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		assertEquals(String[].class, typeFacade.getReturnedClass());
+		assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/TypeFacadeTest.java
@@ -148,10 +148,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = FACADE_FACTORY.createType(classType);
-		assertEquals(Class.class, typeFacade.getReturnedClass());
+		assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = FACADE_FACTORY.createType(arrayType);
-		assertEquals(String[].class, typeFacade.getReturnedClass());
+		assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/TypeFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/TypeFacadeTest.java
@@ -166,10 +166,10 @@ public class TypeFacadeTest {
 		IType typeFacade = null;
 		ClassType classType = new ClassType();
 		typeFacade = new AbstractTypeFacade(FACADE_FACTORY, classType){};
-		assertEquals(Class.class, typeFacade.getReturnedClass());
+		assertEquals(Class.class.getName(), typeFacade.getReturnedClassName());
 		ArrayType arrayType = new ArrayType(null, null, null, String.class);
 		typeFacade = new AbstractTypeFacade(FACADE_FACTORY, arrayType){};
-		assertEquals(String[].class, typeFacade.getReturnedClass());
+		assertEquals(String[].class.getName(), typeFacade.getReturnedClassName());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>