### PR TITLE
JBIDE-27958: Review and Enable Disabled Tests after Updating to ORM 60.0-Alpha8 and Tools 6.0.0.Alpha4 - Reenable ConfigurationFacadeTest#testBuildSessionFactory()

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ConfigurationFacadeTest.java
@@ -265,7 +265,6 @@ public class ConfigurationFacadeTest {
 	}
 
 	
-	@Disabled //TODO: JBIDE-27958
 	@Test
 	public void testBuildSessionFactory() throws Throwable {
 		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>