### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Replace dependency on Maven module 'commons-logging:commons-logging:1.1.1' by plugin dependency on 'org.apache.commons.logging'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3;singleton:=true
 Bundle-Version: 5.4.15.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
+ org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23;bundle-version="5.0.0",
@@ -14,7 +15,6 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/commons-logging-1.1.1.jar,
  lib/hibernate-commons-annotations-4.0.5.Final.jar,
  lib/hibernate-core-4.3.11.Final.jar,
  lib/hibernate-entitymanager-4.3.11.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/build.properties
@@ -4,6 +4,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties,\
-               lib/,\
-               lib/hibernate-tools-4.3.5.Final.jar
-               
+               lib/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<commons-logging.version>1.1.1</commons-logging.version>
 		<hibernate.version>4.3.11.Final</hibernate.version>
 		<hibernate-commons-annotations.version>4.0.5.Final</hibernate-commons-annotations.version>
 		<hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
@@ -40,11 +39,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>commons-logging</groupId>
-							<artifactId>commons-logging</artifactId>
-							<version>${commons-logging.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.common</groupId>
 							<artifactId>hibernate-commons-annotations</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>