### PR TITLE
JBIDE-27958: Review and Enable Disabled Tests after Updating to ORM 60.0-Alpha8 and Tools 6.0.0.Alpha4 - Reenable ConfigurationMetadataDescriptorTest#testCreateMetadata()

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/ConfigurationMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/util/ConfigurationMetadataDescriptorTest.java
@@ -63,7 +63,6 @@ public class ConfigurationMetadataDescriptorTest {
 		assertSame(properties, configurationMetadataDescriptor.getProperties());
 	}
 	
-	@Disabled //TODO: JBIDE-27958
 	@Test
 	public void testCreateMetadata() {
 		MetadataSources metadataSources = new MetadataSources();
@@ -71,7 +70,7 @@ public class ConfigurationMetadataDescriptorTest {
 		Configuration configuration = new Configuration(metadataSources);
 		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());
 		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
-		PersistentClass persistentClass = new RootClass(null);
+		PersistentClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
 		persistentClass.setEntityName("Bar");
 		IPersistentClass persistentClassFacade = 
 				FACADE_FACTORY.createPersistentClass(persistentClass);	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>