### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Replace the Maven dependency on 'javassist:javassist:3.12.0.GA' by eclipse plugin dependency on 'org.jboss.tools.hibernate.libs.javassist.v_3_28'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
@@ -23,6 +24,5 @@ Bundle-ClassPath: .,
  lib/hibernate-core-3.6.10.Final.jar,
  lib/hibernate-entitymanager-3.6.10.Final.jar,
  lib/hibernate-jpa-2.0-api-1.0.1.Final.jar,
- lib/hibernate-tools-3.6.0.Final.jar,
- lib/javassist-3.12.0.GA.jar
+ lib/hibernate-tools-3.6.0.Final.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -19,7 +19,6 @@
 		<hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
 		<hibernate-jpa-2.0-api.version>1.0.1.Final</hibernate-jpa-2.0-api.version>
 		<hibernate-tools.version>3.6.0.Final</hibernate-tools.version>
-		<javassist.version>3.12.0.GA</javassist.version>
 	</properties>
 
 	<build>
@@ -77,11 +76,6 @@
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-tools</artifactId>
 							<version>${hibernate-tools.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>javassist</groupId>
-							<artifactId>javassist</artifactId>
-							<version>${javassist.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>