### PR TITLE
JBIDE-27439: Improve the tests or the 6.0 runtime plugin - Implementation class 'org.jboss.hibernate.tool.runtime.v_6_0.internal.PersistentClassFacadeImpl' needs to be used in test class 'org.jboss.tools.hibernate.runtime.v_6_0.internal.PersistentClassFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/PersistentClassFacadeTest.java
@@ -530,25 +530,25 @@ public class PersistentClassFacadeTest {
 	@Test
 	public void testIsInherited() {
 		persistentClassFacade = 
-				new AbstractPersistentClassFacade(
+				new PersistentClassFacadeImpl(
 						FACADE_FACTORY, 
-						new RootClass(DummyMetadataBuildingContext.INSTANCE)) {};
+						new RootClass(DummyMetadataBuildingContext.INSTANCE));
 		assertFalse(persistentClassFacade.isInherited());
 		persistentClassFacade = 
-				new AbstractPersistentClassFacade(
+				new PersistentClassFacadeImpl(
 						FACADE_FACTORY,
 						new Subclass(
 								new RootClass(DummyMetadataBuildingContext.INSTANCE), 
-								DummyMetadataBuildingContext.INSTANCE)) {};
+								DummyMetadataBuildingContext.INSTANCE));
 		assertTrue(persistentClassFacade.isInherited());
 	}
 	
 	@Test
 	public void testIsJoinedSubclass() {
 		persistentClassFacade = 
-				new AbstractPersistentClassFacade(
+				new PersistentClassFacadeImpl(
 						FACADE_FACTORY, 
-						new RootClass(DummyMetadataBuildingContext.INSTANCE)) {};
+						new RootClass(DummyMetadataBuildingContext.INSTANCE));
 		assertFalse(persistentClassFacade.isJoinedSubclass());
 		Table rootTable = new Table();
 		Table subTable = new Table();
@@ -556,7 +556,7 @@ public class PersistentClassFacadeTest {
 		rootClass.setTable(rootTable);
 		JoinedSubclass subclass = new JoinedSubclass(rootClass, DummyMetadataBuildingContext.INSTANCE);
 		subclass.setTable(subTable);
-		persistentClassFacade = new AbstractPersistentClassFacade(FACADE_FACTORY, subclass) {};
+		persistentClassFacade = new PersistentClassFacadeImpl(FACADE_FACTORY, subclass);
 		assertTrue(persistentClassFacade.isJoinedSubclass());
 		subclass.setTable(rootTable);
 		assertFalse(persistentClassFacade.isJoinedSubclass());


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>