### PR TITLE
JBIDE-27351: Set up a runtime plugin for the upcoming Hibernate 5.5.x releases - Remove unneeded dependency on the dom4j library

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -22,7 +22,6 @@ Bundle-ClassPath: .,
  lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
- org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.4.13",
- org.jboss.tools.hibernate.libs.freemarker.v_2_3_23;bundle-version="5.4.12",
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>