### PR TITLE
JBIDE-28200: Improve the tests of the 5.0 runtime plugin - Implementation class 'org.jboss.hibernate.tool.runtime.v_5_0.internal.PersistentClassFacadeImpl' needs to be used in test class 'org.jboss.tools.hibernate.runtime.v_5_0.internal.PersistentClassFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/PersistentClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/PersistentClassFacadeTest.java
@@ -520,15 +520,15 @@ public class PersistentClassFacadeTest {
 	
 	@Test
 	public void testIsInherited() {
-		persistentClassFacade = new AbstractPersistentClassFacade(FACADE_FACTORY, new RootClass(null)) {};
+		persistentClassFacade = new PersistentClassFacadeImpl(FACADE_FACTORY, new RootClass(null));
 		assertFalse(persistentClassFacade.isInherited());
-		persistentClassFacade = new AbstractPersistentClassFacade(FACADE_FACTORY, new Subclass(new RootClass(null), null)) {};
+		persistentClassFacade = new PersistentClassFacadeImpl(FACADE_FACTORY, new Subclass(new RootClass(null), null));
 		assertTrue(persistentClassFacade.isInherited());
 	}
 	
 	@Test
 	public void testIsJoinedSubclass() {
-		persistentClassFacade = new AbstractPersistentClassFacade(FACADE_FACTORY, new RootClass(null)) {};
+		persistentClassFacade = new PersistentClassFacadeImpl(FACADE_FACTORY, new RootClass(null));
 		assertFalse(persistentClassFacade.isJoinedSubclass());
 		Table rootTable = new Table();
 		Table subTable = new Table();
@@ -536,7 +536,7 @@ public class PersistentClassFacadeTest {
 		rootClass.setTable(rootTable);
 		JoinedSubclass subclass = new JoinedSubclass(rootClass, null);
 		subclass.setTable(subTable);
-		persistentClassFacade = new AbstractPersistentClassFacade(FACADE_FACTORY, subclass) {};
+		persistentClassFacade = new PersistentClassFacadeImpl(FACADE_FACTORY, subclass);
 		assertTrue(persistentClassFacade.isJoinedSubclass());
 		subclass.setTable(rootTable);
 		assertFalse(persistentClassFacade.isJoinedSubclass());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>