### PR TITLE
JBIDE-28092: Update the execution environment of the JBoss Tools plugins to Java 11 - Perform changes for org.jboss.tools.hibernate.runtime.v_5_1.test

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Hibernate Runtime 5.1 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_1.test
 Bundle-Version: 5.4.15.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0"
 Bundle-ClassPath: .,
  lib/h2-1.4.200.jar


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>