### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Replace Maven dependency on 'net.bytebuddy:byte-buddy:1.9.5' by plugin dependency on 'org.jboss.tools.hibernate.libs.byte-buddy.v_1_11'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/byte-buddy-1.9.5.jar,
  lib/commons-collections4-4.4.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.4.32.Final.jar,
@@ -24,6 +23,7 @@ Require-Bundle: org.apache.commons.collections,
  org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+ org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -20,7 +20,6 @@
 		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 		<javassist.version>3.24.0-GA</javassist.version>
 	    <jaxb.version>2.3.1</jaxb.version>
-		<bytebuddy.version>1.9.5</bytebuddy.version>
 		<jboss-logging.version>3.3.0.Final</jboss-logging.version>
 		<slf4j.version>1.6.1</slf4j.version>
 		<istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
@@ -76,11 +75,6 @@
 							<groupId>org.javassist</groupId>
 							<artifactId>javassist</artifactId>
 							<version>${javassist.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>net.bytebuddy</groupId>
-							<artifactId>byte-buddy</artifactId>
-							<version>${bytebuddy.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.jboss</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>