### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CharacterTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CharacterType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CharacterType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CharacterType.java
@@ -1,0 +1,25 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.AdjustableBasicType;
+import org.hibernate.type.descriptor.java.CharacterJavaType;
+import org.hibernate.type.descriptor.jdbc.CharJdbcType;
+
+public class CharacterType extends AbstractSingleColumnStandardBasicType<Character>
+		implements AdjustableBasicType<Character> {
+
+	public static final CharacterType INSTANCE = new CharacterType();
+
+	public CharacterType() {
+		super(CharJdbcType.INSTANCE, CharacterJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "character";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), char.class.getName(), Character.class.getName() };
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CharacterTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CharacterTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class CharacterTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(CharacterType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("character", CharacterType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"character",
+					"char",
+					"java.lang.Character"
+				},
+				CharacterType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>