### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.LocaleTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.LocaleType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LocaleType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LocaleType.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.Locale;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.LocaleJavaType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+
+public class LocaleType extends AbstractSingleColumnStandardBasicType<Locale> {
+
+	public static final LocaleType INSTANCE = new LocaleType();
+
+	public LocaleType() {
+		super( VarcharJdbcType.INSTANCE, LocaleJavaType.INSTANCE );
+	}
+
+	public String getName() {
+		return "locale";
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LocaleTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LocaleTypeTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class LocaleTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(LocaleType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("locale", LocaleType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testRegisterUnderJavaType() {
+		assertTrue(LocaleType.INSTANCE.registerUnderJavaType());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>