### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Adapt test 'org.jboss.tools.hibernate.runtime.v_5_5.internal.FacadeFactoryTest#testCreateHbm2DDLExporter()' and implementation of 'org.jboss.tools.hibernate.runtime.v_5_5.internal.FacadeFactoryImpl#createHbm2DDLExporter(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryImpl.java
@@ -8,6 +8,7 @@ import org.jboss.tools.hibernate.runtime.spi.ICriteria;
 import org.jboss.tools.hibernate.runtime.spi.IEntityMetamodel;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
@@ -48,6 +49,11 @@ public class FacadeFactoryImpl extends AbstractFacadeFactory {
 	@Override
 	public IExporter createExporter(Object target) {
 		return new ExporterFacadeImpl(this, target);
+	}
+	
+	@Override
+	public IHbm2DDLExporter createHbm2DDLExporter(Object target) {
+		return new Hbm2DDLExporterFacadeImpl(this, target);
 	}
 	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/FacadeFactoryTest.java
@@ -193,6 +193,7 @@ public class FacadeFactoryTest {
 	public void testCreateHbm2DDLExporter() {
 		Hbm2DDLExporter hbm2ddlExporter = new Hbm2DDLExporter();
 		IHbm2DDLExporter facade = facadeFactory.createHbm2DDLExporter(hbm2ddlExporter);
+		assertTrue(facade instanceof Hbm2DDLExporterFacadeImpl);
 		assertSame(hbm2ddlExporter, ((IFacade)facade).getTarget());		
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>