### PR TITLE
JBIDE-28172: Improve the tests of the 5.4 runtime plugin - Remove 'hibernate.properties' file and adapt test class 'org.jboss.tools.hibernate.runtime.v_5_4.internal.EntityMetamodelFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/hibernate.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/hibernate.properties
@@ -1,1 +1,0 @@
-hibernate.dialect org.hibernate.dialect.H2Dialect

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/EntityMetamodelFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/EntityMetamodelFacadeTest.java
@@ -89,11 +89,6 @@ public class EntityMetamodelFacadeTest {
 		return rc;
 	}
 	
-	private SessionFactoryImplementor createSessionFactoryImplementor() {
-		MetadataSources metadataSources = new MetadataSources();
-		return (SessionFactoryImplementor)metadataSources.buildMetadata().buildSessionFactory();
-	}
-		
 	private EntityMetamodel createFooBarModel() {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
@@ -115,7 +110,11 @@ public class EntityMetamodelFacadeTest {
 						metadataBuildingOptions, 
 						inFlightMetadataCollector);
 		PersistentClass persistentClass = createPersistentClass(metadataBuildingContext);
-		SessionFactoryImplementor sessionFactoryImplementor = createSessionFactoryImplementor();
+		MetadataSources metadataSources = new MetadataSources(serviceRegistry);
+		SessionFactoryImplementor sessionFactoryImplementor = 
+				(SessionFactoryImplementor)metadataSources
+					.buildMetadata()
+					.buildSessionFactory();
 		return  new EntityMetamodel(persistentClass, null, sessionFactoryImplementor) {
 			private static final long serialVersionUID = 1L;
 			@Override public EntityTuplizer getTuplizer() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>