### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Adapt test 'org.jboss.tools.hibernate.runtime.v_6_0.internal.FacadeFactoryTest#testCreateEntityMetamodel()': Created facade should be instance of 'org.jboss.tools.hibernate.runtime.v_6_0.internal.EntityMetamodelFacadeImpl'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/FacadeFactoryTest.java
@@ -253,6 +253,7 @@ public class FacadeFactoryTest {
 				new Class[] { EntityPersister.class }, 
 				new TestInvocationHandler());
 		IEntityMetamodel entityMetamodel = facadeFactory.createEntityMetamodel(entityPersister);
+		assertTrue(entityMetamodel instanceof EntityMetamodelFacadeImpl);
 		assertSame(entityPersister, ((IFacade)entityMetamodel).getTarget());
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>