### PR TITLE
BIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Contribute class 'org.jboss.tools.hibernate.runtime.v_5_6.internal.ServiceImpl' as a service to the 'org.jboss.tools.hibernate.runtime.spi.services' extension point

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/build.properties
@@ -2,4 +2,6 @@ source.. = src/
 output.. = target/classes/
 bin.includes = .,\
                META-INF/,\
+               plugin.xml,\
+               plugin.properties,\
                lib/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/plugin.properties
@@ -1,0 +1,1 @@
+hibernate.version=5.6 - Preview

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.jboss.tools.hibernate.runtime.spi.services">
+      <service
+             class="org.jboss.tools.hibernate.runtime.v_5_6.internal.ServiceImpl"
+             disabled="true"
+             name="%hibernate.version">
+      </service>
+   </extension>
+
+</plugin>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>