### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Replace Maven dependency on 'javax.persistence:javax.persistence-api:2.2' by plugin dependency on 'org.jboss.tools.hibernate.libs.jpa.v_2_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Bundle-ClassPath: .,
  lib/hibernate-tools-5.4.32.Final.jar,
  lib/istack-commons-runtime-3.0.7.jar,
  lib/jandex-2.1.2.Final.jar,
- lib/javassist-3.24.0-GA.jar,
- lib/javax.persistence-api-2.2.jar
+ lib/javassist-3.24.0-GA.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
@@ -23,6 +22,7 @@ Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.jaxb.v_2_3,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
+ org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -15,7 +15,6 @@
 		<hibernate.version>5.4.32.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
 		<jandex.version>2.1.2.Final</jandex.version>
-		<javax.persistence-api.version>2.2</javax.persistence-api.version>
 		<javassist.version>3.24.0-GA</javassist.version>
 		<istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
 	</properties>
@@ -50,11 +49,6 @@
 							<groupId>org.hibernate.common</groupId>
 							<artifactId>hibernate-commons-annotations</artifactId>
 							<version>${hibernate-commons-annotations.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>javax.persistence</groupId>
-							<artifactId>javax.persistence-api</artifactId>
-							<version>${javax.persistence-api.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.javassist</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>