### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Replace Maven dependency on 'org.jboss.logging:jboss-logging:3.4.1.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.jboss-logging.v_3_4'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -15,13 +15,13 @@ Bundle-ClassPath: .,
  lib/jandex-2.2.3.Final.jar,
  lib/javax.persistence-api-2.2.jar,
  lib/jaxb-api-2.3.1.jar,
- lib/jaxb-runtime-2.3.1.jar,
- lib/jboss-logging-3.4.1.Final.jar
+ lib/jaxb-runtime-2.3.1.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -19,7 +19,6 @@
 		<jandex.version>2.2.3.Final</jandex.version>
 		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 	    <jaxb.version>2.3.1</jaxb.version>
-		<jboss-logging.version>3.4.1.Final</jboss-logging.version>
 	</properties>
 
 	<build>
@@ -82,11 +81,6 @@
 						    <groupId>org.jboss</groupId>
 						    <artifactId>jandex</artifactId>
 						    <version>${jandex.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.jboss.logging</groupId>
-							<artifactId>jboss-logging</artifactId>
-							<version>${jboss-logging.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>