### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateCollectionMetadata()' and remove default 'FacadeFactoryImpl#createCollectionMetadata(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -76,12 +76,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 	
 	@Override
-	public ICollectionMetadata createCollectionMetadata(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public IColumn createColumn(Object target) {
 		// TODO Auto-generated method stub
 		return null;

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.metadata.CollectionMetadata;
 import org.hibernate.tool.api.export.ArtifactCollector;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.reveng.RevengSettings;
@@ -26,6 +27,7 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
+import org.jboss.tools.hibernate.runtime.spi.ICollectionMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
@@ -164,6 +166,16 @@ public class FacadeFactoryTest {
 		IClassMetadata facade = facadeFactory.createClassMetadata(classMetadata);
 		assertTrue(facade instanceof ClassMetadataFacadeImpl);
 		assertSame(classMetadata, ((IFacade)facade).getTarget());		
+	}
+	
+	@Test
+	public void testCreateCollectionMetadata() {
+		CollectionMetadata collectionMetadata = (CollectionMetadata)Proxy.newProxyInstance(
+				facadeFactory.getClassLoader(), 
+				new Class[] { CollectionMetadata.class }, 
+				new TestInvocationHandler());
+		ICollectionMetadata facade = facadeFactory.createCollectionMetadata(collectionMetadata);
+		assertSame(collectionMetadata, ((IFacade)facade).getTarget());		
 	}
 	
 	private class TestInvocationHandler implements InvocationHandler {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>