### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'javassist:javassist:3.12.1.GA' by plugin dependency on 'org.jboss.tools.hibernate.libs.javassist.v_3_28'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
@@ -23,8 +24,7 @@ Bundle-ClassPath: .,
  lib/hibernate-jpa-2.0-api-1.0.1.Final.jar,
  lib/hibernate-tools-4.0.1.Final.jar,
  lib/jboss-logging-3.1.0.CR2.jar,
- lib/jboss-transaction-api_1.1_spec-1.0.0.Final.jar,
- lib/javassist-3.12.1.GA.jar
+ lib/jboss-transaction-api_1.1_spec-1.0.0.Final.jar
 Bundle-Vendor: Red Hat
 Eclipse-BundleShape: dir
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -19,7 +19,6 @@
 		<hibernate-tools.version>4.0.1.Final</hibernate-tools.version>
 		<jboss-logging.version>3.1.0.CR2</jboss-logging.version>
 		<jboss-transaction-api_1.1_spec.version>1.0.0.Final</jboss-transaction-api_1.1_spec.version>
-		<javassist.version>3.12.1.GA</javassist.version>
 	</properties>
 
 	<build>
@@ -77,11 +76,6 @@
 							<groupId>org.jboss.spec.javax.transaction</groupId>
 							<artifactId>jboss-transaction-api_1.1_spec</artifactId>
 							<version>${jboss-transaction-api_1.1_spec.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>javassist</groupId>
-							<artifactId>javassist</artifactId>
-							<version>${javassist.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>