### PR TITLE
JBIDE-28364: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_3_5 to version 3.5.3.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Bundle-ClassPath: .,
  lib/hibernate-annotations-3.5.6-Final.jar,
  lib/hibernate-core-3.5.6-Final.jar,
  lib/hibernate-entitymanager-3.5.6-Final.jar,
- lib/hibernate-tools-3.5.2.Final.jar
+ lib/hibernate-tools-3.5.3.Final.jar
 Bundle-Vendor: Red Hat

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/build.properties
@@ -4,5 +4,4 @@ bin.includes = .,\
                META-INF/,\
                lib/,\
                plugin.xml,\
-               plugin.properties,
-               
+               plugin.properties

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -15,7 +15,7 @@
 		<asm.version>3.1</asm.version>
 		<cglib.version>2.2</cglib.version>
 		<hibernate.version>3.5.6-Final</hibernate.version>
-		<hibernate-tools.version>3.5.2.Final</hibernate-tools.version>
+		<hibernate-tools.version>3.5.3.Final</hibernate-tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("3.5.2.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("3.5.3.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>