### PR TITLE
JBIDE-28101: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_5' - Replace Maven dependency on 'org.hibernate.common:hibernate-commons-annotations:5.1.2.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.5.8.Final.jar,
  lib/hibernate-tools-5.5.8.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
@@ -16,6 +15,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jaxb.v_2_3,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -13,7 +13,6 @@
 
 	<properties>
 		<hibernate.version>5.5.8.Final</hibernate.version>
-		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
 	</properties>
 
 	<build>
@@ -41,11 +40,6 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-tools</artifactId>
 							<version>${hibernate.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.hibernate.common</groupId>
-							<artifactId>hibernate-commons-annotations</artifactId>
-							<version>${hibernate-commons-annotations.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>