### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateExporter()' and remove default 'FacadeFactoryImpl#createExporter(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ExporterFacadeImpl.java
@@ -1,0 +1,12 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal;
+
+import org.jboss.tools.hibernate.runtime.common.AbstractExporterFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+
+public class ExporterFacadeImpl extends AbstractExporterFacade {
+
+	public ExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
+		super(facadeFactory, target);
+	}
+
+}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -67,10 +67,9 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 
 	@Override
 	public IExporter createExporter(Object target) {
-		// TODO Auto-generated method stub
-		return null;
+		return new ExporterFacadeImpl(this, target);
 	}
-
+	
 	@Override
 	public IClassMetadata createClassMetadata(Object target) {
 		// TODO Auto-generated method stub

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
@@ -23,6 +24,7 @@ import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
+import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
@@ -138,6 +140,17 @@ public class FacadeFactoryTest {
 		TableFilter tableFilter = new TableFilter();
 		ITableFilter facade = facadeFactory.createTableFilter(tableFilter);
 		assertSame(tableFilter, ((IFacade)facade).getTarget());		
+	}
+	
+	@Test
+	public void testCreateExporter() {
+		Exporter exporter = (Exporter)Proxy.newProxyInstance(
+				facadeFactory.getClassLoader(), 
+				new Class[] { Exporter.class }, 
+				new TestInvocationHandler());
+		IExporter facade = facadeFactory.createExporter(exporter);
+		assertTrue(facade instanceof ExporterFacadeImpl);
+		assertSame(exporter, ((IFacade)facade).getTarget());		
 	}
 	
 	private class TestInvocationHandler implements InvocationHandler {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>