### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add 'FacadeFactoryTest#testCreateTable()' and remove default 'FacadeFactoryImpl#createTable(Object)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryImpl.java
@@ -138,12 +138,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
-	public ITable createTable(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
 	public ITypeFactory createTypeFactory() {
 		return new TypeFactoryFacadeImpl(this, null);
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/FacadeFactoryTest.java
@@ -20,6 +20,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.metadata.CollectionMetadata;
@@ -72,6 +73,7 @@ import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.jboss.tools.hibernate.runtime.spi.ISession;
 import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
+import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.ITableFilter;
 import org.jboss.tools.hibernate.runtime.spi.IType;
 import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
@@ -372,6 +374,13 @@ public class FacadeFactoryTest {
 		assertNotNull(facade);
 		assertTrue(facade instanceof TypeFactoryFacadeImpl);
 		assertNull(((IFacade)facade).getTarget());
+	}
+	
+	@Test
+	public void testCreateTable() {
+		Table table = new Table();
+		ITable facade = facadeFactory.createTable(table);
+		assertSame(table, ((IFacade)facade).getTarget());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>