### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Replace Maven dependency on 'org.apache.commons:commons-collections4:4.4' by plugin dependency on 'org.jboss.tools.hibernate.libs.commons-collections4.v_4_4'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/commons-collections4-4.4.jar,
  lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.5.7.Final.jar,
@@ -16,6 +15,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jaxb.v_2_3,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<commons-collections.version>4.4</commons-collections.version>
 		<hibernate.version>5.5.7.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
 		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
@@ -39,11 +38,6 @@
 							<artifactId>istack-commons-runtime</artifactId>
 							<version>${istack-commons-runtime.version}</version>
 						</artifactItem> 
- 	        			<artifactItem>
-		        			<groupId>org.apache.commons</groupId>
-		        			<artifactId>commons-collections4</artifactId>
-		        			<version>${commons-collections.version}</version>
-	        			</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>