### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.DummyMetadataBuildingContextTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.DummyMetadataBuildingContext'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataBuildingContext.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataBuildingContext.java
@@ -1,0 +1,31 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import org.hibernate.boot.internal.BootstrapContextImpl;
+import org.hibernate.boot.internal.InFlightMetadataCollectorImpl;
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.internal.MetadataBuildingContextRootImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.boot.spi.InFlightMetadataCollector;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.dialect.Dialect;
+
+public class DummyMetadataBuildingContext {
+	
+	public static MetadataBuildingContext INSTANCE = createInstance();
+	
+	private static MetadataBuildingContext createInstance() {
+		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+		ssrb.applySetting("hibernate.dialect", DummyDialect.class.getName());
+		StandardServiceRegistry serviceRegistry = ssrb.build();
+		MetadataBuildingOptions metadataBuildingOptions = new MetadataBuilderImpl.MetadataBuildingOptionsImpl(serviceRegistry);
+		BootstrapContext bootstrapContext = new BootstrapContextImpl(serviceRegistry, metadataBuildingOptions);
+		InFlightMetadataCollector inflightMetadataCollector = new InFlightMetadataCollectorImpl(bootstrapContext, metadataBuildingOptions);
+		return new MetadataBuildingContextRootImpl(bootstrapContext, metadataBuildingOptions, inflightMetadataCollector);
+	}
+
+	public static class DummyDialect extends Dialect {}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataBuildingContextTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/DummyMetadataBuildingContextTest.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.junit.jupiter.api.Test;
+
+public class DummyMetadataBuildingContextTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DummyMetadataBuildingContext.INSTANCE);
+		StandardServiceRegistry serviceRegistry = DummyMetadataBuildingContext.INSTANCE
+				.getBootstrapContext().getServiceRegistry();
+		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
+		Dialect dialect = jdbcServices.getDialect();
+		assertTrue(dialect instanceof DummyMetadataBuildingContext.DummyDialect);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>