### PR TITLE
JBIDE-28215: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_0' - Remove unneeded dependency on Maven module 'org.slf4j:slf4j-api:1.6.1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Bundle-ClassPath: .,
  lib/hibernate-tools-5.0.7.Final.jar,
  lib/javassist-3.18.1-GA.jar,
  lib/jaxb-impl-2.3.0.jar,
- lib/jboss-logging-3.3.0.Final.jar,
- lib/slf4j-api-1.6.1.jar
+ lib/jboss-logging-3.3.0.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -19,7 +19,6 @@
 		<javassist.version>3.18.1-GA</javassist.version>
 	    <jaxb.version>2.3.0</jaxb.version>
 		<jboss-logging.version>3.3.0.Final</jboss-logging.version>
-		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
 	<build>
@@ -77,11 +76,6 @@
 							<groupId>org.jboss.logging</groupId>
 							<artifactId>jboss-logging</artifactId>
 							<version>${jboss-logging.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-api</artifactId>
-							<version>${slf4j.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>