### PR TITLE
JBIDE-28402: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_5_6 to version 5.6.6.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Version: 5.4.16.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-core-5.6.5.Final.jar,
- lib/hibernate-tools-5.6.5.Final.jar
+ lib/hibernate-core-5.6.6.Final.jar,
+ lib/hibernate-tools-5.6.6.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/build.properties
@@ -5,3 +5,4 @@ bin.includes = .,\
                plugin.xml,\
                plugin.properties,\
                lib/
+               

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>5.6.5.Final</hibernate.version>
+		<hibernate.version>5.6.6.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("5.6.5.Final", org.hibernate.tool.Version.VERSION);
+		assertEquals("5.6.6.Final", org.hibernate.tool.Version.VERSION);
 	}
 
 	@Test
 	public void testCoreVersion() {
-		assertEquals("5.6.5.Final", org.hibernate.Version.getVersionString());
+		assertEquals("5.6.6.Final", org.hibernate.Version.getVersionString());
 	}
 
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>