### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Remove unneeded Maven dependency on 'org.slf4j:slf4j-log4j12:1.5.8'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -24,8 +24,7 @@ Bundle-ClassPath: .,
  lib/hibernate-tools-4.0.1.Final.jar,
  lib/jboss-logging-3.1.0.CR2.jar,
  lib/jboss-transaction-api_1.1_spec-1.0.0.Final.jar,
- lib/javassist-3.12.1.GA.jar,
- lib/slf4j-log4j12-1.5.8.jar
+ lib/javassist-3.12.1.GA.jar
 Bundle-Vendor: Red Hat
 Eclipse-BundleShape: dir
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -20,7 +20,6 @@
 		<jboss-logging.version>3.1.0.CR2</jboss-logging.version>
 		<jboss-transaction-api_1.1_spec.version>1.0.0.Final</jboss-transaction-api_1.1_spec.version>
 		<javassist.version>3.12.1.GA</javassist.version>
-		<slf4j.version>1.5.8</slf4j.version>
 	</properties>
 
 	<build>
@@ -83,11 +82,6 @@
 							<groupId>javassist</groupId>
 							<artifactId>javassist</artifactId>
 							<version>${javassist.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-log4j12</artifactId>
-							<version>${slf4j.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>