### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ClassTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ClassType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ClassType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ClassType.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.ClassJavaType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+
+public class ClassType extends AbstractSingleColumnStandardBasicType<Class> {
+	public static final ClassType INSTANCE = new ClassType();
+
+	public ClassType() {
+		super(VarcharJdbcType.INSTANCE, ClassJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "class";
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ClassTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ClassTypeTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ClassTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(ClassType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("class", ClassType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testRegisterUnderJavaType() {
+		assertTrue(ClassType.INSTANCE.registerUnderJavaType());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>