### PR TITLE
JBIDE-28472: Verify the necessity of plugin 'org.jboss.tools.hibernate.libs.activation.v_1_2_0' and remove if not needed - Remove from 'org.hibernate.eclipse.feature/feature.xml'

### DIFF
--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -240,12 +240,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.jboss.tools.hibernate.libs.activation.v_1_2_0"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.jboss.tools.hibernate.libs.jaxb-api.v_2_3_0"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>