### PR TITLE
JBIDE-27439: Set up a runtime plugin for the Hibernate 6.0.x releases - Depend on plugin 'org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_9' instead of pulling in Maven dependency on 'org.antlr.antlr4-runtime'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/antlr4-runtime-4.8-1.jar,
  lib/hibernate-core-6.0.0.Alpha9.jar,
  lib/hibernate-tools-orm-6.0.0.Alpha5.jar,
  lib/hibernate-tools-utils-6.0.0.Alpha5.jar
@@ -23,4 +22,5 @@ Require-Bundle: org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
- org.jboss.tools.hibernate.libs.jaxb.v_2_3
+ org.jboss.tools.hibernate.libs.jaxb.v_2_3,
+ org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_9

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<antlr.version>4.8-1</antlr.version>
 		<hibernate.core.version>6.0.0.Alpha9</hibernate.core.version>
 		<hibernate.tools.version>6.0.0.Alpha5</hibernate.tools.version>
 	</properties>
@@ -33,11 +32,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
- 						<artifactItem>
-							<groupId>org.antlr</groupId>
-							<artifactId>antlr4-runtime</artifactId>
-							<version>${antlr.version}</version>
-						</artifactItem> 
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-orm</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>