### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CalendarDateTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CalendarDateType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarDateType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarDateType.java
@@ -1,0 +1,20 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.Calendar;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.CalendarDateJavaType;
+import org.hibernate.type.descriptor.jdbc.DateJdbcType;
+
+public class CalendarDateType extends AbstractSingleColumnStandardBasicType<Calendar> {
+	public static final CalendarDateType INSTANCE = new CalendarDateType();
+
+	public CalendarDateType() {
+		super(DateJdbcType.INSTANCE, CalendarDateJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "calendar_date";
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarDateTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarDateTypeTest.java
@@ -1,0 +1,20 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class CalendarDateTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(CalendarDateType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("calendar_date", CalendarDateType.INSTANCE.getName());
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>