### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Replace Maven dependency on 'javax.persistence:javax.persistence-api:2.2' by plugin dependency on 'org.jboss.tools.hibernate.libs.jpa.v_2_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Bundle-ClassPath: .,
  lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.5.7.Final.jar,
- lib/hibernate-tools-5.5.7.Final.jar,
- lib/javax.persistence-api-2.2.jar
+ lib/hibernate-tools-5.5.7.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
@@ -21,6 +20,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jaxb.v_2_3,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
+ org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -16,7 +16,6 @@
 		<hibernate.version>5.5.7.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
 		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
-		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 	</properties>
 
 	<build>
@@ -40,11 +39,6 @@
 							<artifactId>istack-commons-runtime</artifactId>
 							<version>${istack-commons-runtime.version}</version>
 						</artifactItem> 
-						<artifactItem>
-							<groupId>javax.persistence</groupId>
-							<artifactId>javax.persistence-api</artifactId>
-							<version>${javax.persistence-api.version}</version>
-						</artifactItem>
  	        			<artifactItem>
 		        			<groupId>org.apache.commons</groupId>
 		        			<artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>