### PR TITLE
JBIDE-28340: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_6' - Replace the Maven dependency on 'org.hibernate:hibernate-commons-annotations:3.2.0.Final' by eclipse plugin dependency on 'org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1,
  org.jboss.tools.hibernate.libs.javassist.v_3_28,
  org.jboss.tools.hibernate.libs.jpa.v_2_2,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
@@ -18,7 +19,6 @@ Require-Bundle: org.apache.commons.collections,
  org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-commons-annotations-3.2.0.Final.jar,
  lib/hibernate-core-3.6.10.Final.jar,
  lib/hibernate-entitymanager-3.6.10.Final.jar,
  lib/hibernate-tools-3.6.2.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -13,7 +13,6 @@
 
 	<properties>
 		<hibernate.version>3.6.10.Final</hibernate.version>
-		<hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
 		<hibernate-tools.version>3.6.2.Final</hibernate-tools.version>
 	</properties>
 
@@ -33,11 +32,6 @@
 				</executions>
 				<configuration>
 					<artifactItems>
-						<artifactItem>
-							<groupId>org.hibernate</groupId>
-							<artifactId>hibernate-commons-annotations</artifactId>
-							<version>${hibernate-commons-annotations.version}</version>
-						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>
 							<artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>