### PR TITLE
JBIDE-27839: Use the preferences mechanism to read/save the default Hibernate runtime - Implement 'RuntimeServiceManager#setDefaultVersion(String)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
@@ -79,6 +79,18 @@ public class RuntimeServiceManager {
 		return enabled[enabled.length - 1];
 	}
 	
+	public void setDefaultVersion(String version) {
+		if (!enabledVersions.contains(version)) {
+			throw new RuntimeException("Setting a disabled Hibernate runtime as the default is not allowed");
+		}
+		servicePreferences.put("default", version);
+		try {
+			servicePreferences.flush();
+		} catch (BackingStoreException bse) {
+			throw new RuntimeException(bse);
+		}
+	}
+	
 	public boolean isServiceEnabled(String version) {
 		return enabledVersions.contains(version);
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
@@ -80,6 +80,35 @@ public class RuntimeServiceManagerTest {
 	}
 	
 	@Test
+	public void testSetDefaultVersion() throws Exception {
+		Preferences preferences = InstanceScope.INSTANCE.getNode(testPreferencesName);
+		Field preferencesField = RuntimeServiceManager.class.getDeclaredField("servicePreferences");
+		preferencesField.setAccessible(true);
+		preferencesField.set(runtimeServiceManager, preferences);
+		Field enabledVersionsField = RuntimeServiceManager.class.getDeclaredField("enabledVersions");
+		enabledVersionsField.setAccessible(true);
+		enabledVersionsField.set(
+				runtimeServiceManager, 
+				new HashSet<String> (Arrays.asList("foo", "bar")));
+		Assert.assertNull(preferences.get("default", null));
+		// first: trying to set a disabled runtime as the default should fail
+		try {
+			runtimeServiceManager.setDefaultVersion("baz");
+			Assert.fail();
+		} catch (Exception e) {
+			Assert.assertEquals(
+					"Setting a disabled Hibernate runtime as the default is not allowed", 
+					e.getMessage());
+		}
+		// second: choosing an enabled runtime
+		Assert.assertNull(preferences.get("default", null));
+		runtimeServiceManager.setDefaultVersion("foo");
+		Assert.assertEquals("foo", preferences.get("default", null));
+		runtimeServiceManager.setDefaultVersion("bar");
+		Assert.assertEquals("bar", preferences.get("default", null));
+	}
+	
+	@Test
 	public void testGetDefaultVersion() throws Exception {
 		Preferences preferences = InstanceScope.INSTANCE.getNode(testPreferencesName);
 		Field preferencesField = RuntimeServiceManager.class.getDeclaredField("servicePreferences");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>