### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Remove unneeded dependency on 'com.sun.istack.istack-commons-runtime'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Bundle-ClassPath: .,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-6.0.0.Alpha9.jar,
  lib/hibernate-tools-orm-6.0.0.Alpha5.jar,
- lib/hibernate-tools-utils-6.0.0.Alpha5.jar,
- lib/istack-commons-runtime-3.0.11.jar
+ lib/hibernate-tools-utils-6.0.0.Alpha5.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -16,7 +16,6 @@
 		<hibernate.core.version>6.0.0.Alpha9</hibernate.core.version>
 		<hibernate.tools.version>6.0.0.Alpha5</hibernate.tools.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
-		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
 		<jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
 	</properties>
 
@@ -36,11 +35,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>com.sun.istack</groupId>
-							<artifactId>istack-commons-runtime</artifactId>
-							<version>${istack-commons-runtime.version}</version>
-						</artifactItem> 
  						<artifactItem>
 							<groupId>org.antlr</groupId>
 							<artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>