### PR TITLE
JBIDE-28215: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_0' - Replace dependency on Maven module 'org.apache.geronimo.specs:geronimo-jta_1.1_spec:1.1.1' by plugin dependency on 'org.jboss.tools.hibernate.libs.transaction-api.v_1_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/geronimo-jta_1.1_spec-1.1.1.jar,
  lib/hibernate-commons-annotations-5.0.1.Final.jar,
  lib/hibernate-core-5.0.12.Final.jar,
  lib/hibernate-entitymanager-5.0.12.Final.jar,
@@ -26,5 +25,6 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0,
  org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
+ org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>
 		<hibernate.version>5.0.12.Final</hibernate.version>
 		<hibernate-commons-annotations.version>5.0.1.Final</hibernate-commons-annotations.version>
 		<hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
@@ -78,11 +77,6 @@
 							<groupId>org.jboss.logging</groupId>
 							<artifactId>jboss-logging</artifactId>
 							<version>${jboss-logging.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.apache.geronimo.specs</groupId>
-							<artifactId>geronimo-jta_1.1_spec</artifactId>
-							<version>${geronimo-jta_1.1_spec.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>