### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.JdbcMetadataConfigurationTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.JdbcMetadataConfiguration'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/JdbcMetadataConfiguration.java
@@ -1,0 +1,62 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+
+public class JdbcMetadataConfiguration {
+
+	private Properties properties = new Properties();
+	private ReverseEngineeringStrategy revengStrategy = null;
+	private boolean preferBasicCompositeIds = true;
+	private Metadata metadata = null;
+
+	public Object getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Properties properties) {
+		this.properties = properties;
+	}
+
+	public Object getProperty(String key) {
+		return properties.get(key);
+	}
+
+	public void setProperty(String key, String value) {
+		properties.put(key, value);
+	}
+
+	public void addProperties(Properties properties) {
+		this.properties.putAll(properties);
+	}
+
+	public Object getReverseEngineeringStrategy() {
+		return revengStrategy;
+	}
+
+	public void setReverseEngineeringStrategy(ReverseEngineeringStrategy strategy) {
+		this.revengStrategy = strategy;
+	}
+
+	public boolean preferBasicCompositeIds() {
+		return preferBasicCompositeIds;
+	}
+
+	public void setPreferBasicCompositeIds(boolean b) {
+		preferBasicCompositeIds = b;
+	}
+
+	public Metadata getMetadata() {
+		return metadata;
+	}
+
+	public void readFromJDBC() {
+		metadata = MetadataDescriptorFactory
+				.createJdbcDescriptor(revengStrategy, properties, preferBasicCompositeIds)
+				.createMetadata();
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/META-INF/MANIFEST.MF
@@ -6,5 +6,6 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_6.test
 Bundle-Version: 5.4.14.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_6
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit.jupiter.api
+Require-Bundle: org.junit.jupiter.api,
+ org.jboss.tools.hibernate.libs.h2.v_1_4
 Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/JdbcMetadataConfigurationTest.java
@@ -1,0 +1,166 @@
+ package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+
+import org.h2.Driver;
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
+import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JdbcMetadataConfigurationTest {
+
+	private JdbcMetadataConfiguration jdbcMetadataConfiguration = null;
+	
+	@BeforeEach
+	public void beforeEach() {
+		jdbcMetadataConfiguration = new JdbcMetadataConfiguration();
+	}
+	
+	@Test
+	public void testGetProperties() throws Exception {
+		Properties properties = new Properties();
+		Field propertiesField = JdbcMetadataConfiguration.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);	
+		assertNotNull(jdbcMetadataConfiguration.getProperties());
+		assertNotSame(properties,  jdbcMetadataConfiguration.getProperties());
+		propertiesField.set(jdbcMetadataConfiguration, properties);
+		assertSame(properties, jdbcMetadataConfiguration.getProperties());
+	}
+	
+	@Test
+	public void testSetProperties() throws Exception {
+		Properties properties = new Properties();
+		Field propertiesField = JdbcMetadataConfiguration.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);	
+		assertNotNull(propertiesField.get(jdbcMetadataConfiguration));
+		assertNotSame(properties,  propertiesField.get(jdbcMetadataConfiguration));
+		jdbcMetadataConfiguration.setProperties(properties);
+		assertSame(properties, propertiesField.get(jdbcMetadataConfiguration));
+	}
+	
+	@Test
+	public void testGetProperty() throws Exception {
+		assertNull(jdbcMetadataConfiguration.getProperty("foo"));
+		Field propertiesField = JdbcMetadataConfiguration.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = (Properties)propertiesField.get(jdbcMetadataConfiguration);
+		properties.put("foo", "bar");
+		assertEquals("bar", jdbcMetadataConfiguration.getProperty("foo"));
+	}
+
+	@Test
+	public void testSetProperty() throws Exception {
+		Field propertiesField = JdbcMetadataConfiguration.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = (Properties)propertiesField.get(jdbcMetadataConfiguration);
+		assertNull(properties.get("foo"));
+		jdbcMetadataConfiguration.setProperty("foo", "bar");
+		assertEquals("bar", properties.get("foo"));
+	}
+	
+	@Test
+	public void testAddProperties() throws Exception {
+		Field propertiesField = JdbcMetadataConfiguration.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = (Properties)propertiesField.get(jdbcMetadataConfiguration);
+		Properties addedProperties = new Properties();
+		addedProperties.put("foo", "bar");
+		assertNull(properties.get("foo"));
+		jdbcMetadataConfiguration.addProperties(addedProperties);
+		assertEquals("bar", properties.get("foo"));
+	}
+	
+	@Test
+	public void testGetReverseEngineeringStrategy() throws Exception {
+		Field revengStrategyField = JdbcMetadataConfiguration.class.getDeclaredField("revengStrategy");
+		revengStrategyField.setAccessible(true);
+		ReverseEngineeringStrategy strategy = new DefaultReverseEngineeringStrategy();
+		assertNull(jdbcMetadataConfiguration.getReverseEngineeringStrategy());
+		revengStrategyField.set(jdbcMetadataConfiguration, strategy);
+		assertSame(strategy, jdbcMetadataConfiguration.getReverseEngineeringStrategy());
+	}
+	
+	@Test
+	public void testSetReverseEngineeringStrategy() throws Exception {
+		Field revengStrategyField = JdbcMetadataConfiguration.class.getDeclaredField("revengStrategy");
+		revengStrategyField.setAccessible(true);
+		ReverseEngineeringStrategy strategy = new DefaultReverseEngineeringStrategy();
+		assertNull(revengStrategyField.get(jdbcMetadataConfiguration));
+		jdbcMetadataConfiguration.setReverseEngineeringStrategy(strategy);
+		assertSame(strategy, revengStrategyField.get(jdbcMetadataConfiguration));
+	}
+	
+	@Test
+	public void testPreferBasicCompositeIds() throws Exception {
+		Field preferBasicCompositeField = JdbcMetadataConfiguration.class.getDeclaredField("preferBasicCompositeIds");
+		preferBasicCompositeField.setAccessible(true);
+		assertTrue(jdbcMetadataConfiguration.preferBasicCompositeIds());
+		preferBasicCompositeField.set(jdbcMetadataConfiguration, false);
+		assertFalse(jdbcMetadataConfiguration.preferBasicCompositeIds());
+	}
+	
+	@Test
+	public void testSetPreferBasicCompositeIds() throws Exception {
+		Field preferBasicCompositeField = JdbcMetadataConfiguration.class.getDeclaredField("preferBasicCompositeIds");
+		preferBasicCompositeField.setAccessible(true);
+		assertTrue((boolean)preferBasicCompositeField.get(jdbcMetadataConfiguration));
+		jdbcMetadataConfiguration.setPreferBasicCompositeIds(false);
+		assertFalse((boolean)preferBasicCompositeField.get(jdbcMetadataConfiguration));
+	}
+	
+	@Test
+	public void testGetMetadata() throws Exception {
+		Field metadataField = JdbcMetadataConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		Metadata metadata = (Metadata)Proxy.newProxyInstance(
+				getClass().getClassLoader(), 
+				new Class[] { Metadata.class }, 
+				new InvocationHandler() {					
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						return null;
+					}
+				});
+		assertNull(jdbcMetadataConfiguration.getMetadata());
+		metadataField.set(jdbcMetadataConfiguration, metadata);
+		assertSame(metadata, jdbcMetadataConfiguration.getMetadata());
+	}
+	
+	@Test
+	public void testReadFromJdbc() throws Exception {
+		Field metadataField = JdbcMetadataConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		Driver h2Driver = new Driver();
+		DriverManager.registerDriver(h2Driver);
+		Connection connection = DriverManager.getConnection("jdbc:h2:mem:test");
+		Statement statement = connection.createStatement();
+		statement.execute("CREATE TABLE FOO(id int primary key, bar varchar(255))");
+		jdbcMetadataConfiguration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
+		jdbcMetadataConfiguration.setReverseEngineeringStrategy(new DefaultReverseEngineeringStrategy());
+		assertNull(metadataField.get(jdbcMetadataConfiguration));
+		jdbcMetadataConfiguration.readFromJDBC();
+		assertNotNull(metadataField.get(jdbcMetadataConfiguration));
+		statement.execute("DROP TABLE FOO");
+		statement.close();
+		connection.close();
+		DriverManager.deregisterDriver(h2Driver);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>