### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.DummyMetadataDescriptorTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.DummyMetadataDescriptor'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataDescriptor.java
@@ -1,0 +1,40 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+
+public class DummyMetadataDescriptor implements MetadataDescriptor {
+
+	private static final MetadataInvocationHandler HANDLER = new MetadataInvocationHandler();	
+	private static final Class<?>[] INTERFACES = new Class[] { Metadata.class };
+	private static final ClassLoader LOADER = Metadata.class.getClassLoader();
+
+	@Override
+	public Metadata createMetadata() {
+		return (Metadata)Proxy.newProxyInstance(LOADER, INTERFACES, HANDLER);
+	}
+
+	@Override
+	public Properties getProperties() {
+		return null;
+	}
+
+	private static class MetadataInvocationHandler implements InvocationHandler {
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ("getEntityBindings".equals(method.getName()) || 
+					"collectTableMappings".equals(method.getName())) {
+				return Collections.emptySet();
+			} else {
+				return null;
+			}
+		}		
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataDescriptorTest.java
@@ -1,0 +1,34 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.junit.jupiter.api.Test;
+
+public class DummyMetadataDescriptorTest {
+	
+	@Test
+	public void testConstruction() {
+		assertTrue(new DummyMetadataDescriptor() instanceof MetadataDescriptor);
+	}
+	
+	@Test
+	public void testGetProperties() {
+		assertNull(new DummyMetadataDescriptor().getProperties());
+	}
+	
+	@Test
+	public void testCreateMetadata() {
+		Metadata metadata = new DummyMetadataDescriptor().createMetadata();
+		assertNotNull(metadata);
+		assertEquals(Collections.emptySet(), metadata.getEntityBindings());
+		assertEquals(Collections.emptySet(), metadata.collectTableMappings());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>