### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add plugin 'org.jboss.tools.hibernate.runtime.v_5_6' to feature 'org.hibernate.eclipse.feature'

### DIFF
--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -324,4 +324,11 @@
          install-size="0"
          version="0.0.0"/>
 
+   <plugin
+         id="org.jboss.tools.hibernate.runtime.v_5_6"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>