### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimestampTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimestampType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimestampType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimestampType.java
@@ -1,0 +1,34 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.JdbcTimestampJavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.TimestampJdbcType;
+
+public class TimestampType extends AbstractSingleColumnStandardBasicType<Date> {
+
+	public static final TimestampType INSTANCE = new TimestampType();
+
+	public TimestampType() {
+		super(TimestampJdbcType.INSTANCE, JdbcTimestampJavaType.INSTANCE);
+	}
+
+	protected TimestampType(JdbcType jdbcType, JavaType<Date> javaTypeDescriptor) {
+		super(jdbcType, javaTypeDescriptor);
+	}
+
+	@Override
+	public String getName() {
+		return "timestamp";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), Timestamp.class.getName(), Date.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TextTypeTest.java
@@ -2,7 +2,6 @@ package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimestampTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimestampTypeTest.java
@@ -1,0 +1,32 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class TimestampTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(TimestampType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("timestamp", TimestampType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"timestamp",
+					"java.sql.Timestamp",
+					"java.util.Date"
+				},
+				TimestampType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>