### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test class 'org.jboss.tools.hibernate.runtime.v_5_6.internal.HibernateMappingExporterExtensionTest' and implementation 'org.jboss.tools.hibernate.runtime.v_5_6.internal.HibernateMappingExporterExtension'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
@@ -9,14 +9,15 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
  lib/hibernate-core-5.6.0.Beta1.jar,
  lib/hibernate-tools-5.6.0.Beta1.jar
-Require-Bundle: org.jboss.tools.hibernate.libs.jpa.v_2_2,
- org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
- org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
- org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
- org.jboss.tools.hibernate.libs.jaxb.v_2_3,
- org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
+Require-Bundle: org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
+ org.jboss.tools.hibernate.libs.jaxb.v_2_3,
+ org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
+ org.jboss.tools.hibernate.libs.jpa.v_2_2,
+ org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
- org.jboss.tools.hibernate.runtime.spi,
- org.jboss.tools.hibernate.libs.commons-collections4.v_4_4;bundle-version="5.4.14"
+ org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
@@ -1,0 +1,44 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal;
+
+import java.io.File;
+import java.util.Map;
+
+import org.hibernate.tool.hbm2x.HibernateMappingExporter;
+import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
+import org.jboss.tools.hibernate.runtime.v_5_6.internal.util.ConfigurationMetadataDescriptor;
+
+public class HibernateMappingExporterExtension extends HibernateMappingExporter {
+
+	private IFacadeFactory facadeFactory;
+	private IExportPOJODelegate delegateExporter;
+
+	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
+		this.facadeFactory = facadeFactory;
+		setMetadataDescriptor(new ConfigurationMetadataDescriptor(cfg));
+		setOutputDirectory(file);
+	}
+
+	public void setDelegate(IExportPOJODelegate delegate) {
+		delegateExporter = delegate;
+	}
+
+	public void superExportPOJO(Map<String, Object> map, POJOClass pojoClass) {
+		super.exportPOJO(map, pojoClass);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	protected void exportPOJO(Map map, POJOClass pojoClass) {
+		if (delegateExporter == null) {
+			super.exportPOJO(map, pojoClass);
+		} else {
+			delegateExporter.exportPOJO(
+					(Map<Object, Object>)map, 
+					facadeFactory.createPOJOClass(pojoClass));
+		}
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
@@ -1,0 +1,174 @@
+package org.jboss.tools.hibernate.runtime.v_5_6.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.Version;
+import org.hibernate.tool.hbm2x.AbstractExporter;
+import org.hibernate.tool.hbm2x.ArtifactCollector;
+import org.hibernate.tool.hbm2x.Cfg2HbmTool;
+import org.hibernate.tool.hbm2x.Cfg2JavaTool;
+import org.hibernate.tool.hbm2x.TemplateHelper;
+import org.hibernate.tool.hbm2x.pojo.EntityPOJOClass;
+import org.hibernate.tool.hbm2x.pojo.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
+import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
+import org.jboss.tools.hibernate.runtime.v_5_6.internal.util.ConfigurationMetadataDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class HibernateMappingExporterExtensionTest {
+
+	private static IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private HibernateMappingExporterExtension hibernateMappingExporterExtension = null;
+	private IConfiguration configurationFacade = null;
+	
+	@TempDir
+	public File tempDir = new File("temp");
+	
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		configurationFacade = FACADE_FACTORY.createConfiguration(new Configuration());
+		hibernateMappingExporterExtension = 
+				new HibernateMappingExporterExtension(
+						FACADE_FACTORY, 
+						configurationFacade, 
+						tempDir);
+	}
+	
+	@Test
+	public void testConstruction() throws Exception {
+		Field facadeFactoryField = HibernateMappingExporterExtension.class.getDeclaredField("facadeFactory");
+		facadeFactoryField.setAccessible(true);
+		assertSame(FACADE_FACTORY, facadeFactoryField.get(hibernateMappingExporterExtension));
+		Field metadataDescriptorField = AbstractExporter.class.getDeclaredField("metadataDescriptor");
+		metadataDescriptorField.setAccessible(true);
+		ConfigurationMetadataDescriptor cmdd = (ConfigurationMetadataDescriptor)metadataDescriptorField.get(hibernateMappingExporterExtension);
+		Field configurationFacadeField = ConfigurationMetadataDescriptor.class.getDeclaredField("configurationFacade");
+		configurationFacadeField.setAccessible(true);
+		assertSame(configurationFacade, configurationFacadeField.get(cmdd));
+		Field outputDirField = AbstractExporter.class.getDeclaredField("outputdir");
+		outputDirField.setAccessible(true);
+		assertSame(tempDir, outputDirField.get(hibernateMappingExporterExtension));
+	}
+	
+	@Test
+	public void testSetDelegate() throws Exception {
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+		};
+		assertNull(delegateField.get(hibernateMappingExporterExtension));
+		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
+		assertSame(exportPojoDelegate, delegateField.get(hibernateMappingExporterExtension));
+	}
+	
+	@Test
+	public void testSuperExportPOJO() throws Exception {
+		initializeTemplateHelper();
+		ArtifactCollector artifactCollector = new ArtifactCollector();
+		hibernateMappingExporterExtension.setArtifactCollector(artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File(tempDir, "foo" + File.separator + "Bar.hbm.xml").exists());
+		Map<String, Object> additionalContext = new HashMap<String, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.getDefault().toString());
+		additionalContext.put("c2h", c2h);
+		hibernateMappingExporterExtension.superExportPOJO(
+				additionalContext, 
+				createPojoClass());
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals(tempDir.getPath() + File.separator + "foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File(tempDir, "foo" + File.separator + "Bar.hbm.xml").exists());
+	}
+	
+	@Test
+	public void testExportPOJO() throws Exception {
+		initializeTemplateHelper();
+		POJOClass pojoClass = createPojoClass();
+		// first without a delegate exporter
+		ArtifactCollector artifactCollector = new ArtifactCollector();
+		hibernateMappingExporterExtension.setArtifactCollector(artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Map<Object, Object> additionalContext = new HashMap<Object, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.VERSION);
+		additionalContext.put("c2h", c2h);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File(tempDir, "foo" + File.separator + "Bar.hbm.xml").exists());
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals(tempDir.getPath() + File.separator + "foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File(tempDir, "foo" + File.separator + "Bar.hbm.xml").exists());
+		// then with a delegate exporter
+		artifactCollector = new ArtifactCollector();
+		hibernateMappingExporterExtension.setArtifactCollector(artifactCollector);
+		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+				arguments.put("map", map);
+				arguments.put("pojoClass", pojoClass);
+			}
+		};
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		delegateField.set(hibernateMappingExporterExtension, exportPojoDelegate);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertNull(arguments.get("map"));
+		assertNull(arguments.get("pojoClass"));
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertSame(additionalContext, arguments.get("map"));
+		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+	}
+	
+	private POJOClass createPojoClass() {
+		RootClass persistentClass = new RootClass(null);
+		Table rootTable = new Table();
+		rootTable.setName("table");
+		persistentClass.setTable(rootTable);
+		persistentClass.setEntityName("Bar");
+		persistentClass.setClassName("foo.Bar");
+		return new EntityPOJOClass(persistentClass, new Cfg2JavaTool());		
+	}
+	
+	private void initializeTemplateHelper() throws Exception {
+		Method setTemplateHelperMethod = AbstractExporter.class.getDeclaredMethod(
+				"setTemplateHelper", 
+				new Class[] { TemplateHelper.class });
+		setTemplateHelperMethod.setAccessible(true);
+		TemplateHelper templateHelper = new TemplateHelper();
+		templateHelper.init(null, new String[0]);
+		setTemplateHelperMethod.invoke(
+				hibernateMappingExporterExtension, 
+				new Object[] { templateHelper });		
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>