### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateHQLCodeAssist()' and remove default 'FacadeFactoryImpl#createHQLCodeAssist(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -10,7 +10,6 @@ import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IForeignKey;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
-import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
@@ -103,12 +102,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	@Override
 	public IHibernateMappingExporter createHibernateMappingExporter(Object target) {
 		return new HibernateMappingExporterFacadeImpl(this, target);
-	}
-
-	@Override
-	public IHQLCodeAssist createHQLCodeAssist(Object target) {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -20,6 +20,7 @@ import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
@@ -41,6 +42,7 @@ import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IForeignKey;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
@@ -251,6 +253,13 @@ public class FacadeFactoryTest {
 		IHibernateMappingExporter facade = facadeFactory.createHibernateMappingExporter(hibernateMappingExporter);
 		assertSame(hibernateMappingExporter, ((IFacade)facade).getTarget());	
 		assertTrue(facade instanceof HibernateMappingExporterFacadeImpl);
+	}
+	
+	@Test
+	public void testCreateHQLCodeAssist() {
+		HQLCodeAssist hqlCodeAssist = new HQLCodeAssist(null);
+		IHQLCodeAssist facade = facadeFactory.createHQLCodeAssist(hqlCodeAssist);
+		assertSame(hqlCodeAssist, ((IFacade)facade).getTarget());		
 	}
 	
 	private class TestInvocationHandler implements InvocationHandler {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>