### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Replace dependency on Maven module 'org.hibernate.common:hibernate-commons-annotations:4.0.5.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.0.0",
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
@@ -21,7 +22,6 @@ Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-commons-annotations-4.0.5.Final.jar,
  lib/hibernate-core-4.3.11.Final.jar,
  lib/hibernate-entitymanager-4.3.11.Final.jar,
  lib/hibernate-tools-4.3.5.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -13,7 +13,6 @@
 
 	<properties>
 		<hibernate.version>4.3.11.Final</hibernate.version>
-		<hibernate-commons-annotations.version>4.0.5.Final</hibernate-commons-annotations.version>
 		<hibernate-tools.version>4.3.5.Final</hibernate-tools.version>
 	</properties>
 
@@ -33,11 +32,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>org.hibernate.common</groupId>
-							<artifactId>hibernate-commons-annotations</artifactId>
-							<version>${hibernate-commons-annotations.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>