### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.1.Final' by plugin dependency on 'org.jboss.tools.hibernate.libs.jpa.v_2_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
+ org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
@@ -23,7 +24,6 @@ Bundle-ClassPath: .,
  lib/hibernate-commons-annotations-4.0.1.Final.jar,
  lib/hibernate-core-4.0.1.Final.jar,
  lib/hibernate-entitymanager-4.0.1.Final.jar,
- lib/hibernate-jpa-2.0-api-1.0.1.Final.jar,
  lib/hibernate-tools-4.0.1.Final.jar
 Bundle-Vendor: Red Hat
 Eclipse-BundleShape: dir

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/build.properties
@@ -4,5 +4,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties,\
-               lib/,\
-               lib/hibernate-tools-4.0.1.Final.jar
+               lib/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -15,7 +15,6 @@
 		<commons-logging.version>1.1.1</commons-logging.version>
 		<hibernate.version>4.0.1.Final</hibernate.version>
 		<hibernate-commons-annotations.version>4.0.1.Final</hibernate-commons-annotations.version>
-		<hibernate-jpa-2.0-api.version>1.0.1.Final</hibernate-jpa-2.0-api.version>
 		<hibernate-tools.version>4.0.1.Final</hibernate-tools.version>
 	</properties>
 
@@ -54,11 +53,6 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-entitymanager</artifactId>
 							<version>${hibernate.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.hibernate.javax.persistence</groupId>
-							<artifactId>hibernate-jpa-2.0-api</artifactId>
-							<version>${hibernate-jpa-2.0-api.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>