### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.HibernateToolsPersistenceProviderTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.HibernateToolsPersistenceProvider'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.jaxb.v_2_3,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
- org.jboss.tools.hibernate.libs.classmate.v_1_5
+ org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.jandex.v_2_4

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/HibernateToolsPersistenceProvider.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/HibernateToolsPersistenceProvider.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import java.util.Map;
+
+import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
+
+public class HibernateToolsPersistenceProvider extends HibernatePersistenceProvider {
+
+	static EntityManagerFactoryBuilderImpl createEntityManagerFactoryBuilder(
+			final String persistenceUnit, 
+			final Map<Object, Object> properties) {
+		return new HibernateToolsPersistenceProvider()
+				.getEntityManagerFactoryBuilder(
+						persistenceUnit, 
+						properties);
+	}	
+
+	private EntityManagerFactoryBuilderImpl getEntityManagerFactoryBuilder(
+			String persistenceUnit, 
+			Map<Object, Object> properties) {
+		return (EntityManagerFactoryBuilderImpl)getEntityManagerFactoryBuilderOrNull(
+				persistenceUnit, 
+				properties);
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/HibernateToolsPersistenceProviderTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/HibernateToolsPersistenceProviderTest.java
@@ -1,0 +1,69 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Properties;
+
+import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class HibernateToolsPersistenceProviderTest {
+	
+	private static final String PERSISTENCE_XML = 
+			"<persistence version='2.2'" +
+	        "  xmlns='http://xmlns.jcp.org/xml/ns/persistence'" +
+		    "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
+	        "  xsi:schemaLocation='http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd'>" +
+	        "  <persistence-unit name='foobar'/>" +
+			"</persistence>";
+	
+	private ClassLoader original = null;
+	
+	@TempDir
+	public File tempRoot = new File("temproot");
+	
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		File metaInf = new File(tempRoot, "META-INF");
+		metaInf.mkdirs();
+		File persistenceXml = new File(metaInf, "persistence.xml");
+		persistenceXml.createNewFile();
+		FileWriter fileWriter = new FileWriter(persistenceXml);
+		fileWriter.write(PERSISTENCE_XML);
+		fileWriter.close();
+		original = Thread.currentThread().getContextClassLoader();
+		ClassLoader urlCl = URLClassLoader.newInstance(
+				new URL[] { new URL(tempRoot.toURI().toURL().toString())} , 
+				original);
+		Thread.currentThread().setContextClassLoader(urlCl);
+	}
+	
+	@AfterEach
+	public void afterEach() {
+		Thread.currentThread().setContextClassLoader(original);
+	}
+	
+	@Test
+	public void testCreateEntityManagerFactoryBuilder() {
+		Properties properties = new Properties();
+		properties.put("foo", "bar");
+		assertNull(
+				HibernateToolsPersistenceProvider.createEntityManagerFactoryBuilder(
+						"barfoo", properties));
+		EntityManagerFactoryBuilderImpl entityManagerFactoryBuilder = 
+				HibernateToolsPersistenceProvider.createEntityManagerFactoryBuilder(
+						"foobar", properties);
+		assertNotNull(entityManagerFactoryBuilder);
+		assertEquals("bar", entityManagerFactoryBuilder.getConfigurationValues().get("foo"));
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>