### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.util.DummyMetadataBuildingContextTest' and implement class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.util.DummyMetadataBuildingContextTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.byte-buddy.v_1_12,
  org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0,
  org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
+ org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/util/DummyMetadataBuildingContext.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/util/DummyMetadataBuildingContext.java
@@ -1,0 +1,31 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.util;
+
+import org.hibernate.boot.internal.BootstrapContextImpl;
+import org.hibernate.boot.internal.InFlightMetadataCollectorImpl;
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.internal.MetadataBuildingContextRootImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.boot.spi.InFlightMetadataCollector;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.cfg.AvailableSettings;
+
+public class DummyMetadataBuildingContext {
+	
+	public static MetadataBuildingContext INSTANCE = createInstance();
+	
+	private static MetadataBuildingContext createInstance() {
+		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+		ssrb.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
+		ssrb.applySetting(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
+		StandardServiceRegistry serviceRegistry = ssrb.build();
+		MetadataBuildingOptions metadataBuildingOptions = new MetadataBuilderImpl.MetadataBuildingOptionsImpl(serviceRegistry);
+		BootstrapContext bootstrapContext = new BootstrapContextImpl(serviceRegistry, metadataBuildingOptions);
+		((MetadataBuilderImpl.MetadataBuildingOptionsImpl)metadataBuildingOptions).setBootstrapContext(bootstrapContext);
+		InFlightMetadataCollector inflightMetadataCollector = new InFlightMetadataCollectorImpl(bootstrapContext, metadataBuildingOptions);
+		return new MetadataBuildingContextRootImpl("JBoss Tools", bootstrapContext, metadataBuildingOptions, inflightMetadataCollector);
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/util/DummyMetadataBuildingContextTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/util/DummyMetadataBuildingContextTest.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.junit.jupiter.api.Test;
+
+public class DummyMetadataBuildingContextTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DummyMetadataBuildingContext.INSTANCE);
+		StandardServiceRegistry serviceRegistry = DummyMetadataBuildingContext.INSTANCE
+				.getBootstrapContext().getServiceRegistry();
+		JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
+		Dialect dialect = jdbcServices.getDialect();
+		assertTrue(dialect instanceof MockDialect);
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>