### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Remove the unneeded Maven dependency on 'asm:asm:3.1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Require-Bundle: org.apache.commons.collections,
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/asm-3.1.jar,
  lib/cglib-2.2.jar,
  lib/commons-logging-1.0.4.jar,
  lib/hibernate-commons-annotations-3.2.0.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<asm.version>3.1</asm.version>
 		<cglib.version>2.2</cglib.version>
 		<commons-logging.version>1.0.4</commons-logging.version>
 		<hibernate.version>3.6.10.Final</hibernate.version>
@@ -36,11 +35,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>asm</groupId>
-							<artifactId>asm</artifactId>
-							<version>${asm.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>cglib</groupId>
 							<artifactId>cglib</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>