### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.DateTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.DateType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DateType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DateType.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.Date;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.JdbcDateJavaType;
+import org.hibernate.type.descriptor.jdbc.DateJdbcType;
+
+public class DateType extends AbstractSingleColumnStandardBasicType<Date> {
+
+	public static final DateType INSTANCE = new DateType();
+
+	public DateType() {
+		super(DateJdbcType.INSTANCE, JdbcDateJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "date";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), java.sql.Date.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DateTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DateTypeTest.java
@@ -1,0 +1,31 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class DateTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DateType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("date", DateType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"date",
+					"java.sql.Date"
+				},
+				DateType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>