### PR TITLE
JBIDE-28046: Use the H2 library plugin as dependency in the runtime test fragments instead of the maven library dependency - Perform change for 'org.jboss.tools.hibernate.runtime.v_4_3.test'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3.test
 Bundle-Version: 5.4.16.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit.jupiter.api
-Bundle-ClassPath: .,
- lib/h2-1.4.200.jar
+Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,
+ org.junit.jupiter.api
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/build.properties
@@ -1,5 +1,4 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .,\
-               lib/h2-1.4.200.jar
+               .


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>