### PR TITLE
JBIDE-28472: Verify the necessity of plugin 'org.jboss.tools.hibernate.libs.activation.v_1_2_0' and remove if not needed - Remove dependency from 'org.jboss.tools.hibernate.runtime.v_5_5'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -9,8 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/hibernate-core-5.5.9.Final.jar,
  lib/hibernate-tools-5.5.9.Final.jar
-Require-Bundle: org.jboss.tools.hibernate.libs.activation.v_1_2_0,
- org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
+Require-Bundle: org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>