### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'org.jboss.logging:jboss-logging:3.1.0.CR2' by plugin dependency on 'org.jboss.tools.hibernate.libs.jboss-logging.v_3_4'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
+ org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
@@ -23,8 +24,7 @@ Bundle-ClassPath: .,
  lib/hibernate-core-4.0.1.Final.jar,
  lib/hibernate-entitymanager-4.0.1.Final.jar,
  lib/hibernate-jpa-2.0-api-1.0.1.Final.jar,
- lib/hibernate-tools-4.0.1.Final.jar,
- lib/jboss-logging-3.1.0.CR2.jar
+ lib/hibernate-tools-4.0.1.Final.jar
 Bundle-Vendor: Red Hat
 Eclipse-BundleShape: dir
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -17,7 +17,6 @@
 		<hibernate-commons-annotations.version>4.0.1.Final</hibernate-commons-annotations.version>
 		<hibernate-jpa-2.0-api.version>1.0.1.Final</hibernate-jpa-2.0-api.version>
 		<hibernate-tools.version>4.0.1.Final</hibernate-tools.version>
-		<jboss-logging.version>3.1.0.CR2</jboss-logging.version>
 	</properties>
 
 	<build>
@@ -65,11 +64,6 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-tools</artifactId>
 							<version>${hibernate-tools.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.jboss.logging</groupId>
-							<artifactId>jboss-logging</artifactId>
-							<version>${jboss-logging.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>