### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateNamingStrategy()'  and remove default 'FacadeFactoryImpl#createNamingStrategy(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -17,7 +17,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -42,12 +41,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();
-	}
-
-	@Override
-	public INamingStrategy createNamingStrategy(Object target) {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -3,12 +3,14 @@ package org.jboss.tools.hibernate.runtime.v_6_1.internal;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
+import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +47,13 @@ public class FacadeFactoryTest {
 		Cfg2HbmTool cfg2HbmTool = new Cfg2HbmTool();
 		ICfg2HbmTool facade = facadeFactory.createCfg2HbmTool(cfg2HbmTool);
 		assertSame(cfg2HbmTool,  ((IFacade)facade).getTarget());
+	}
+	
+	@Test
+	public void testCreateNamingStrategy() {
+		DefaultNamingStrategy namingStrategy = new DefaultNamingStrategy();
+		INamingStrategy facade = facadeFactory.createNamingStrategy(namingStrategy);
+		assertSame(namingStrategy, ((IFacade)facade).getTarget());
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>