### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add class 'org.jboss.tools.hibernate.runtime.v_5_6.internal.ExporterFacadeTest#testCreateConfiguration()' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.FacadeFactoryImpl#createConfiguration(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/FacadeFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.tools.hibernate.runtime.v_5_6.internal;
 
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 
@@ -11,6 +12,11 @@ public class FacadeFactoryImpl extends AbstractFacadeFactory {
 		return FacadeFactoryImpl.class.getClassLoader();
 	}
 
+	@Override
+	public IConfiguration createConfiguration(Object target) {
+		return new ConfigurationFacadeImpl(this, target);
+	}
+	
 	@Override
 	public IPersistentClass createSpecialRootClass(IProperty property) {
 		// TODO Auto-generated method stub

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/FacadeFactoryTest.java
@@ -2,7 +2,11 @@ package org.jboss.tools.hibernate.runtime.v_5_6.internal;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hibernate.cfg.Configuration;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +29,14 @@ public class FacadeFactoryTest {
 		assertSame(
 				FacadeFactoryImpl.class.getClassLoader(), 
 				facadeFactory.getClassLoader());
+	}
+	
+	@Test
+	public void testCreateConfiguration() {
+		Configuration configuration = new Configuration();
+		IConfiguration facade = facadeFactory.createConfiguration(configuration);
+		assertTrue(facade instanceof ConfigurationFacadeImpl);
+		assertSame(configuration, ((IFacade)facade).getTarget());		
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>