### PR TITLE
JBIDE-28483: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_6_0 to version 6.0.1.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -7,11 +7,11 @@ Bundle-Version: 5.4.17.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.0.0.Final.jar,
- lib/hibernate-core-6.0.0.Final.jar,
- lib/hibernate-tools-orm-6.0.0.Final.jar,
- lib/hibernate-tools-utils-6.0.0.Final.jar
-Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_9,
+ lib/hibernate-ant-6.0.1.Final.jar,
+ lib/hibernate-core-6.0.1.Final.jar,
+ lib/hibernate-tools-orm-6.0.1.Final.jar,
+ lib/hibernate-tools-utils-6.0.1.Final.jar
+Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_11,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/build.properties
@@ -4,4 +4,8 @@ bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                plugin.properties,\
-               lib/
+               lib/,\
+               lib/hibernate-ant-6.0.1.Final.jar,\
+               lib/hibernate-core-6.0.1.Final.jar,\
+               lib/hibernate-tools-orm-6.0.1.Final.jar,\
+               lib/hibernate-tools-utils-6.0.1.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>6.0.0.Final</hibernate.version>
+		<hibernate.version>6.0.1.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/VersionTest.java
@@ -11,12 +11,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.0.0.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.0.1.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.0.0.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.0.1.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HQLCodeAssistFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HQLCodeAssistFacadeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.ide.completion.IHQLCompletionRequestor;
 import org.jboss.tools.hibernate.runtime.common.AbstractHQLCodeAssistFacade;
@@ -27,9 +28,10 @@ public class HQLCodeAssistFacadeTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		hqlCodeAssistTarget = new org.hibernate.tool.ide.completion.IHQLCodeAssist() {			
+		hqlCodeAssistTarget = new HQLCodeAssist(null) {
 			@Override
 			public void codeComplete(String query, int currentOffset, IHQLCompletionRequestor handler) {
+				super.codeComplete(query, currentOffset, handler);
 				handler.accept(HQL_COMPLETION_PROPOSAL);
 			}
 		};
@@ -39,7 +41,7 @@ public class HQLCodeAssistFacadeTest {
 	@Test
 	public void testCodeComplete() {
 		assertNull(acceptedProposal);
-		hqlCodeAssistFacade.codeComplete("foo", Integer.MAX_VALUE, new TestHQLCompletionHandler());
+		hqlCodeAssistFacade.codeComplete("foo bar", 1, new TestHQLCompletionHandler());
 		assertNotNull(acceptedProposal);
 		assertSame(HQL_COMPLETION_PROPOSAL, ((IFacade)acceptedProposal).getTarget());
 	}
@@ -52,8 +54,6 @@ public class HQLCodeAssistFacadeTest {
 		}
 		@Override
 		public void completionFailure(String errorMessage) {
-			// TODO Auto-generated method stub
-			
 		}		
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>