### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Add dependencies on Hibernate 5.5.0.Alpha1 and implement 'org.jboss.tools.hibernate.runtime.v_5_5.VersionTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -1,8 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.5 libraries
+Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.5
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5;singleton:=true
-Bundle-Version: 5.4.9.qualifier
-Bundle-Localization: plugin
+Bundle-Version: 5.4.13.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ lib/hibernate-core-5.5.0.Alpha1.jar,
+ lib/hibernate-tools-5.5.0.Alpha1.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = .,\
+               META-INF/,\
+               lib/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -4,11 +4,59 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.9-SNAPSHOT</version>
+		<version>5.4.13-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_5</artifactId> 
 	
 	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<hibernate.version>5.5.0.Alpha1</hibernate.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>get-libs</id>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<phase>generate-resources</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.hibernate</groupId>
+							<artifactId>hibernate-core</artifactId>
+							<version>${hibernate.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.hibernate</groupId>
+							<artifactId>hibernate-tools</artifactId>
+							<version>${hibernate.version}</version>
+						</artifactItem>
+					</artifactItems>
+					<skip>false</skip>
+					<outputDirectory>${basedir}/lib</outputDirectory>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/lib</directory>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/orm/plugin/runtime/pom.xml
+++ b/orm/plugin/runtime/pom.xml
@@ -24,6 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.jboss.tools.hibernate.runtime.v_5_2</module>
 		<module>org.jboss.tools.hibernate.runtime.v_5_3</module>
 		<module>org.jboss.tools.hibernate.runtime.v_5_4</module>
+		<module>org.jboss.tools.hibernate.runtime.v_5_5</module>
 		<module>org.jboss.tools.hibernate.runtime.v_6_0</module>
 	</modules>
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
@@ -1,9 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.5 Tests
+Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.5.test
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5.test
-Bundle-Version: 5.4.9.qualifier
+Bundle-Version: 5.4.13.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_5
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit
+Require-Bundle: org.junit.jupiter.api
 Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/build.properties
@@ -2,3 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .
+                             

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.9-SNAPSHOT</version>
+		<version>5.4.13-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_5.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/VersionTest.java
@@ -1,14 +1,20 @@
 package org.jboss.tools.hibernate.runtime.v_5_5;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VersionTest {
 	
 	@Test
-	public void dummy() {
-		assertTrue(true);
+	public void testToolsVersion() {
+		assertEquals("5.5.0.Alpha1", org.hibernate.tool.Version.VERSION);
 	}
+
+	@Test
+	public void testCoreVersion() {
+		assertEquals("5.5.0.Alpha1", org.hibernate.Version.getVersionString());
+	}
+
 
 }

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -25,6 +25,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	    <module>org.jboss.tools.hibernate.runtime.v_5_2.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_5_3.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_5_4.test</module>
+	    <module>org.jboss.tools.hibernate.runtime.v_5_5.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_0.test</module>
 	</modules>
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>