### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Some cleanup in 'org.jboss.tools.hibernate.runtime.v_4_3.test'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
@@ -17,30 +17,6 @@
 	
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>get-libs</id>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<phase>generate-resources</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<artifactItems>
-						<artifactItem>
-							<groupId>com.h2database</groupId>
-							<artifactId>h2</artifactId>
-							<version>${h2.version}</version>
-						</artifactItem>
-					</artifactItems>
-					<skip>false</skip>
-					<outputDirectory>${basedir}/lib</outputDirectory>
-				</configuration>
-			</plugin>
 			<plugin> 
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
@@ -50,16 +26,6 @@
 						<include>**/*Test.class</include>
 					</includes>
 					<skip>${skipTests}</skip>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>${basedir}/lib</directory>
-						</fileset>
-					</filesets>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>