### PR TITLE
JBIDE-28171: Use the 5.6 runtime to run the tests in 'org.jboss.toolshibernate.orm.test'

### DIFF
--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -38,7 +38,7 @@ Require-Bundle: org.hibernate.eclipse,
  org.hibernate.eclipse.mapper,
  org.eclipse.gef,
  org.hibernate.eclipse.jdt.ui,
- org.jboss.tools.hibernate.runtime.v_5_5
+ org.jboss.tools.hibernate.runtime.v_5_6
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.util


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>