### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Remove the unneeded Maven dependency on 'cglib:cglib:2.2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Require-Bundle: org.apache.commons.collections,
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/cglib-2.2.jar,
  lib/commons-logging-1.0.4.jar,
  lib/hibernate-commons-annotations-3.2.0.Final.jar,
  lib/hibernate-core-3.6.10.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<cglib.version>2.2</cglib.version>
 		<commons-logging.version>1.0.4</commons-logging.version>
 		<hibernate.version>3.6.10.Final</hibernate.version>
 		<hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
@@ -35,11 +34,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>cglib</groupId>
-							<artifactId>cglib</artifactId>
-							<version>${cglib.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>commons-logging</groupId>
 							<artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>