### PR TITLE
JBIDE-27839: Use the preferences mechanism to read/save the default Hibernate runtime - Prevent disabling the default runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
@@ -42,6 +42,9 @@ public class RuntimeServiceManager {
 	}
 	
 	public void enableService(String version, boolean enabled) {
+		if (version.equals(getDefaultVersion()) && !enabled) {
+			throw new RuntimeException("Disabliing the default Hibernate runtime is not allowed");
+		}
 		servicePreferences.putBoolean(version, enabled);
 		if (enabled) {
 			enabledVersions.add(version);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
@@ -136,6 +136,7 @@ public class RuntimeServiceManagerTest {
 		Field enabledVersionsField = RuntimeServiceManager.class.getDeclaredField("enabledVersions");
 		enabledVersionsField.setAccessible(true);	
 		Set<String> enabledVersions = new HashSet<String>();
+		enabledVersions.add("zanzibar");
 		enabledVersionsField.set(runtimeServiceManager, enabledVersions);
 		Preferences preferences = InstanceScope.INSTANCE.getNode(testPreferencesName);
 		Field preferencesField = RuntimeServiceManager.class.getDeclaredField("servicePreferences");
@@ -149,6 +150,14 @@ public class RuntimeServiceManagerTest {
 		runtimeServiceManager.enableService("foobar", false);
 		Assert.assertFalse(preferences.getBoolean("foobar", false));
 		Assert.assertFalse(enabledVersions.contains("foobar"));
+		try {
+			runtimeServiceManager.enableService("zanzibar", false);
+			Assert.fail();
+		} catch (Exception e) {
+			Assert.assertEquals(
+					"Disabliing the default Hibernate runtime is not allowed", 
+					e.getMessage());
+		}
 	}
 	
 	private IService createService() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>