### PR TITLE
JBIDE-27986: Set up a runtime plugin for the Hibernate 5.6.x releases - Add test fragment 'org.jboss.tools.hibernate.runtime.v_5_6.test' to test feature 'org.hibernate.eclipse.test.feature'

### DIFF
--- a/features/org.hibernate.eclipse.test.feature/feature.xml
+++ b/features/org.hibernate.eclipse.test.feature/feature.xml
@@ -145,4 +145,12 @@
          install-size="0"
          version="0.0.0"/>
 
+   <plugin
+         id="org.jboss.tools.hibernate.runtime.v_5_6.test"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>