### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Implementation of test class 'org.jboss.tools.hibernate.runtime.v_5_5.internal.PojoClassFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/PojoClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/PojoClassFacadeTest.java
@@ -1,0 +1,52 @@
+package org.jboss.tools.hibernate.runtime.v_5_5.internal;
+
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.AbstractPOJOClassFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PojoClassFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private static final String QUALIFIED_DECLARATION_NAME = new String("foobar");
+	
+	private IPOJOClass pojoClassFacade = null; 
+	private POJOClass pojoClassTarget = null;
+	
+	@BeforeEach
+	public void beforeEach() {
+		pojoClassTarget = createPojoClass();
+		pojoClassFacade = new AbstractPOJOClassFacade(FACADE_FACTORY, pojoClassTarget) {};
+	}
+	
+	@Test
+	public void testGetQualifiedDeclarationName() {
+		assertSame(QUALIFIED_DECLARATION_NAME, pojoClassFacade.getQualifiedDeclarationName());
+	}
+	
+	private POJOClass createPojoClass() {
+		return (POJOClass)Proxy.newProxyInstance(
+				getClass().getClassLoader(), 
+				new Class[] { POJOClass.class }, 
+				new InvocationHandler() {		
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						if ("getQualifiedDeclarationName".equals(method.getName())) {
+							return QUALIFIED_DECLARATION_NAME;
+						}
+						return null;
+					}
+				});
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>