### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Replace dependency on Maven module 'org.javassist:javassist:3.18.1-GA' by plugin dependency on 'org.jboss.tools.hibernate.libs.javassist.v_3_28'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.common;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
@@ -23,5 +24,4 @@ Bundle-ClassPath: .,
  lib/jboss-logging-3.1.3.GA.jar,
  lib/jboss-transaction-api_1.2_spec-1.0.0.Final.jar,
  lib/jandex-1.1.0.Final.jar,
- lib/javassist-3.18.1-GA.jar,
  lib/slf4j-api-1.6.1.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -19,7 +19,6 @@
 		<jboss-logging.version>3.1.3.GA</jboss-logging.version>
 		<jboss-transaction-api_1.2_spec.version>1.0.0.Final</jboss-transaction-api_1.2_spec.version>
 		<jandex.version>1.1.0.Final</jandex.version>
-		<javassist.version>3.18.1-GA</javassist.version>
 		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
@@ -78,11 +77,6 @@
 							<groupId>org.jboss</groupId>
 							<artifactId>jandex</artifactId>
 							<version>${jandex.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.javassist</groupId>
-							<artifactId>javassist</artifactId>
-							<version>${javassist.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>