### PR TITLE
JBIDE-28316: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_4_3 to version 4.3.6.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -5,9 +5,8 @@ Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3;singleton:=true
 Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
-Require-Bundle: org.apache.commons.collections,
- org.apache.commons.logging,
- org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+Require-Bundle: org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+ org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
@@ -18,10 +17,9 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
- org.jboss.tools.hibernate.runtime.spi,
- org.slf4j.api
+ org.jboss.tools.hibernate.runtime.spi
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/hibernate-core-4.3.11.Final.jar,
  lib/hibernate-entitymanager-4.3.11.Final.jar,
- lib/hibernate-tools-4.3.5.Final.jar
+ lib/hibernate-tools-4.3.6.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -13,7 +13,7 @@
 
 	<properties>
 		<hibernate.version>4.3.11.Final</hibernate.version>
-		<hibernate-tools.version>4.3.5.Final</hibernate-tools.version>
+		<hibernate-tools.version>4.3.6.Final</hibernate-tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("4.3.5.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("4.3.6.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>