### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Replace Maven dependency on 'net.bytebuddy:byte-buddy:1.10.14' by plugin dependency on 'org.jboss.tools.hibernate.libs.byte-buddy.v_1_11'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/byte-buddy-1.10.14.jar,
  lib/commons-collections4-4.4.jar,
  lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
@@ -21,7 +20,8 @@ Bundle-ClassPath: .,
  lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+ org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
+ org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.runtime.common,
- org.jboss.tools.hibernate.runtime.spi,
- org.jboss.tools.hibernate.libs.classmate.v_1_5
+ org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -21,7 +21,6 @@
 	    <jaxb.version>2.3.1</jaxb.version>
 		<jboss-logging.version>3.4.1.Final</jboss-logging.version>
 		<jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
-		<bytebuddy.version>1.10.14</bytebuddy.version>
 	</properties>
 
 	<build>
@@ -55,11 +54,6 @@
 							<artifactId>jaxb-api</artifactId>
 							<version>${jaxb.version}</version>
 						</artifactItem> 
-						<artifactItem>
-							<groupId>net.bytebuddy</groupId>
-							<artifactId>byte-buddy</artifactId>
-							<version>${bytebuddy.version}</version>
-						</artifactItem>
  	        			<artifactItem>
 		        			<groupId>org.apache.commons</groupId>
 		        			<artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>