### PR TITLE
JBIDE-28149: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_5_5 to version 5.5.8.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
- lib/hibernate-core-5.5.7.Final.jar,
- lib/hibernate-tools-5.5.7.Final.jar
+ lib/hibernate-core-5.5.8.Final.jar,
+ lib/hibernate-tools-5.5.8.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>5.5.7.Final</hibernate.version>
+		<hibernate.version>5.5.8.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
 		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
 	</properties>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("5.5.7.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("5.5.8.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test
 	public void testCoreVersion() {
-		assertEquals("5.5.7.Final", org.hibernate.Version.getVersionString());
+		assertEquals("5.5.8.Final", org.hibernate.Version.getVersionString());
 	}
 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>