### PR TITLE
JBIDE-28512: Update dependency of 'org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10' on 'org.antlr:antlr4-runtime' to version 4.10.1

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10
 Bundle-Version: 5.4.17.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-ClassPath: lib/antlr4-runtime-4.10.jar
+Bundle-ClassPath: lib/antlr4-runtime-4.10.1.jar
 Export-Package: org.antlr.v4.runtime,
  org.antlr.v4.runtime.atn,
  org.antlr.v4.runtime.dfa,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/build.properties
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/build.properties
@@ -1,4 +1,3 @@
 src.includes = pom.xml
 bin.includes = META-INF/,\
-               lib/,\
-               lib/antlr4-runtime-4.10.jar
+               lib/

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<properties>
-	    <antlr4-runtime.version>4.10</antlr4-runtime.version>
+	    <antlr4-runtime.version>4.10.1</antlr4-runtime.version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>