### PR TITLE
JBIDE-27971: The org.eclipse.core.commands.util package is planned to be removed. - Refactor 'org.jboss.tools.hibernate.jpt.ui.internal.mappings.db.xpl.DatabaseObjectCombo'

### DIFF
--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/src/org/jboss/tools/hibernate/jpt/ui/internal/mappings/db/xpl/DatabaseObjectCombo.java
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/src/org/jboss/tools/hibernate/jpt/ui/internal/mappings/db/xpl/DatabaseObjectCombo.java
@@ -11,7 +11,7 @@
  ******************************************************************************/
 package org.jboss.tools.hibernate.jpt.ui.internal.mappings.db.xpl;
 
-import org.eclipse.core.commands.util.Tracing;
+import org.eclipse.core.commands.internal.util.Tracing;
 import org.eclipse.jpt.common.ui.internal.swt.listeners.SWTListenerTools;
 import org.eclipse.jpt.common.ui.internal.widgets.ComboPane;
 import org.eclipse.jpt.common.ui.internal.widgets.Pane;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>