### PR TITLE
JBIDE-27907: Switch Hibernate core dependency of test plugin 'org.jboss.tools.hibernate.orm.test' from 5.4 to 5.5

### DIFF
--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -36,9 +36,9 @@ Require-Bundle: org.hibernate.eclipse,
  org.jboss.tools.hibernate.ui,
  org.eclipse.ui.workbench,
  org.hibernate.eclipse.mapper,
- org.jboss.tools.hibernate.runtime.v_5_4,
  org.eclipse.gef,
- org.hibernate.eclipse.jdt.ui
+ org.hibernate.eclipse.jdt.ui,
+ org.jboss.tools.hibernate.runtime.v_5_5
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>