### PR TITLE
JBIDE-28276: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_5_2 to version 5.2.13.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
@@ -6,12 +6,12 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/hibernate-core-5.2.18.Final.jar,
- lib/hibernate-tools-5.2.12.Final.jar,
+ lib/hibernate-tools-5.2.13.Final.jar,
  .
-Require-Bundle: org.apache.commons.collections,
- org.apache.commons.logging,
+Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.commons-collections4.v_4_4;bundle-version="5.4.15",
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
@@ -13,7 +13,7 @@
 
 	<properties>
 		<hibernate.version>5.2.18.Final</hibernate.version>
-		<hibernate-tools.version>5.2.12.Final</hibernate-tools.version>
+		<hibernate-tools.version>5.2.13.Final</hibernate-tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("5.2.12.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("5.2.13.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>