### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ShortTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.ShortType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ShortType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ShortType.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.ShortJavaType;
+import org.hibernate.type.descriptor.jdbc.SmallIntJdbcType;
+
+public class ShortType extends AbstractSingleColumnStandardBasicType<Short> {
+
+	public static final ShortType INSTANCE = new ShortType();
+
+	private static final Short ZERO = (short) 0;
+
+	public ShortType() {
+		super(SmallIntJdbcType.INSTANCE, ShortJavaType.INSTANCE);
+	}
+
+	@Override
+	public String getName() {
+		return "short";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), short.class.getName(), Short.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ShortTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/ShortTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class ShortTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(ShortType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("short", ShortType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"short",
+					"short",
+					"java.lang.Short"
+				},
+				ShortType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>