### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CalendarTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CalendarType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarType.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.CalendarJavaType;
+import org.hibernate.type.descriptor.jdbc.TimestampJdbcType;
+
+public class CalendarType extends AbstractSingleColumnStandardBasicType<Calendar> {
+
+	public static final CalendarType INSTANCE = new CalendarType();
+
+	public CalendarType() {
+		super(TimestampJdbcType.INSTANCE, CalendarJavaType.INSTANCE);
+	}
+
+	@Override
+	public String getName() {
+		return "calendar";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), Calendar.class.getName(), GregorianCalendar.class.getName() };
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CalendarTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class CalendarTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(CalendarType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("calendar", CalendarType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"calendar",
+					"java.util.Calendar",
+					"java.util.GregorianCalendar"
+				},
+				CalendarType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>