### PR TITLE
JBIDE-28349: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_5' - Replace the Maven dependency on 'commons-logging:commons-logging:1.0.4' by plugin dependency on 'org.apache.commons.logging'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5;singleton:=true
 Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
+ org.apache.commons.logging,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.dom4j.v_1_6_1,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3_23,
@@ -21,7 +22,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/asm-3.1.jar,
  lib/cglib-2.2.jar,
- lib/commons-logging-1.0.4.jar,
  lib/hibernate-annotations-3.5.6-Final.jar,
  lib/hibernate-core-3.5.6-Final.jar,
  lib/hibernate-entitymanager-3.5.6-Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/build.properties
@@ -4,5 +4,5 @@ bin.includes = .,\
                META-INF/,\
                lib/,\
                plugin.xml,\
-               plugin.properties,\
-               lib/hibernate-entitymanager-3.5.6-Final.jar
+               plugin.properties,
+               

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -14,7 +14,6 @@
 	<properties>
 		<asm.version>3.1</asm.version>
 		<cglib.version>2.2</cglib.version>
-		<commons-logging.version>1.0.4</commons-logging.version>
 		<hibernate.version>3.5.6-Final</hibernate.version>
 		<hibernate-tools.version>3.5.2.Final</hibernate-tools.version>
 	</properties>
@@ -44,11 +43,6 @@
 							<groupId>cglib</groupId>
 							<artifactId>cglib</artifactId>
 							<version>${cglib.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>commons-logging</groupId>
-							<artifactId>commons-logging</artifactId>
-							<version>${commons-logging.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>