### PR TITLE
JBIDE-28349: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_5' - Remove the unneeded Maven dependency on 'asm:asm:3.1'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
- org.hibernate.eclipse
+ org.hibernate.eclipse,
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/asm-3.1.jar,
@@ -26,6 +27,5 @@ Bundle-ClassPath: .,
  lib/javassist-3.9.0.GA.jar,
  lib/jta-1.1.jar,
  lib/log4j-1.2.15.jar,
- lib/slf4j-api-1.5.8.jar,
- lib/slf4j-log4j12-1.5.8.jar
+ lib/slf4j-api-1.5.8.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -106,11 +106,6 @@
 							<artifactId>slf4j-api</artifactId>
 							<version>${slf4j.version}</version>
 						</artifactItem>
-						<artifactItem>
-							<groupId>org.slf4j</groupId>
-							<artifactId>slf4j-log4j12</artifactId>
-							<version>${slf4j.version}</version>
-						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>
 					<outputDirectory>${basedir}/lib</outputDirectory>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>