### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.DoubleTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.DoubleType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DoubleType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DoubleType.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.DoubleJavaType;
+import org.hibernate.type.descriptor.jdbc.DoubleJdbcType;
+
+public class DoubleType extends AbstractSingleColumnStandardBasicType<Double> {
+	public static final DoubleType INSTANCE = new DoubleType();
+
+	public DoubleType() {
+		super(DoubleJdbcType.INSTANCE, DoubleJavaType.INSTANCE);
+	}
+
+	@Override
+	public String getName() {
+		return "double";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), double.class.getName(), Double.class.getName() };
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DoubleTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/DoubleTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class DoubleTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(DoubleType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("double", DoubleType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"double",
+					"double",
+					"java.lang.Double"
+				},
+				DoubleType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>