### PR TITLE
JBIDE-28349: Remove the Maven dependencies for 'org.jboss.tools.hibernate.runtime.v_3_5' - Remove unneeded Maven dependency on 'cglib:cglib:2.2'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Require-Bundle: org.apache.commons.collections,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/asm-3.1.jar,
- lib/cglib-2.2.jar,
  lib/hibernate-annotations-3.5.6-Final.jar,
  lib/hibernate-core-3.5.6-Final.jar,
  lib/hibernate-entitymanager-3.5.6-Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -13,7 +13,6 @@
 	
 	<properties>
 		<asm.version>3.1</asm.version>
-		<cglib.version>2.2</cglib.version>
 		<hibernate.version>3.5.6-Final</hibernate.version>
 		<hibernate-tools.version>3.5.3.Final</hibernate-tools.version>
 	</properties>
@@ -38,11 +37,6 @@
 							<groupId>asm</groupId>
 							<artifactId>asm</artifactId>
 							<version>${asm.version}</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>cglib</groupId>
-							<artifactId>cglib</artifactId>
-							<version>${cglib.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>