### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Create method 'FacadeFactoryImpl#createType(Object)' to return an instance of 'org.jboss.tools.hibernate.runtime.v_6_0.internal.TypeFacadeImpl'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryImpl.java
@@ -22,6 +22,7 @@ import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.jboss.tools.hibernate.runtime.spi.ISession;
 import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
+import org.jboss.tools.hibernate.runtime.spi.IType;
 import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 
 public class FacadeFactoryImpl  extends AbstractFacadeFactory {
@@ -127,6 +128,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	@Override
 	public IPersistentClass createSpecialRootClass(IProperty property) {
 		return new SpecialRootClassFacadeImpl(this, property);
+	}
+	
+	@Override
+	public IType createType(Object target) {
+		return new TypeFacadeImpl(this, target);
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
@@ -400,6 +400,7 @@ public class FacadeFactoryTest {
 				new Class[] { Type.class }, 
 				new TestInvocationHandler());
 		IType facade = facadeFactory.createType(type);
+		assertTrue(facade instanceof TypeFacadeImpl);
 		assertSame(type, ((IFacade)facade).getTarget());
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>