### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Remove unneeded dependency on 'com.sun.istack:istack-commons-runtime:3.0.11'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/istack-commons-runtime-3.0.11.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.5.8.Final.jar,
  lib/hibernate-tools-5.5.8.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -14,7 +14,6 @@
 	<properties>
 		<hibernate.version>5.5.8.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
-		<istack-commons-runtime.version>3.0.11</istack-commons-runtime.version>
 	</properties>
 
 	<build>
@@ -33,11 +32,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>com.sun.istack</groupId>
-							<artifactId>istack-commons-runtime</artifactId>
-							<version>${istack-commons-runtime.version}</version>
-						</artifactItem> 
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>