### PR TITLE
JBIDE-28497: Update the Maven dependency on 'hibernate-commons-annotations' in 'org.jboss.tools.hibernate.libs.hibernate-commons-annnotations.v_6_0' to version 6.0.2.Final

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.libs.hibernate-commons-annotation
 Bundle-Version: 5.4.17.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-ClassPath: lib/hibernate-commons-annotations-6.0.1.Final.jar
 Export-Package: org.hibernate.annotations.common.annotationfactory,
  org.hibernate.annotations.common.reflection,
  org.hibernate.annotations.common.reflection.java,
  org.hibernate.annotations.common.reflection.java.generics
+Bundle-ClassPath: lib/hibernate-commons-annotations-6.0.2.Final.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/build.properties
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/build.properties
@@ -1,4 +1,3 @@
 src.includes = pom.xml
 bin.includes = META-INF/,\
-               lib/,\
-               lib/hibernate-commons-annotations-6.0.1.Final.jar
+               lib/

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<properties>
-		<hibernate-commons-annotations.version>6.0.1.Final</hibernate-commons-annotations.version>
+		<hibernate-commons-annotations.version>6.0.2.Final</hibernate-commons-annotations.version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>