### PR TITLE
Create a preference page to enable/disable contributed Hibernate runtime implementations - Remove method 'RuntimeServiceManager#restoreDefaults() and expose the initially enabled runtimes'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManager.java
@@ -73,6 +73,10 @@ public class RuntimeServiceManager {
 		return enabled;
 	}
 	
+	public Set<String> getInitiallyEnabledVersions() {
+		return new HashSet<String>(initiallyEnabledVersions);
+	}
+	
 	public IService getDefaultService() {
 		return findService(getDefaultVersion());
 	}
@@ -99,19 +103,6 @@ public class RuntimeServiceManager {
 	
 	public boolean isServiceEnabled(String version) {
 		return enabledVersions.contains(version);
-	}
-	
-	public void restoreDefaults() {
-		try {
-			for (String key : servicePreferences.keys()) {
-				servicePreferences.remove(key);
-			}
-			servicePreferences.flush();
-			enabledVersions.clear();
-			enabledVersions.addAll(initiallyEnabledVersions);
-		} catch (BackingStoreException e) {
-			throw new RuntimeException(e);
-		}
 	}
 	
 	private void initializePreferences() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/src/org/jboss/tools/hibernate/runtime/spi/RuntimeServiceManagerTest.java
@@ -206,50 +206,6 @@ public class RuntimeServiceManagerTest {
 		}
 	}
 	
-	@Test
-	public void testRestoreDefaults() throws Exception {
-		Field servicesMapField = RuntimeServiceManager.class.getDeclaredField("servicesMap");
-		servicesMapField.setAccessible(true);
-		Map<String, IService> servicesMap = new HashMap<String, IService>();
-		servicesMap.put("foo", createService());
-		servicesMap.put("bar", createService());
-		servicesMap.put("baz", createService());
-		servicesMap.put("zanzibar", createService());
-		servicesMapField.set(runtimeServiceManager, servicesMap);
-		Preferences preferences = InstanceScope.INSTANCE.getNode(testPreferencesName + ".testRestoreDefaults");
-		preferences.putBoolean("foo", true);
-		preferences.putBoolean("bar", false);
-		preferences.putBoolean("baz", true);
-		preferences.putBoolean("zanzibar", true);
-		preferences.put("default", "zanzibar");
-		Field preferencesField = RuntimeServiceManager.class.getDeclaredField("servicePreferences");
-		preferencesField.setAccessible(true);
-		preferencesField.set(runtimeServiceManager, preferences);
-		Field initiallyEnabledVersionsField = 
-				RuntimeServiceManager.class.getDeclaredField("initiallyEnabledVersions");
-		initiallyEnabledVersionsField.setAccessible(true);
-		initiallyEnabledVersionsField.set(
-				runtimeServiceManager, 
-				new HashSet<String>(Arrays.asList("bar", "baz", "foo" )));
-		Field enabledVersionsField = RuntimeServiceManager.class.getDeclaredField("enabledVersions");
-		enabledVersionsField.setAccessible(true);
-		enabledVersionsField.set(
-				runtimeServiceManager, 
-				new HashSet<String>(Arrays.asList("foo", "baz", "zanzibar")));
-		Assert.assertEquals("zanzibar", runtimeServiceManager.getDefaultVersion());
-		Assert.assertFalse(runtimeServiceManager.isServiceEnabled("bar"));
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("baz"));
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("foo"));
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("zanzibar"));
-		runtimeServiceManager.restoreDefaults();
-		Assert.assertEquals("foo", runtimeServiceManager.getDefaultVersion());
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("bar"));
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("baz"));
-		Assert.assertTrue(runtimeServiceManager.isServiceEnabled("foo"));
-		Assert.assertFalse(runtimeServiceManager.isServiceEnabled("zanzibar"));
-		Assert.assertEquals(0, preferences.keys().length);
-	}
-	
 	private IService createService() {
 		return (IService)Proxy.newProxyInstance(
 				getClass().getClassLoader(), 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>