### PR TITLE
JBIDE-27854: Fix typo in class 'org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade#setFilename(String)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractQueryExporterFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractQueryExporterFacade.java
@@ -27,7 +27,7 @@ implements IQueryExporter {
 	public void setFilename(String filename) {
 		Util.invokeMethod(
 				getTarget(), 
-				"setFileName", 
+				"setFilename", 
 				new Class[] { String.class }, 
 				new Object[] { filename });
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_3_5.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_3_6.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_4_0.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_4_3.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_5_0.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_5_1.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@Before
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_5_2.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@BeforeEach
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_5_3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@BeforeEach
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,51 @@
+package org.jboss.tools.hibernate.runtime.v_5_4.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.hbm2x.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@BeforeEach
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new AbstractQueryExporterFacade(FACADE_FACTORY, queryExporterTarget) {};
+	}
+	
+	@Test
+	public void testSetQueries() throws Exception {
+		Field queryStringsField = QueryExporter.class.getDeclaredField("queryStrings");
+		queryStringsField.setAccessible(true);
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryStringsField.get(queryExporterTarget));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryStringsField.get(queryExporterTarget));
+	}
+	
+	@Test
+	public void testSetFileName() throws Exception {
+		Field fileNameField = QueryExporter.class.getDeclaredField("filename");
+		fileNameField.setAccessible(true);
+		assertNotEquals("foo", fileNameField.get(queryExporterTarget));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", fileNameField.get(queryExporterTarget));
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>