### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.LongTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.LongType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LongType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LongType.java
@@ -1,0 +1,25 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.LongJavaType;
+import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
+
+public class LongType extends AbstractSingleColumnStandardBasicType<Long> {
+
+	public static final LongType INSTANCE = new LongType();
+
+	public LongType() {
+		super(BigIntJdbcType.INSTANCE, LongJavaType.INSTANCE);
+	}
+
+	@Override
+	public String getName() {
+		return "long";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), long.class.getName(), Long.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LongTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/LongTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class LongTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(LongType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("long", LongType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"long",
+					"long",
+					"java.lang.Long"
+				},
+				LongType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>