### PR TITLE
JBIDE-28468: Update Maven dependency of 'org.jboss.tools.hibernate.libs.jboss-logging.v_3_4' to version 3.4.3.Final

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jboss-logging.v_3_4
 Bundle-Version: 5.4.17.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-ClassPath: lib/jboss-logging-3.4.2.Final.jar
+Bundle-ClassPath: lib/jboss-logging-3.4.3.Final.jar
 Export-Package: org.jboss.logging

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<jboss-logging.version>3.4.2.Final</jboss-logging.version>
+		<jboss-logging.version>3.4.3.Final</jboss-logging.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>