### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Depend on plugin 'org.jboss.tools.hibernate.libs.transaction-api.v_1_2' instead of pulling in Maven dependency on 'jboss-transaction-api_1.2_spec'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -20,10 +20,10 @@ Bundle-ClassPath: .,
  lib/jaxb-api-2.3.1.jar,
  lib/jaxb-runtime-2.3.1.jar,
  lib/javax.persistence-api-2.2.jar,
- lib/jboss-logging-3.4.1.Final.jar,
- lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
+ lib/jboss-logging-3.4.1.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
- org.jboss.tools.hibernate.libs.freemarker.v_2_3_23
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.transaction-api.v_1_2

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -113,11 +113,6 @@
 							<artifactId>jboss-logging</artifactId>
 							<version>${jboss-logging.version}</version>
 						</artifactItem>
-						<artifactItem>
-							<groupId>org.jboss.spec.javax.transaction</groupId>
-							<artifactId>jboss-transaction-api_1.2_spec</artifactId>
-							<version>${jboss-transaction-api_1.2_spec.version}</version>
-						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>
 					<outputDirectory>${basedir}/lib</outputDirectory>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>