### PR TITLE
JBIDE-27954: Creating Hibernate Console Configuration is not completely successful when not navigating to cfg.xml creation page

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/NewConfigurationWizard.java
+++ b/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/NewConfigurationWizard.java
@@ -350,6 +350,7 @@ public class NewConfigurationWizard extends Wizard implements INewWizard {
 			confPage.setConfigurationFilePath(cPage.getContainerFullPath().append(cPage.getFileName()));
 			confPage.getHibernateVersionCombo().select(connectionInfoPage.getHibernateVersionComboSelectionIndex());
 			confPage.getHibernateVersionCombo().setEnabled(false);
+			confPage.setPreviousPage(page);
 		}
 		return super.getNextPage( page );
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>