### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Initially disable the 6.0 runtime (it can be enabled trough the Hibernate preferences page)

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/plugin.xml
@@ -5,6 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_6_0.internal.ServiceImpl"
+            disabled="true"
             name="%hibernate.version">
       </service>
    </extension>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>