### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Replace dependency on Maven module 'org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.0.Final' by plugin dependency on ' org.jboss.tools.hibernate.libs.transaction-api.v_1_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",
  org.slf4j.api
@@ -23,5 +24,4 @@ Bundle-ClassPath: .,
  lib/hibernate-entitymanager-4.3.11.Final.jar,
  lib/hibernate-jpa-2.1-api-1.0.0.Final.jar,
  lib/hibernate-tools-4.3.5.Final.jar,
- lib/jboss-logging-3.1.3.GA.jar,
- lib/jboss-transaction-api_1.2_spec-1.0.0.Final.jar
+ lib/jboss-logging-3.1.3.GA.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -17,7 +17,6 @@
 		<hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
 		<hibernate-tools.version>4.3.5.Final</hibernate-tools.version>
 		<jboss-logging.version>3.1.3.GA</jboss-logging.version>
-		<jboss-transaction-api_1.2_spec.version>1.0.0.Final</jboss-transaction-api_1.2_spec.version>
 	</properties>
 
 	<build>
@@ -65,11 +64,6 @@
 							<groupId>org.jboss.logging</groupId>
 							<artifactId>jboss-logging</artifactId>
 							<version>${jboss-logging.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.jboss.spec.javax.transaction</groupId>
-							<artifactId>jboss-transaction-api_1.2_spec</artifactId>
-							<version>${jboss-transaction-api_1.2_spec.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>