### PR TITLE
JBIDE-27841: Disable runtimes 3.5, 4.0, 5.0, 5.1, 5.2 and 5.3 by default - they can be reenabled through the Hibernate preferences page

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/schema/services.exsd
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/schema/services.exsd
@@ -66,6 +66,13 @@
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="disabled" type="boolean" use="default" value="false">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_3_5.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_4_0.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_5_0.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_5_1.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_5_2.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_5_3.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>