### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Remove unneeded Maven dependency on 'org.slf4j:slf4j-api:1.6.1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -16,8 +16,7 @@ Bundle-ClassPath: .,
  lib/jaxb-api-2.3.1.jar,
  lib/jaxb-runtime-2.3.1.jar,
  lib/jboss-logging-3.3.0.Final.jar,
- lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar,
- lib/slf4j-api-1.6.1.jar
+ lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -20,7 +20,6 @@
 		<javassist.version>3.24.0-GA</javassist.version>
 	    <jaxb.version>2.3.1</jaxb.version>
 		<jboss-logging.version>3.3.0.Final</jboss-logging.version>
-		<slf4j.version>1.6.1</slf4j.version>
 		<istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
 	</properties>
 
@@ -79,11 +78,6 @@
 							<groupId>org.jboss.logging</groupId>
 							<artifactId>jboss-logging</artifactId>
 							<version>${jboss-logging.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-api</artifactId>
-							<version>${slf4j.version}</version>
 						</artifactItem>
  						<artifactItem>
 							<groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>