### PR TITLE
JBIDE-28522: Create a library plugin for Dom4J versions 2.1.x - The packages from the library need to be on the classpath and exported...

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/META-INF/MANIFEST.MF
@@ -5,3 +5,18 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.libs.dom4j.v_2_1
 Bundle-Vendor: Red Hat
 Bundle-Version: 5.4.17.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ClassPath: lib/dom4j-2.1.3.jar
+Export-Package: org.dom4j,
+ org.dom4j.bean,
+ org.dom4j.datatype,
+ org.dom4j.dom,
+ org.dom4j.dtd,
+ org.dom4j.io,
+ org.dom4j.jaxb,
+ org.dom4j.rule,
+ org.dom4j.rule.pattern,
+ org.dom4j.swing,
+ org.dom4j.tree,
+ org.dom4j.util,
+ org.dom4j.xpath,
+ org.dom4j.xpp


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>