### PR TITLE
JBIDE-28215: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_0' - Replace dependency on Maven module 'org.hibernate.common:hibernate-commons-annotations:5.0.1.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-commons-annotations-5.0.1.Final.jar,
  lib/hibernate-core-5.0.12.Final.jar,
  lib/hibernate-entitymanager-5.0.12.Final.jar,
  lib/hibernate-jpa-2.1-api-1.0.0.Final.jar,
@@ -19,6 +18,7 @@ Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0,
  org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -13,7 +13,6 @@
 
 	<properties>
 		<hibernate.version>5.0.12.Final</hibernate.version>
-		<hibernate-commons-annotations.version>5.0.1.Final</hibernate-commons-annotations.version>
 		<hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
 		<hibernate-tools.version>5.0.7.Final</hibernate-tools.version>
 	    <jaxb.version>2.3.0</jaxb.version>
@@ -35,11 +34,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>org.hibernate.common</groupId>
-							<artifactId>hibernate-commons-annotations</artifactId>
-							<version>${hibernate-commons-annotations.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>