### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test class 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.ConfigurationMetadataDescriptorTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.util.ConfigurationMetadataDescriptor'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/ConfigurationMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/ConfigurationMetadataDescriptor.java
@@ -1,0 +1,63 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.internal.MetadataImpl;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.tool.api.metadata.MetadataDescriptor;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.v_5_6.internal.ConfigurationFacadeImpl;
+
+public class ConfigurationMetadataDescriptor implements MetadataDescriptor {
+	
+	private ConfigurationFacadeImpl configurationFacade;
+
+	public ConfigurationMetadataDescriptor(IConfiguration configurationFacade) {
+		this.configurationFacade = (ConfigurationFacadeImpl)configurationFacade;
+	}
+
+	@Override
+	public Properties getProperties() {
+		return configurationFacade.getProperties();
+	}
+
+	@Override
+	public Metadata createMetadata() {
+		Metadata result = configurationFacade.getMetadata();
+		if (result != null) {
+			result = patch(result);
+		}
+		return result;
+	}
+
+	private Metadata patch(Metadata metadata) {
+		try {
+			if (metadata instanceof MetadataImpl ) {
+				MetadataImpl metadataImpl = (MetadataImpl)metadata;
+				Field entityBindingMapField = metadataImpl.getClass().getDeclaredField("entityBindingMap");
+				if (entityBindingMapField != null) {
+					entityBindingMapField.setAccessible(true);
+					Object object = entityBindingMapField.get(metadataImpl);
+					if (object instanceof HashMap<?, ?>) {
+						@SuppressWarnings("unchecked")
+						HashMap<String, PersistentClass> map = (HashMap<String, PersistentClass>)object;
+						for (IPersistentClass ipc : ((ConfigurationFacadeImpl)this.configurationFacade).getAddedClasses()) {
+							PersistentClass pc = (PersistentClass)((IFacade)ipc).getTarget();
+							map.put(pc.getEntityName(), pc);
+						}
+					}
+				}
+			}
+			return metadata;
+		}
+		catch (Throwable t) {
+			throw new RuntimeException("Problem while creating metadata", t);
+		}
+	} 
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/ConfigurationMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/util/ConfigurationMetadataDescriptorTest.java
@@ -1,0 +1,85 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.RootClass;
+import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.v_5_6.internal.ConfigurationFacadeImpl;
+import org.jboss.tools.hibernate.runtime.v_5_6.internal.FacadeFactoryImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationMetadataDescriptorTest {
+
+	private static final String TEST_HBM_XML_STRING =
+			"<hibernate-mapping package='org.jboss.tools.hibernate.runtime.v_5_6.internal.util'>" +
+			"  <class name='ConfigurationMetadataDescriptorTest$Foo'>" + 
+			"    <id name='id'/>" +
+			"  </class>" +
+			"</hibernate-mapping>";
+	
+	static class Foo {
+		public String id;
+	}
+	
+	public static class TestDialect extends Dialect {}
+		
+	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private ConfigurationMetadataDescriptor configurationMetadataDescriptor = null;
+	
+	private Configuration configurationTarget = null;
+	private ConfigurationFacadeImpl configurationFacade = null;
+	
+	@BeforeEach
+	public void beforeEach() {
+		configurationTarget = new Configuration();
+		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
+		configurationMetadataDescriptor = new ConfigurationMetadataDescriptor(configurationFacade);
+	}
+	
+	@Test
+	public void testConstruction() throws Exception {
+		Field configurationFacadeField = 
+				ConfigurationMetadataDescriptor.class.getDeclaredField("configurationFacade");
+		configurationFacadeField.setAccessible(true);
+		assertNotNull(configurationMetadataDescriptor);
+		assertSame(configurationFacade, configurationFacadeField.get(configurationMetadataDescriptor));
+	}
+	
+	@Test 
+	public void testGetProperties() {
+		Properties properties = new Properties();
+		configurationTarget.setProperties(properties);
+		assertSame(properties, configurationMetadataDescriptor.getProperties());
+	}
+	
+	@Test
+	public void testCreateMetadata() {
+		MetadataSources metadataSources = new MetadataSources();
+		metadataSources.addInputStream(new ByteArrayInputStream(TEST_HBM_XML_STRING.getBytes()));
+		Configuration configuration = new Configuration(metadataSources);
+		configuration.setProperty("hibernate.dialect", TestDialect.class.getName());
+		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
+		PersistentClass persistentClass = new RootClass(null);
+		persistentClass.setEntityName("Bar");
+		IPersistentClass persistentClassFacade = 
+				FACADE_FACTORY.createPersistentClass(persistentClass);	
+		configurationFacade.addClass(persistentClassFacade);
+		configurationMetadataDescriptor = new ConfigurationMetadataDescriptor(configurationFacade);
+		Metadata metadata = configurationMetadataDescriptor.createMetadata();
+		assertNotNull(metadata.getEntityBinding(Foo.class.getName()));
+		assertNotNull(metadata.getEntityBinding("Bar"));
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>