### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateReverseEngineeringSettings()'  and remove default 'FacadeFactoryImpl#createReverseEngineeringSettings(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -44,12 +44,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
-	public IReverseEngineeringSettings createReverseEngineeringSettings(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object target) {
 		// TODO Auto-generated method stub
 		return null;

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
+import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +56,13 @@ public class FacadeFactoryTest {
 		DefaultNamingStrategy namingStrategy = new DefaultNamingStrategy();
 		INamingStrategy facade = facadeFactory.createNamingStrategy(namingStrategy);
 		assertSame(namingStrategy, ((IFacade)facade).getTarget());
+	}
+	
+	@Test
+	public void testCreateReverseEngineeringSettings() {
+		RevengSettings res = new RevengSettings(null);
+		IReverseEngineeringSettings facade = facadeFactory.createReverseEngineeringSettings(res);
+		assertSame(res, ((IFacade)facade).getTarget());		
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>