### PR TITLE
JBIDE-28453: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_6_0 to version 6.0.0.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -7,10 +7,10 @@ Bundle-Version: 5.4.17.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.0.0.CR2.jar,
- lib/hibernate-core-6.0.0.CR2.jar,
- lib/hibernate-tools-orm-6.0.0.CR2.jar,
- lib/hibernate-tools-utils-6.0.0.CR2.jar
+ lib/hibernate-ant-6.0.0.Final.jar,
+ lib/hibernate-core-6.0.0.Final.jar,
+ lib/hibernate-tools-orm-6.0.0.Final.jar,
+ lib/hibernate-tools-utils-6.0.0.Final.jar
 Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
  org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_9,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>6.0.0.CR2</hibernate.version>
+		<hibernate.version>6.0.0.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.0.0.CR2", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.0.0.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.0.0.CR2", org.hibernate.Version.getVersionString());
+		assertEquals("6.0.0.Final", org.hibernate.Version.getVersionString());
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>