### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Adapt test 'org.jboss.tools.hibernate.runtime.v_5_5.internal.FacadeFactoryTest#testCreateClassMetadata()': Created facade should be instance of 'org.jboss.tools.hibernate.runtime.v_5_5.internal.ClassMetadataFacadeImpl'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.tools.hibernate.runtime.v_5_5.internal;
 
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
@@ -35,6 +36,11 @@ public class FacadeFactoryImpl extends AbstractFacadeFactory {
 	@Override
 	public IExporter createExporter(Object target) {
 		return new ExporterFacadeImpl(this, target);
+	}
+	
+	@Override
+	public IClassMetadata createClassMetadata(Object target) {
+		return new ClassMetadataFacadeImpl(this, target);
 	}
 	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryTest.java
@@ -228,6 +228,7 @@ public class FacadeFactoryTest {
 				new Class[] { ClassMetadata.class }, 
 				new TestInvocationHandler());
 		IClassMetadata facade = facadeFactory.createClassMetadata(classMetadata);
+		assertTrue(facade instanceof ClassMetadataFacadeImpl);
 		assertSame(classMetadata, ((IFacade)facade).getTarget());		
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>