### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CurrencyTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.CurrencyType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CurrencyType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CurrencyType.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.Currency;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.CurrencyJavaType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+
+public class CurrencyType extends AbstractSingleColumnStandardBasicType<Currency> {
+
+	public static final CurrencyType INSTANCE = new CurrencyType();
+
+	public CurrencyType() {
+		super(VarcharJdbcType.INSTANCE, CurrencyJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "currency";
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CurrencyTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/CurrencyTypeTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class CurrencyTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(CurrencyType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("currency", CurrencyType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testRegisterUnderJavaType() {
+		assertTrue(CurrencyType.INSTANCE.registerUnderJavaType());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>