### PR TITLE
JBIDE-28159: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_4' - Remove unneeded Maven dependency on 'com.sun.istack:istack-commons-runtime:3.0.7'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/hibernate-commons-annotations-5.1.2.Final.jar,
  lib/hibernate-core-5.4.32.Final.jar,
- lib/hibernate-tools-5.4.32.Final.jar,
- lib/istack-commons-runtime-3.0.7.jar
+ lib/hibernate-tools-5.4.32.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -14,7 +14,6 @@
 	<properties>
 		<hibernate.version>5.4.32.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
-		<istack-commons-runtime.version>3.0.7</istack-commons-runtime.version>
 	</properties>
 
 	<build>
@@ -48,11 +47,6 @@
 							<artifactId>hibernate-commons-annotations</artifactId>
 							<version>${hibernate-commons-annotations.version}</version>
 						</artifactItem>
- 						<artifactItem>
-							<groupId>com.sun.istack</groupId>
-							<artifactId>istack-commons-runtime</artifactId>
-							<version>${istack-commons-runtime.version}</version>
-						</artifactItem> 
 					</artifactItems>
 					<skip>false</skip>
 					<outputDirectory>${basedir}/lib</outputDirectory>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>