### PR TITLE
JBIDE-28349: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_5' - Replace the Maven dependency on 'javax.transaction:jta:1.1' by plugin dependency on 'org.jboss.tools.hibernate.libs.transaction-api.v_1_2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
  org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801,
+ org.jboss.tools.hibernate.libs.transaction-api.v_1_2,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi,
  org.hibernate.eclipse,
@@ -24,6 +25,5 @@ Bundle-ClassPath: .,
  lib/hibernate-entitymanager-3.5.6-Final.jar,
  lib/hibernate-jpa-2.0-api-1.0.0.Final.jar,
  lib/hibernate-tools-3.5.2.Final.jar,
- lib/javassist-3.9.0.GA.jar,
- lib/jta-1.1.jar
+ lib/javassist-3.9.0.GA.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -20,7 +20,6 @@
 		<hibernate-jpa-2.0-api.version>1.0.0.Final</hibernate-jpa-2.0-api.version>
 		<hibernate-tools.version>3.5.2.Final</hibernate-tools.version>
 		<javassist.version>3.9.0.GA</javassist.version>
-		<jta.version>1.1</jta.version>
 	</properties>
 
 	<build>
@@ -88,11 +87,6 @@
 							<groupId>javassist</groupId>
 							<artifactId>javassist</artifactId>
 							<version>${javassist.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>javax.transaction</groupId>
-							<artifactId>jta</artifactId>
-							<version>${jta.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>