### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Implement 'org.jboss.tools.hibernate.runtime.v_5_5.internal.util.MetadataHelperTest' and 'org.jboss.tools.hibernate.runtime.v_5_5.internal.util.MetadataHelper' and add necessary dependencies

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -6,5 +6,15 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5;singleton:=true
 Bundle-Version: 5.4.13.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
+ lib/byte-buddy-1.10.14.jar,
+ lib/classmate-1.3.4.jar,
+ lib/istack-commons-runtime-3.0.11.jar,
+ lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.5.0.Alpha1.jar,
- lib/hibernate-tools-5.5.0.Alpha1.jar
+ lib/hibernate-tools-5.5.0.Alpha1.jar,
+ lib/javax.persistence-api-2.2.jar,
+ lib/jaxb-api-2.3.1.jar,
+ lib/jaxb-runtime-2.3.1.jar,
+ lib/jboss-logging-3.4.1.Final.jar,
+ lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
+Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -12,7 +12,15 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
+		<classmate.version>1.3.4</classmate.version>
 		<hibernate.version>5.5.0.Alpha1</hibernate.version>
+		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
+		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
+		<javax.persistence-api.version>2.2</javax.persistence-api.version>
+	    <jaxb.version>2.3.1</jaxb.version>
+		<jboss-logging.version>3.4.1.Final</jboss-logging.version>
+		<jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
+		<bytebuddy.version>1.10.14</bytebuddy.version>
 	</properties>
 
 	<build>
@@ -32,6 +40,36 @@
 				<configuration>
 					<artifactItems>
 						<artifactItem>
+							<groupId>com.fasterxml</groupId>
+							<artifactId>classmate</artifactId>
+							<version>${classmate.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>com.sun.istack</groupId>
+							<artifactId>istack-commons-runtime</artifactId>
+							<version>${istack-commons-runtime.version}</version>
+						</artifactItem> 
+						<artifactItem>
+							<groupId>javax.persistence</groupId>
+							<artifactId>javax.persistence-api</artifactId>
+							<version>${javax.persistence-api.version}</version>
+						</artifactItem>
+ 						<artifactItem>
+							<groupId>javax.xml.bind</groupId>
+							<artifactId>jaxb-api</artifactId>
+							<version>${jaxb.version}</version>
+						</artifactItem> 
+						<artifactItem>
+							<groupId>net.bytebuddy</groupId>
+							<artifactId>byte-buddy</artifactId>
+							<version>${bytebuddy.version}</version>
+						</artifactItem>
+ 						<artifactItem>
+							<groupId>org.glassfish.jaxb</groupId>
+							<artifactId>jaxb-runtime</artifactId>
+							<version>${jaxb.version}</version>
+						</artifactItem> 
+						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>
 							<version>${hibernate.version}</version>
@@ -40,6 +78,21 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-tools</artifactId>
 							<version>${hibernate.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.hibernate.common</groupId>
+							<artifactId>hibernate-commons-annotations</artifactId>
+							<version>${hibernate-commons-annotations.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.jboss.logging</groupId>
+							<artifactId>jboss-logging</artifactId>
+							<version>${jboss-logging.version}</version>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.jboss.spec.javax.transaction</groupId>
+							<artifactId>jboss-transaction-api_1.2_spec</artifactId>
+							<version>${jboss-transaction-api_1.2_spec.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/MetadataHelper.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/MetadataHelper.java
@@ -1,0 +1,113 @@
+package org.jboss.tools.hibernate.runtime.v_5_5.internal.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+
+public class MetadataHelper {
+	
+	public static Metadata getMetadata(Configuration configuration) {
+		Metadata result = getMetadataFromMethod(configuration);
+		if (result == null) {
+			result = getMetadataFromField(configuration);
+		}
+		if (result == null) {
+			result = buildFromMetadataSources(configuration);
+		}
+		return result;
+	}
+	
+	public static MetadataSources getMetadataSources(Configuration configuration) {
+		MetadataSources result = null;
+		Field metadataSourcesField = getField("metadataSources", configuration);
+		if (metadataSourcesField != null) {
+			try {
+				metadataSourcesField.setAccessible(true);
+				result = 
+						(MetadataSources)metadataSourcesField.get(configuration);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		if (result == null) {
+			result = new MetadataSources();
+		}
+		return result;
+	}
+	
+	private static Metadata getMetadataFromMethod(Configuration configuration) {
+		Metadata result = null;
+		Method metadataMethod = getMethod("getMetadata", configuration);
+		if (metadataMethod != null) {
+			try {
+				metadataMethod.setAccessible(true);
+				result = (Metadata)metadataMethod.invoke(
+						configuration, 
+						new Object[] {});
+			} catch (InvocationTargetException | 
+					IllegalAccessException | 
+					IllegalArgumentException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Method getMethod(String methodName, Object target) {
+		Method result = null;
+		Class<?> clazz = target.getClass();
+		try {
+			result = clazz.getMethod(methodName, new Class[] {});
+		} catch (NoSuchMethodException | SecurityException e1) {
+			// ignore;
+		}
+		return result;
+	}
+
+	private static Metadata getMetadataFromField(Configuration configuration) {
+		Metadata result = null;
+		Field metadataField = getField("metadata", configuration);
+		if (metadataField != null) {
+			try {
+				metadataField.setAccessible(true);
+				result = (Metadata)metadataField.get(configuration);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Field getField(String fieldName, Object target) {
+		Field result = null;
+		Class<?> clazz = target.getClass();
+		while (clazz != null) {
+			try {
+				result = clazz.getDeclaredField(fieldName);
+				// if it exists, exit the while loop
+				break;
+			} catch (NoSuchFieldException e) {
+				// if it doesn't exist, look in the superclass
+				clazz = clazz.getSuperclass();
+			} catch (SecurityException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Metadata buildFromMetadataSources(Configuration configuration) {
+		MetadataSources metadataSources = getMetadataSources(configuration);
+		StandardServiceRegistryBuilder builder = configuration.getStandardServiceRegistryBuilder();
+		builder.applySettings(configuration.getProperties());
+		StandardServiceRegistry serviceRegistry = builder.build();
+		return metadataSources.buildMetadata(serviceRegistry);
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/MetadataHelperTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/MetadataHelperTest.java
@@ -1,0 +1,101 @@
+package org.jboss.tools.hibernate.runtime.v_5_5.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Dialect;
+import org.junit.jupiter.api.Test;
+
+public class MetadataHelperTest {
+	
+	@Test
+	public void testGetMetadataSources() {
+		MetadataSources mds1 = new MetadataSources();
+		Configuration configuration = new Configuration();
+		MetadataSources mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertNotSame(mds1, mds2);
+		configuration = new Configuration(mds1);
+		mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertSame(mds1, mds2);
+	}
+	
+	@Test
+	public void testGetMetadata() {
+		 Configuration methodConfiguration = new MetadataMethodConfiguration();
+	     assertSame(
+	    		 MetadataMethodConfiguration.METADATA, 
+	    		 MetadataHelper.getMetadata(methodConfiguration));
+	     Configuration fieldConfiguration = new MetadataFieldConfiguration();
+	     assertSame(
+	    		 MetadataFieldConfiguration.METADATA, 
+	    		 MetadataHelper.getMetadata(fieldConfiguration));
+	     MetadataSources metadataSources = new MetadataSources();
+	     metadataSources.addInputStream(new ByteArrayInputStream(TEST_HBM_XML_STRING.getBytes()));
+	     Configuration configuration = new Configuration(metadataSources);
+	     configuration.setProperty(
+	    		 "hibernate.dialect", 
+	    		 TestDialect.class.getName());
+	     Metadata metadata = MetadataHelper.getMetadata(configuration);
+	     assertNotNull(metadata.getEntityBinding("org.jboss.tools.hibernate.runtime.v_5_5.internal.util.MetadataHelperTest$Foo"));
+	}
+	
+	private static class MetadataMethodConfiguration extends Configuration {
+		static Metadata METADATA = createMetadata();
+		@SuppressWarnings("unused")
+		public Metadata getMetadata() {
+			return METADATA;
+		}
+	}
+	
+	private static class MetadataFieldConfiguration extends Configuration {
+		static Metadata METADATA = createMetadata();
+		@SuppressWarnings("unused")
+		private Metadata metadata = METADATA;
+	}
+	
+	private static Metadata createMetadata() {
+		Metadata result = null;
+		result = (Metadata) Proxy.newProxyInstance(
+				MetadataHelperTest.class.getClassLoader(), 
+				new Class[] { Metadata.class },  
+				new InvocationHandler() {				
+					@Override
+					public Object invoke(
+							Object proxy, 
+							Method method, 
+							Object[] args) throws Throwable {
+						return null;
+					}
+				});
+		return result;
+	}
+	
+	public static class TestDialect extends Dialect {}
+	
+	@SuppressWarnings("unused")
+	private static class Foo {
+		public String id;
+	}
+	
+	private static final String TEST_HBM_XML_STRING =
+			"<!DOCTYPE hibernate-mapping PUBLIC" +
+			"		'-//Hibernate/Hibernate Mapping DTD 3.0//EN'" +
+			"		'http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd'>" +
+			"<hibernate-mapping package='org.jboss.tools.hibernate.runtime.v_5_5.internal.util'>" +
+			"  <class name='MetadataHelperTest$Foo'>" + 
+			"    <id name='id'/>" +
+			"  </class>" +
+			"</hibernate-mapping>";
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>