### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Replace the Maven dependency on 'org.slf4j:slf4j-api:1.6.1' and on 'org.slf4j:slf4j-log4j12:1.6.1' by eclipse plugin dependency on 'org.slf4j.api'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
- org.hibernate.eclipse
+ org.hibernate.eclipse,
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/asm-3.1.jar,
@@ -23,7 +24,5 @@ Bundle-ClassPath: .,
  lib/hibernate-jpa-2.0-api-1.0.1.Final.jar,
  lib/hibernate-tools-3.6.0.Final.jar,
  lib/javassist-3.12.0.GA.jar,
- lib/jta-1.1.jar,
- lib/log4j-1.2.15.jar,
- lib/slf4j-api-1.6.1.jar
+ lib/jta-1.1.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -21,7 +21,6 @@
 		<hibernate-tools.version>3.6.0.Final</hibernate-tools.version>
 		<javassist.version>3.12.0.GA</javassist.version>
 		<jta.version>1.1</jta.version>
-		<slf4j.version>1.6.1</slf4j.version>
 	</properties>
 
 	<build>
@@ -89,16 +88,6 @@
 							<groupId>javax.transaction</groupId>
 							<artifactId>jta</artifactId>
 							<version>${jta.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-api</artifactId>
-							<version>${slf4j.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-log4j12</artifactId>
-							<version>${slf4j.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>