### PR TITLE
JBIDE-27839: Use the preferences mechanism to read/save the default Hibernate runtime - Expose enabled runtimes through convenience method 'RuntimeServiceManager#getEnabledVersions()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
@@ -66,6 +66,12 @@ public class RuntimeServiceManager {
 		return Arrays.copyOf(allVersions, allVersions.length);
 	}
 	
+	public String[] getEnabledVersions() {
+		String[] enabled = enabledVersions.toArray(new String[enabledVersions.size()]);
+		Arrays.sort(enabled);
+		return enabled;
+	}
+	
 	public IService getDefaultService() {
 		return findService(getDefaultVersion());
 	}
@@ -74,8 +80,7 @@ public class RuntimeServiceManager {
 		String defaultVersion = servicePreferences.get("default", null);
 		if (defaultVersion != null) return defaultVersion;
 		if (enabledVersions.isEmpty()) throw new RuntimeException("No Hibernate runtimes are enabled.");
-		String[] enabled = enabledVersions.toArray(new String[enabledVersions.size()]);
-		Arrays.sort(enabled);
+		String[] enabled = getEnabledVersions();
 		return enabled[enabled.length - 1];
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
@@ -80,6 +80,16 @@ public class RuntimeServiceManagerTest {
 	}
 	
 	@Test
+	public void testGetEnabledVersions() throws Exception {
+		Field enabledVersionsField = RuntimeServiceManager.class.getDeclaredField("enabledVersions");
+		enabledVersionsField.setAccessible(true);
+		enabledVersionsField.set(
+				runtimeServiceManager, 
+				new HashSet<String> (Arrays.asList("foo", "bar")));
+		Assert.assertArrayEquals(new String[] {"bar", "foo" }, runtimeServiceManager.getEnabledVersions());
+	}
+	
+	@Test
 	public void testSetDefaultVersion() throws Exception {
 		Preferences preferences = InstanceScope.INSTANCE.getNode(testPreferencesName);
 		Field preferencesField = RuntimeServiceManager.class.getDeclaredField("servicePreferences");


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>