### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Depend on plugin 'org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1'' instead of pulling in Maaven dependency on 'org.hibernate.common.hibernate-commons-annotations'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/antlr4-runtime-4.8-1.jar,
- lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-6.0.0.Alpha9.jar,
  lib/hibernate-tools-orm-6.0.0.Alpha5.jar,
  lib/hibernate-tools-utils-6.0.0.Alpha5.jar
@@ -20,6 +19,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.libs.jpa.v_2_2,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -15,8 +15,6 @@
 		<antlr.version>4.8-1</antlr.version>
 		<hibernate.core.version>6.0.0.Alpha9</hibernate.core.version>
 		<hibernate.tools.version>6.0.0.Alpha5</hibernate.tools.version>
-		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
-		<jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
 	</properties>
 
 	<build>
@@ -54,11 +52,6 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>
 							<version>${hibernate.core.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.hibernate.common</groupId>
-							<artifactId>hibernate-commons-annotations</artifactId>
-							<version>${hibernate-commons-annotations.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>