### PR TITLE
JBIDE-28215: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_5_0' - Replace dependency on Maven module 'com.sun.xml.bind:jaxb-impl:2.3.0' by plugin dependency on 'org.jboss.tools.hibernate.libs.jaxb.v_2_3'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -9,8 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/hibernate-core-5.0.12.Final.jar,
  lib/hibernate-entitymanager-5.0.12.Final.jar,
- lib/hibernate-tools-5.0.7.Final.jar,
- lib/jaxb-impl-2.3.0.jar
+ lib/hibernate-tools-5.0.7.Final.jar
 Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
@@ -19,6 +18,7 @@ Require-Bundle: org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
+ org.jboss.tools.hibernate.libs.jaxb.v_2_3,
  org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0,
  org.jboss.tools.hibernate.libs.jaxb-core.v_2_3_0,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -12,9 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>5.0.12.Final</hibernate.version>
-		<hibernate-tools.version>5.0.7.Final</hibernate-tools.version>
-	    <jaxb.version>2.3.0</jaxb.version>
+		<hibernate.core.version>5.0.12.Final</hibernate.core.version>
+		<hibernate.tools.version>5.0.7.Final</hibernate.tools.version>
 	</properties>
 
 	<build>
@@ -36,23 +35,18 @@
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>
-							<version>${hibernate.version}</version>
+							<version>${hibernate.core.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-entitymanager</artifactId>
-							<version>${hibernate.version}</version>
+							<version>${hibernate.core.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-tools</artifactId>
-							<version>${hibernate-tools.version}</version>
+							<version>${hibernate.tools.version}</version>
 						</artifactItem>
- 						<artifactItem>
-							<groupId>com.sun.xml.bind</groupId>
-							<artifactId>jaxb-impl</artifactId>
-							<version>${jaxb.version}</version>
-						</artifactItem> 
 					</artifactItems>
 					<skip>false</skip>
 					<outputDirectory>${basedir}/lib</outputDirectory>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>