### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Replace Maven dependency on 'org.jboss.logging:jboss-logging:3.3.0.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.jboss-logging.v_3_4'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Bundle-ClassPath: .,
  lib/javassist-3.24.0-GA.jar,
  lib/javax.persistence-api-2.2.jar,
  lib/jaxb-api-2.3.1.jar,
- lib/jaxb-runtime-2.3.1.jar,
- lib/jboss-logging-3.3.0.Final.jar
+ lib/jaxb-runtime-2.3.1.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
@@ -24,6 +23,7 @@ Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -18,7 +18,6 @@
 		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 		<javassist.version>3.24.0-GA</javassist.version>
 	    <jaxb.version>2.3.1</jaxb.version>
-		<jboss-logging.version>3.3.0.Final</jboss-logging.version>
 		<istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
 	</properties>
 
@@ -67,11 +66,6 @@
 							<groupId>org.jboss</groupId>
 							<artifactId>jandex</artifactId>
 							<version>${jandex.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.jboss.logging</groupId>
-							<artifactId>jboss-logging</artifactId>
-							<version>${jboss-logging.version}</version>
 						</artifactItem>
  						<artifactItem>
 							<groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>