### PR TITLE
JBIDE-28313: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_4_0' - Replace Maven dependency on 'commons-logging:commons-logging:1.1.1' by plugin dependency on 'org.apache.commons.logging'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0;singleton:=true
 Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
+ org.apache.commons.logging,
  org.apache.log4j,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
@@ -21,7 +22,6 @@ Require-Bundle: org.apache.commons.collections,
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/commons-logging-1.1.1.jar,
  lib/hibernate-core-4.0.1.Final.jar,
  lib/hibernate-entitymanager-4.0.1.Final.jar,
  lib/hibernate-tools-4.0.1.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<commons-logging.version>1.1.1</commons-logging.version>
 		<hibernate.version>4.0.1.Final</hibernate.version>
 		<hibernate-tools.version>4.0.1.Final</hibernate-tools.version>
 	</properties>
@@ -33,11 +32,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>commons-logging</groupId>
-							<artifactId>commons-logging</artifactId>
-							<version>${commons-logging.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>