### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'org.slf4j:slf4j-api:1.5.8' by plugin dependency on 'org.slf4j.api'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
- org.hibernate.eclipse
+ org.hibernate.eclipse,
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/commons-logging-1.1.1.jar,
@@ -24,7 +25,6 @@ Bundle-ClassPath: .,
  lib/jboss-logging-3.1.0.CR2.jar,
  lib/jboss-transaction-api_1.1_spec-1.0.0.Final.jar,
  lib/javassist-3.12.1.GA.jar,
- lib/slf4j-api-1.5.8.jar,
  lib/slf4j-log4j12-1.5.8.jar
 Bundle-Vendor: Red Hat
 Eclipse-BundleShape: dir

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -86,11 +86,6 @@
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-api</artifactId>
-							<version>${slf4j.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
 							<artifactId>slf4j-log4j12</artifactId>
 							<version>${slf4j.version}</version>
 						</artifactItem>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>