### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Some cleanup in 'org.jboss.tools.hibernate.runtime.v_4_0.test'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
@@ -24,16 +24,6 @@
 					<skip>${skipTests}</skip>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>${basedir}/lib</directory>
-						</fileset>
-					</filesets>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>