### PR TITLE
JBIDE-28198: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_5_3 to version 5.3.24.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-core-5.3.23.Final.jar,
- lib/hibernate-tools-5.3.23.Final.jar
+ lib/hibernate-core-5.3.24.Final.jar,
+ lib/hibernate-tools-5.3.24.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>5.3.23.Final</hibernate.version>
+		<hibernate.version>5.3.24.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("5.3.23.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("5.3.24.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test
 	public void testCoreVersion() {
-		assertEquals("5.3.23.Final", org.hibernate.Version.getVersionString());
+		assertEquals("5.3.24.Final", org.hibernate.Version.getVersionString());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>