### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'log4j:log4j:1.2.15' by plugin dependency on 'org.apache.log4j'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0;singleton:=true
 Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
+ org.apache.log4j,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
@@ -23,7 +24,6 @@ Bundle-ClassPath: .,
  lib/jboss-logging-3.1.0.CR2.jar,
  lib/jboss-transaction-api_1.1_spec-1.0.0.Final.jar,
  lib/javassist-3.12.1.GA.jar,
- lib/log4j-1.2.15.jar,
  lib/slf4j-api-1.5.8.jar,
  lib/slf4j-log4j12-1.5.8.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -20,7 +20,6 @@
 		<jboss-logging.version>3.1.0.CR2</jboss-logging.version>
 		<jboss-transaction-api_1.1_spec.version>1.0.0.Final</jboss-transaction-api_1.1_spec.version>
 		<javassist.version>3.12.1.GA</javassist.version>
-		<log4j.version>1.2.15</log4j.version>
 		<slf4j.version>1.5.8</slf4j.version>
 	</properties>
 
@@ -84,11 +83,6 @@
 							<groupId>javassist</groupId>
 							<artifactId>javassist</artifactId>
 							<version>${javassist.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>log4j</groupId>
-							<artifactId>log4j</artifactId>
-							<version>${log4j.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>