### PR TITLE
JBIDE-28170: Remove the unneeded dependency on javassist from the 5.4 runtime implementation and rework the relevant unit tests

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -10,8 +10,7 @@ Bundle-ClassPath: .,
  lib/hibernate-core-5.4.32.Final.jar,
  lib/hibernate-tools-5.4.32.Final.jar,
  lib/istack-commons-runtime-3.0.7.jar,
- lib/jandex-2.1.2.Final.jar,
- lib/javassist-3.24.0-GA.jar
+ lib/jandex-2.1.2.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ArtifactCollectorFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ArtifactCollectorFacadeTest.java
@@ -1,10 +1,12 @@
 package org.jboss.tools.hibernate.runtime.v_5_4.internal;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Method;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.hibernate.tool.hbm2x.ArtifactCollector;
 import org.jboss.tools.hibernate.runtime.common.AbstractArtifactCollectorFacade;
@@ -13,69 +15,58 @@ import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
-import javassist.util.proxy.ProxyObject;
-
 public class ArtifactCollectorFacadeTest {
 	
 	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
-
-	private String methodName = null;
-	private Object[] arguments = null;
 	
-	private IArtifactCollector artifactCollector = null; 
+	private static final Set<String> FILE_TYPES = new HashSet<String>();
+	private static final File[] FILES = new File[] { new File("foobar") };
 	
+	private IArtifactCollector artifactCollectorFacade = null;
+	private ArtifactCollector artifactCollectorTarget = null;
+		
 	@BeforeEach
-	public void beforeEach() throws Exception {
-		ProxyFactory proxyFactory = new ProxyFactory();
-		proxyFactory.setSuperclass(ArtifactCollector.class);
-		Class<?> proxyClass = proxyFactory.createClass();
-		ProxyObject proxy = (ProxyObject)proxyClass.newInstance();
-		proxy.setHandler(new MethodHandler() {		
-			@Override
-			public Object invoke(
-					Object self, 
-					Method m, 
-					Method proceed, 
-					Object[] args) throws Throwable {
-				if (methodName == null) {
-					methodName = m.getName();
-				}
-				if (arguments == null) {
-					arguments = args;
-				}
-				return proceed.invoke(self, args);
-			}
-		});
-		artifactCollector = new AbstractArtifactCollectorFacade(FACADE_FACTORY, (ArtifactCollector)proxy) {};
-		reset();
+	public void beforeEach() {
+		artifactCollectorTarget = new TestArtifactCollector();
+		artifactCollectorFacade = new AbstractArtifactCollectorFacade(FACADE_FACTORY, artifactCollectorTarget) {};
 	}
-
+	
 	@Test
 	public void testGetFileTypes() {
-		assertNotNull(artifactCollector.getFileTypes());
-		assertEquals("getFileTypes", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-	}
-
-	@Test
-	public void testFormatFiles() {
-		artifactCollector.formatFiles();
-		assertEquals("formatFiles", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-	}
-
-	@Test
-	public void testGetFiles() {
-		assertNotNull(artifactCollector.getFiles("foobar"));
-		assertEquals("getFiles", methodName);
-		assertArrayEquals(new Object[] { "foobar" }, arguments);
-	}
-
-	private void reset() {
-		methodName = null;
-		arguments = null;
+		assertSame(FILE_TYPES, artifactCollectorFacade.getFileTypes());
 	}
 	
+	@Test
+	public void testFormatFiles() {
+		assertFalse(((TestArtifactCollector)artifactCollectorTarget).formatted);
+		artifactCollectorFacade.formatFiles();
+		assertTrue(((TestArtifactCollector)artifactCollectorTarget).formatted);
+	}
+	
+	@Test
+	public void testGetFiles() {
+		assertSame(FILES, artifactCollectorFacade.getFiles("foobar"));
+	}
+	
+	private class TestArtifactCollector extends ArtifactCollector {
+		
+		private boolean formatted = false;
+		
+		@Override
+		public Set<String> getFileTypes() {
+			return FILE_TYPES;
+		}
+		
+		@Override
+		public void formatFiles() {
+			formatted = true;
+		}
+		
+		@Override
+		public File[] getFiles(String str) {
+			return FILES;
+		}
+		
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ForeignKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/ForeignKeyFacadeTest.java
@@ -1,14 +1,10 @@
 package org.jboss.tools.hibernate.runtime.v_5_4.internal;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -25,10 +21,6 @@ import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
-import javassist.util.proxy.ProxyObject;
-
 
 public class ForeignKeyFacadeTest {
 
@@ -37,64 +29,25 @@ public class ForeignKeyFacadeTest {
 	private IForeignKey foreignKeyFacade = null; 
 	private ForeignKey foreignKey = null;
 	
-	private String methodName = null;
-	private Object[] arguments = null;
-	
 	@BeforeEach
-	public void beforeEach() throws Exception {
-		ProxyFactory proxyFactory = new ProxyFactory();
-		proxyFactory.setSuperclass(ForeignKey.class);
-		Class<?> proxyClass = proxyFactory.createClass();
-		foreignKey = (ForeignKey)proxyClass.newInstance();
-		((ProxyObject)foreignKey).setHandler(new MethodHandler() {		
-			@Override
-			public Object invoke(
-					Object self, 
-					Method m, 
-					Method proceed, 
-					Object[] args) throws Throwable {
-				if (methodName == null) {
-					methodName = m.getName();
-				}
-				if (arguments == null) {
-					arguments = args;
-				}
-				return proceed.invoke(self, args);
-			}
-		});
+	public void beforeEach() {
+		foreignKey = new ForeignKey();
 		foreignKeyFacade = new AbstractForeignKeyFacade(FACADE_FACTORY, foreignKey) {};
-		reset();
 	}
 	
 	@Test
 	public void testGetReferencedTable() {
-		ITable first = foreignKeyFacade.getReferencedTable();
-		assertEquals("getReferencedTable", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-		assertNull(first);
-		Table table = new Table();
-		foreignKey.setReferencedTable(table);
-		reset();
-		ITable second = foreignKeyFacade.getReferencedTable();
-		assertEquals("getReferencedTable", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-		assertNotNull(second);
-		assertSame(table, ((IFacade)second).getTarget());
-		reset();
-		ITable third = foreignKeyFacade.getReferencedTable();
-		assertNull(methodName);
-		assertNull(arguments);
-		assertSame(second, third);
+		Table tableTarget = new Table();
+		foreignKey.setReferencedTable(tableTarget);
+		ITable table = foreignKeyFacade.getReferencedTable();
+		assertSame(tableTarget, ((IFacade)table).getTarget());
 	}
 	
 	@Test
 	public void testColumnIterator() {
 		Column column = new Column();
 		foreignKey.addColumn(column);
-		reset();
 		Iterator<IColumn> iterator = foreignKeyFacade.columnIterator();
-		assertEquals("columnIterator", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
 		IColumn columnFacade = iterator.next();
 		assertSame(column, ((IFacade)columnFacade).getTarget());
 		assertFalse(iterator.hasNext());
@@ -103,35 +56,26 @@ public class ForeignKeyFacadeTest {
 	@Test
 	public void testIsReferenceToPrimaryKey() {
 		assertTrue(foreignKeyFacade.isReferenceToPrimaryKey());
-		assertEquals("isReferenceToPrimaryKey", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-		Column column = new Column();
 		ArrayList<Column> list = new ArrayList<Column>();
+		Column column = new Column();
 		list.add(column);
 		foreignKey.addReferencedColumns(list.iterator());
-		reset();
 		assertFalse(foreignKeyFacade.isReferenceToPrimaryKey());
-		assertEquals("isReferenceToPrimaryKey", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
 	}
 	
 	@Test
 	public void testGetReferencedColumns() {
 		List<IColumn> list = foreignKeyFacade.getReferencedColumns();
-		assertTrue(list.isEmpty());
-		assertEquals("getReferencedColumns", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-		// recreate facade to reinitialize the instance variables
-		foreignKeyFacade = new AbstractForeignKeyFacade(FACADE_FACTORY, foreignKey) {};
+		assertTrue(list.isEmpty());		
 		Column column = new Column();
 		ArrayList<Column> columns = new ArrayList<Column>();
 		columns.add(column);
 		foreignKey.addReferencedColumns(columns.iterator());
-		reset();
+		// recreate facade to reinitialize the instance variables
+		foreignKeyFacade = new AbstractForeignKeyFacade(FACADE_FACTORY, foreignKey) {};
 		list = foreignKeyFacade.getReferencedColumns();
-		assertFalse(list.isEmpty());
-		assertEquals("getReferencedColumns", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
+		assertEquals(1, list.size());
+		assertSame(column, ((IFacade)list.get(0)).getTarget());
 	}
 	
 	@Test
@@ -139,18 +83,8 @@ public class ForeignKeyFacadeTest {
 		Column column = new Column();
 		IColumn columnFacade = FACADE_FACTORY.createColumn(column);
 		assertFalse(foreignKeyFacade.containsColumn(columnFacade));
-		assertEquals("containsColumn", methodName);
-		assertArrayEquals(new Object[] { column }, arguments);
 		foreignKey.addColumn(column);
-		reset();
 		assertTrue(foreignKeyFacade.containsColumn(columnFacade));
-		assertEquals("containsColumn", methodName);
-		assertArrayEquals(new Object[] { column }, arguments);
-	}
-	
-	private void reset() {
-		methodName = null;
-		arguments = null;
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/GenericExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/GenericExporterFacadeTest.java
@@ -1,9 +1,9 @@
 package org.jboss.tools.hibernate.runtime.v_5_4.internal;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 
 import org.hibernate.tool.hbm2x.GenericExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractGenericExporterFacade;
@@ -11,10 +11,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
-import javassist.util.proxy.ProxyObject;
 
 
 public class GenericExporterFacadeTest {
@@ -24,85 +20,55 @@ public class GenericExporterFacadeTest {
 	private IGenericExporter genericExporterFacade = null; 
 	private GenericExporter genericExporter = null;
 	
-	private String methodName = null;
-	private Object[] arguments = null;
-	
 	@BeforeEach
-	public void setUp() throws Exception {
-		ProxyFactory proxyFactory = new ProxyFactory();
-		proxyFactory.setSuperclass(GenericExporter.class);
-		Class<?> proxyClass = proxyFactory.createClass();
-		genericExporter = (GenericExporter)proxyClass.newInstance();
-		((ProxyObject)genericExporter).setHandler(new MethodHandler() {		
-			@Override
-			public Object invoke(
-					Object self, 
-					Method m, 
-					Method proceed, 
-					Object[] args) throws Throwable {
-				if (methodName == null) {
-					methodName = m.getName();
-				}
-				if (arguments == null) {
-					arguments = args;
-				}
-				return proceed.invoke(self, args);
-			}
-		});
+	public void beforeEach() {
+		genericExporter = new GenericExporter();
 		genericExporterFacade = new AbstractGenericExporterFacade(FACADE_FACTORY, genericExporter) {};
-		reset();
 	}
 	
 	@Test
-	public void testSetFilePattern() {
-		genericExporter.setFilePattern("barfoo");
-		assertEquals("barfoo", genericExporter.getFilePattern());
-		reset();
+	public void testSetFilePattern() throws Exception {
+		Field filePatternField = GenericExporter.class.getDeclaredField("filePattern");
+		filePatternField.setAccessible(true);
+		assertNotEquals("foobar", filePatternField.get(genericExporter));
 		genericExporterFacade.setFilePattern("foobar");
-		assertEquals("setFilePattern", methodName);
-		assertArrayEquals(new Object[] { "foobar" }, arguments);
-		assertEquals("foobar", genericExporter.getFilePattern());
+		assertEquals("foobar", filePatternField.get(genericExporter));
 	}
 	
 	@Test
-	public void testSetTemplate() {
-		genericExporter.setTemplateName("barfoo");
-		assertEquals("barfoo", genericExporter.getTemplateName());
-		reset();
-		genericExporterFacade.setTemplateName("foobar");
-		assertEquals("setTemplateName", methodName);
-		assertArrayEquals(new Object[] { "foobar" }, arguments);
-		assertEquals("foobar", genericExporter.getTemplateName());
+	public void testSetTemplate() throws Exception {
+		Field templateNameField = GenericExporter.class.getDeclaredField("templateName");
+		templateNameField.setAccessible(true);
+		assertNotEquals("barfoo", templateNameField.get(genericExporter));
+		genericExporterFacade.setTemplateName("barfoo");
+		assertEquals("barfoo", templateNameField.get(genericExporter));
 	}
 	
 	@Test
-	public void testSetForEach() {
+	public void testSetForEach() throws Exception {
+		Field forEachField = GenericExporter.class.getDeclaredField("forEach");
+		forEachField.setAccessible(true);
+		assertNotEquals("foobar", forEachField.get(genericExporter));
 		genericExporterFacade.setForEach("foobar");
-		assertEquals("setForEach", methodName);
-		assertArrayEquals(new Object[] { "foobar" }, arguments);
+		assertEquals("foobar", forEachField.get(genericExporter));
 	}
 	
 	@Test
-	public void testGetFilePattern() {
-		genericExporter.setFilePattern("foobar");
-		reset();
+	public void testGetFilePattern() throws Exception {
+		Field filePatternField = GenericExporter.class.getDeclaredField("filePattern");
+		filePatternField.setAccessible(true);
+		assertNotEquals("foobar", genericExporterFacade.getFilePattern());
+		filePatternField.set(genericExporter, "foobar");
 		assertEquals("foobar", genericExporterFacade.getFilePattern());
-		assertEquals("getFilePattern", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
 	}
 	
 	@Test
-	public void testGetTemplateName() {
-		genericExporter.setTemplateName("foobar");
-		reset();
+	public void testGetTemplateName() throws Exception {
+		Field templateNameField = GenericExporter.class.getDeclaredField("templateName");
+		templateNameField.setAccessible(true);
+		assertNotEquals("foobar", genericExporterFacade.getTemplateName());
+		templateNameField.set(genericExporter, "foobar");
 		assertEquals("foobar", genericExporterFacade.getTemplateName());
-		assertEquals("getTemplateName", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-	}
-	
-	private void reset() {
-		methodName = null;
-		arguments = null;
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/Hbm2DDLExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/Hbm2DDLExporterFacadeTest.java
@@ -1,75 +1,52 @@
 package org.jboss.tools.hibernate.runtime.v_5_4.internal;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.util.Properties;
 
+import org.hibernate.tool.hbm2x.AbstractExporter;
 import org.hibernate.tool.hbm2x.Hbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractHbm2DDLExporterFacade;
-import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
-import javassist.util.proxy.ProxyObject;
-
 
 public class Hbm2DDLExporterFacadeTest {
 
-	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
 	
-	private IHbm2DDLExporter hbm2DDLExporterFacade = null; 
-	private Hbm2DDLExporter hbm2ddlExporter = null;
+	private IHbm2DDLExporter ddlExporterFacade = null;
+	private Hbm2DDLExporter ddlExporterTarget = null;
 	
-	private String methodName = null;
-	private Object[] arguments = null;
 	
 	@BeforeEach
-	public void beforeEach() throws Exception {
-		ProxyFactory proxyFactory = new ProxyFactory();
-		proxyFactory.setSuperclass(Hbm2DDLExporter.class);
-		Class<?> proxyClass = proxyFactory.createClass();
-		hbm2ddlExporter = (Hbm2DDLExporter)proxyClass.newInstance();
-		((ProxyObject)hbm2ddlExporter).setHandler(new MethodHandler() {		
-			@Override
-			public Object invoke(
-					Object self, 
-					Method m, 
-					Method proceed, 
-					Object[] args) throws Throwable {
-				if (methodName == null) {
-					methodName = m.getName();
-				}
-				if (arguments == null) {
-					arguments = args;
-				}
-				return proceed.invoke(self, args);
-			}
-		});
-		hbm2DDLExporterFacade = new AbstractHbm2DDLExporterFacade(FACADE_FACTORY, hbm2ddlExporter) {};
-		reset();
+	public void before() {
+		ddlExporterTarget = new Hbm2DDLExporter();
+		ddlExporterFacade = new AbstractHbm2DDLExporterFacade(FACADE_FACTORY, ddlExporterTarget) {};
+	}
+	
+	@Test 
+	public void testGetProperties() throws Exception {
+		Field propertiesField = AbstractExporter.class.getDeclaredField("properties");
+		propertiesField.setAccessible(true);
+		Properties properties = new Properties();
+		assertNotSame(properties, ddlExporterFacade.getProperties());
+		propertiesField.set(ddlExporterTarget, properties);
+		assertSame(properties, ddlExporterFacade.getProperties());
 	}
 	
 	@Test
-	public void testSetExport() {
-		hbm2DDLExporterFacade.setExport(true);
-		assertEquals("setExport", methodName);
-		assertArrayEquals(new Object[] { true }, arguments);
+	public void testSetExport() throws Exception {
+		Field exportToDatabaseField = Hbm2DDLExporter.class.getDeclaredField("exportToDatabase");
+		exportToDatabaseField.setAccessible(true);
+		assertTrue((Boolean)exportToDatabaseField.get(ddlExporterTarget));
+		ddlExporterFacade.setExport(false);
+		assertFalse((Boolean)exportToDatabaseField.get(ddlExporterTarget));
 	}
-	
-	@Test
-	public void testGetProperties() {
-		hbm2DDLExporterFacade.getProperties();
-		assertEquals("getProperties", methodName);
-		assertArrayEquals(new Object[] {}, arguments);
-	}
-	
-	private void reset() {
-		methodName = null;
-		arguments = null;
-	}
-	
+
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>