### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Replace dependency on Maven module '>org.slf4j:slf4j-api:1.6.1' by plugin dependency on 'org.slf4j.api'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.common;bundle-version="5.0.0",
- org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
+ org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/hibernate-commons-annotations-4.0.5.Final.jar,
@@ -23,5 +24,4 @@ Bundle-ClassPath: .,
  lib/hibernate-tools-4.3.5.Final.jar,
  lib/jboss-logging-3.1.3.GA.jar,
  lib/jboss-transaction-api_1.2_spec-1.0.0.Final.jar,
- lib/jandex-1.1.0.Final.jar,
- lib/slf4j-api-1.6.1.jar
+ lib/jandex-1.1.0.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -19,7 +19,6 @@
 		<jboss-logging.version>3.1.3.GA</jboss-logging.version>
 		<jboss-transaction-api_1.2_spec.version>1.0.0.Final</jboss-transaction-api_1.2_spec.version>
 		<jandex.version>1.1.0.Final</jandex.version>
-		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
 	<build>
@@ -77,11 +76,6 @@
 							<groupId>org.jboss</groupId>
 							<artifactId>jandex</artifactId>
 							<version>${jandex.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-api</artifactId>
-							<version>${slf4j.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>