### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Change dependency for fragment 'org.jboss.tools.hibernate.runtime.v_5_4.test' + Some additional cleanup

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
@@ -2,9 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.4 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4.test
+Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.4.test
 Bundle-Version: 5.4.14.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_4
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit.jupiter.api
-Bundle-ClassPath: .,
- lib/h2-1.4.200.jar
+Require-Bundle: org.junit.jupiter.api,
+ org.jboss.tools.hibernate.libs.h2.v_1_4
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/build.properties
@@ -1,5 +1,4 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .,\
-               lib/
+               .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ConfigurationFacadeTest.java
@@ -16,6 +16,7 @@ import java.sql.Statement;
 import java.util.Iterator;
 import java.util.Properties;
 
+import org.h2.Driver;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
@@ -37,6 +38,7 @@ import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.v_5_4.internal.util.JdbcMetadataConfiguration;
 import org.jboss.tools.hibernate.runtime.v_5_4.internal.util.MetadataHelper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.EntityResolver;
@@ -62,6 +64,11 @@ public class ConfigurationFacadeTest {
 
 	private IConfiguration configurationFacade = null;
 	private Configuration configuration = null;
+
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
 
 	@BeforeEach
 	public void beforeEach() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ServiceImplTest.java
@@ -14,6 +14,7 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Properties;
 
+import org.h2.Driver;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.Environment;
@@ -66,6 +67,7 @@ import org.jboss.tools.hibernate.runtime.spi.ITableFilter;
 import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
 import org.jboss.tools.hibernate.runtime.v_5_4.internal.util.JdbcMetadataConfiguration;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ServiceImplTest {
@@ -85,6 +87,11 @@ public class ServiceImplTest {
 
 	private ServiceImpl service = new ServiceImpl();
 	
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
+
 	@Test
 	public void testServiceCreation() {
 		assertNotNull(service);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/build.properties
@@ -1,6 +1,5 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .,\
-               lib/
+               .
                              

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
@@ -13,30 +13,6 @@
 	
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>get-libs</id>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<phase>generate-resources</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<artifactItems>
-						<artifactItem>
-							<groupId>com.h2database</groupId>
-							<artifactId>h2</artifactId>
-							<version>${h2.version}</version>
-						</artifactItem>
-					</artifactItems>
-					<skip>false</skip>
-					<outputDirectory>${basedir}/lib</outputDirectory>
-				</configuration>
-			</plugin>
 			<plugin> 
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 6.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0.test
+Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.0.test
 Bundle-Version: 5.4.14.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/build.properties
@@ -1,5 +1,4 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .,\
-               lib/
+               .


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>