### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ByteTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ByteType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ByteType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ByteType.java
@@ -1,0 +1,24 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.ByteJavaType;
+import org.hibernate.type.descriptor.jdbc.TinyIntJdbcType;
+
+public class ByteType extends AbstractSingleColumnStandardBasicType<Byte> {
+
+	public static final ByteType INSTANCE = new ByteType();
+
+	public ByteType() {
+		super(TinyIntJdbcType.INSTANCE, ByteJavaType.INSTANCE);
+	}
+
+	@Override
+	public String getName() {
+		return "byte";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), byte.class.getName(), Byte.class.getName() };
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ByteTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ByteTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class ByteTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(ByteType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("byte", ByteType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"byte",
+					"byte",
+					"java.lang.Byte"
+				},
+				ByteType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>