### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TextTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TextType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextType.java
@@ -1,0 +1,18 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.AdjustableBasicType;
+import org.hibernate.type.descriptor.java.StringJavaType;
+import org.hibernate.type.descriptor.jdbc.LongVarcharJdbcType;
+
+public class TextType extends AbstractSingleColumnStandardBasicType<String> implements AdjustableBasicType<String> {
+	public static final TextType INSTANCE = new TextType();
+
+	public TextType() {
+		super(LongVarcharJdbcType.INSTANCE, StringJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "text";
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextTypeTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TextTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(TextType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("text", TextType.INSTANCE.getName());
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>