### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Remove the Maven dependency on 'log4j:log4j:1.2.15'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -25,6 +25,5 @@ Bundle-ClassPath: .,
  lib/javassist-3.12.0.GA.jar,
  lib/jta-1.1.jar,
  lib/log4j-1.2.15.jar,
- lib/slf4j-api-1.6.1.jar,
- lib/slf4j-log4j12-1.6.1.jar
+ lib/slf4j-api-1.6.1.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -21,7 +21,6 @@
 		<hibernate-tools.version>3.6.0.Final</hibernate-tools.version>
 		<javassist.version>3.12.0.GA</javassist.version>
 		<jta.version>1.1</jta.version>
-		<log4j.version>1.2.15</log4j.version>
 		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
@@ -90,11 +89,6 @@
 							<groupId>javax.transaction</groupId>
 							<artifactId>jta</artifactId>
 							<version>${jta.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>log4j</groupId>
-							<artifactId>log4j</artifactId>
-							<version>${log4j.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>