### PR TITLE
JBIDE-28092: Update the execution environment of the JBoss Tools plugins to Java 11 - Perform changes for org.jboss.tools.hibernate.runtime.v_4_3

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.common;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/commons-logging-1.1.1.jar,
  lib/hibernate-commons-annotations-4.0.5.Final.jar,


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>