### PR TITLE
JBIDE-28352: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_3_6 to version 3.6.2.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -24,5 +24,5 @@ Bundle-ClassPath: .,
  lib/hibernate-commons-annotations-3.2.0.Final.jar,
  lib/hibernate-core-3.6.10.Final.jar,
  lib/hibernate-entitymanager-3.6.10.Final.jar,
- lib/hibernate-tools-3.6.1.Final.jar
+ lib/hibernate-tools-3.6.2.Final.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -17,7 +17,7 @@
 		<commons-logging.version>1.0.4</commons-logging.version>
 		<hibernate.version>3.6.10.Final</hibernate.version>
 		<hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
-		<hibernate-tools.version>3.6.1.Final</hibernate-tools.version>
+		<hibernate-tools.version>3.6.2.Final</hibernate-tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("3.6.1.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("3.6.2.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>