### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/byte-buddy-1.10.14.jar,
- lib/classmate-1.3.4.jar,
  lib/commons-collections4-4.4.jar,
  lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
@@ -24,4 +23,5 @@ Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.runtime.common,
- org.jboss.tools.hibernate.runtime.spi
+ org.jboss.tools.hibernate.runtime.spi,
+ org.jboss.tools.hibernate.libs.classmate.v_1_5

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<classmate.version>1.3.4</classmate.version>
 		<commons-collections.version>4.4</commons-collections.version>
 		<hibernate.version>5.5.7.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
@@ -41,11 +40,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>com.fasterxml</groupId>
-							<artifactId>classmate</artifactId>
-							<version>${classmate.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>com.sun.istack</groupId>
 							<artifactId>istack-commons-runtime</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>