### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.BooleanTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.BooleanType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/BooleanType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/BooleanType.java
@@ -1,0 +1,38 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.Incubating;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.AdjustableBasicType;
+import org.hibernate.type.descriptor.java.BooleanJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BooleanJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+public class BooleanType extends AbstractSingleColumnStandardBasicType<Boolean>
+		implements AdjustableBasicType<Boolean> {
+	public static final BooleanType INSTANCE = new BooleanType();
+
+	public BooleanType() {
+		this(BooleanJdbcType.INSTANCE, BooleanJavaType.INSTANCE);
+	}
+
+	protected BooleanType(JdbcType jdbcType, BooleanJavaType javaTypeDescriptor) {
+		super(jdbcType, javaTypeDescriptor);
+	}
+
+	@Incubating
+	public BooleanType(JdbcType jdbcType, JavaType<Boolean> javaTypeDescriptor) {
+		super(jdbcType, javaTypeDescriptor);
+	}
+
+	@Override
+	public String getName() {
+		return "boolean";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), boolean.class.getName(), Boolean.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/BooleanTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/BooleanTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class BooleanTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(BooleanType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("boolean", BooleanType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"boolean",
+					"boolean",
+					"java.lang.Boolean"
+				},
+				BooleanType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>