### PR TITLE
JBIDE-28200: Add the tests of the 5.0 runtime plugin - Remove unneeded plugin dependency on 'org.junit'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-Version: 5.4.15.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,
- org.junit,
  org.junit.jupiter.api
 Bundle-ClassPath: .


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>