### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Perform changes for 'org.jboss.tools.hibernate.runtime.v_3_6.test'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_6.test
 Bundle-Version: 5.4.16.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_6
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-ClassPath: .,
- lib/h2-1.4.200.jar
+Require-Bundle: org.junit;bundle-version="4.12.0",
+ org.jboss.tools.hibernate.libs.h2.v_1_4
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
@@ -13,30 +13,6 @@
 	
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>get-libs</id>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<phase>generate-resources</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<artifactItems>
-						<artifactItem>
-							<groupId>com.h2database</groupId>
-							<artifactId>h2</artifactId>
-							<version>${h2.version}</version>
-						</artifactItem>
-					</artifactItems>
-					<skip>false</skip>
-					<outputDirectory>${basedir}/lib</outputDirectory>
-				</configuration>
-			</plugin>
 			<plugin> 
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
@@ -46,16 +22,6 @@
 						<include>**/*Test.class</include>
 					</includes>
 					<skip>${skipTests}</skip>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>${basedir}/lib</directory>
-						</fileset>
-					</filesets>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ConfigurationFacadeTest.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 
+import org.h2.Driver;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.DefaultNamingStrategy;
@@ -32,6 +33,7 @@ import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.helpers.DefaultHandler;
@@ -75,6 +77,11 @@ public class ConfigurationFacadeTest {
 
 	private IConfiguration configurationFacade = null;
 	private Configuration configuration = null;
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		DriverManager.registerDriver(new Driver());
+	}
 
 	@Before
 	public void setUp() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/SchemaExportFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/SchemaExportFacadeTest.java
@@ -5,6 +5,7 @@ import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 
+import org.h2.Driver;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
@@ -12,6 +13,7 @@ import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -40,6 +42,11 @@ public class SchemaExportFacadeTest {
 	private File fooFile;
 	private Configuration configuration;
 	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		DriverManager.registerDriver(new Driver());
+	}
+
 	@Before
 	public void before() throws Exception {
 		File folder = temporaryFolder.getRoot();

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/ServiceImplTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.h2.Driver;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.reveng.DefaultReverseEngineeringStrategy;
 import org.hibernate.mapping.Table;
@@ -18,6 +19,7 @@ import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IProgressListener;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ServiceImplTest {
@@ -25,6 +27,11 @@ public class ServiceImplTest {
 	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
 	
 	private ServiceImpl service = new ServiceImpl();
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		DriverManager.registerDriver(new Driver());
+	}
 
 	@Test
 	public void testNewAnnotationConfiguration() {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>