### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.FloatTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.FloatType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/FloatType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/FloatType.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.FloatJavaType;
+import org.hibernate.type.descriptor.jdbc.FloatJdbcType;
+
+public class FloatType extends AbstractSingleColumnStandardBasicType<Float> {
+	public static final FloatType INSTANCE = new FloatType();
+
+
+	public FloatType() {
+		super( FloatJdbcType.INSTANCE, FloatJavaType.INSTANCE );
+	}
+	@Override
+	public String getName() {
+		return "float";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), float.class.getName(), Float.class.getName() };
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/FloatTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/FloatTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class FloatTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(FloatType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("float", FloatType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"float",
+					"float",
+					"java.lang.Float"
+				},
+				FloatType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>