### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Replace Maven dependency on 'org.apache.commons:commons-collections4:4.4' by plugin dependency on 'org.jboss.tools.hibernate.libs.commons-collections4.v_4_4' + Removal of plugin dependency on 'org.apache.commons.collections'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/commons-collections4-4.4.jar,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.4.32.Final.jar,
  lib/hibernate-tools-5.4.32.Final.jar,
@@ -19,12 +18,12 @@ Bundle-ClassPath: .,
  lib/jboss-logging-3.3.0.Final.jar,
  lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar,
  lib/slf4j-api-1.6.1.jar
-Require-Bundle: org.apache.commons.collections,
- org.apache.commons.logging,
+Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.runtime.common,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<commons-collections.version>4.4</commons-collections.version>
 		<jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
 		<hibernate.version>5.4.32.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
@@ -41,11 +40,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-	        			<artifactItem>
-		        			<groupId>org.apache.commons</groupId>
-		        			<artifactId>commons-collections4</artifactId>
-		        			<version>${commons-collections.version}</version>
-	        			</artifactItem>
 						<artifactItem>
 							<groupId>org.jboss.spec.javax.transaction</groupId>
 							<artifactId>jboss-transaction-api_1.2_spec</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>