### PR TITLE
JBIDE-28295: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_3' - Cleanup 'MANIFEST.MF' file

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -5,20 +5,20 @@ Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3;singleton:=true
 Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
-Require-Bundle: org.apache.commons.collections;bundle-version="3.2.0",
+Require-Bundle: org.apache.commons.collections,
  org.apache.commons.logging,
- org.jboss.tools.hibernate.libs.antlr.v_2_7_7;bundle-version="5.0.0",
- org.jboss.tools.hibernate.libs.dom4j.v_1_6_1;bundle-version="5.0.0",
- org.jboss.tools.hibernate.libs.freemarker.v_2_3_23;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+ org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
- org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
- org.jboss.tools.hibernate.runtime.common;bundle-version="5.0.0",
- org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",
+ org.jboss.tools.hibernate.runtime.common,
+ org.jboss.tools.hibernate.runtime.spi,
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>