### PR TITLE
JBIDE-28349: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_5' - Remove unneeded Maven dependency on 'log4j:log4j:1.2.15'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -25,6 +25,5 @@ Bundle-ClassPath: .,
  lib/hibernate-jpa-2.0-api-1.0.0.Final.jar,
  lib/hibernate-tools-3.5.2.Final.jar,
  lib/javassist-3.9.0.GA.jar,
- lib/jta-1.1.jar,
- lib/log4j-1.2.15.jar
+ lib/jta-1.1.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -21,7 +21,6 @@
 		<hibernate-tools.version>3.5.2.Final</hibernate-tools.version>
 		<javassist.version>3.9.0.GA</javassist.version>
 		<jta.version>1.1</jta.version>
-		<log4j.version>1.2.15</log4j.version>
 	</properties>
 
 	<build>
@@ -94,11 +93,6 @@
 							<groupId>javax.transaction</groupId>
 							<artifactId>jta</artifactId>
 							<version>${jta.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>log4j</groupId>
-							<artifactId>log4j</artifactId>
-							<version>${log4j.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>