### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.StrinngTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.StringType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/StringType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/StringType.java
@@ -1,0 +1,25 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.AdjustableBasicType;
+import org.hibernate.type.descriptor.java.StringJavaType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+
+public class StringType extends AbstractSingleColumnStandardBasicType<String> implements AdjustableBasicType<String> {
+
+	public static final StringType INSTANCE = new StringType();
+
+	public StringType() {
+		super(VarcharJdbcType.INSTANCE, StringJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "string";
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/StringTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/StringTypeTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StringTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(StringType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("string", StringType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testRegisterUnderJavaType() {
+		assertTrue(StringType.INSTANCE.registerUnderJavaType());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>