### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Change dependency for fragment 'org.jboss.tools.hibernate.runtime.v_5_5.test'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5.test
 Bundle-Version: 5.4.14.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_5
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit.jupiter.api
-Bundle-ClassPath: .,
- lib/h2-1.4.200.jar
+Require-Bundle: org.junit.jupiter.api,
+ org.jboss.tools.hibernate.libs.h2.v_1_4
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/ConfigurationFacadeTest.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.h2.Driver;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
@@ -49,6 +50,7 @@ import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.v_5_5.internal.util.JdbcMetadataConfiguration;
 import org.jboss.tools.hibernate.runtime.v_5_5.internal.util.MetadataHelper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -82,6 +84,11 @@ public class ConfigurationFacadeTest {
 
 	private IConfiguration configurationFacade = null;
 	private Configuration configuration = null;
+
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
 
 	@BeforeEach
 	public void beforeEach() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/ServiceImplTest.java
@@ -16,6 +16,7 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Properties;
 
+import org.h2.Driver;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Environment;
@@ -73,6 +74,7 @@ import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
 import org.jboss.tools.hibernate.runtime.v_5_5.internal.util.JdbcMetadataConfiguration;
 import org.jboss.tools.hibernate.runtime.v_5_5.internal.util.JpaConfiguration;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +95,11 @@ public class ServiceImplTest {
 
 	private ServiceImpl service = null;
 	
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
+
 	@BeforeEach
 	public void beforeEach() {
 		service = new ServiceImpl();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/util/JdbcMetadataConfigurationTest.java
@@ -17,9 +17,11 @@ import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.Properties;
 
+import org.h2.Driver;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.cfg.reveng.ReverseEngineeringStrategy;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +29,11 @@ public class JdbcMetadataConfigurationTest {
 
 	private JdbcMetadataConfiguration jdbcMetadataConfiguration = null;
 	
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
+
 	@BeforeEach
 	public void beforeEach() {
 		jdbcMetadataConfiguration = new JdbcMetadataConfiguration();


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>