### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimeTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimeType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeType.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.sql.Time;
+import java.util.Date;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.JdbcTimeJavaType;
+import org.hibernate.type.descriptor.jdbc.TimeJdbcType;
+
+public class TimeType extends AbstractSingleColumnStandardBasicType<Date> {
+
+	public static final TimeType INSTANCE = new TimeType();
+
+	public TimeType() {
+		super(TimeJdbcType.INSTANCE, JdbcTimeJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "time";
+	}
+
+	@Override
+	public String[] getRegistrationKeys() {
+		return new String[] { getName(), Time.class.getName() };
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeTypeTest.java
@@ -1,0 +1,31 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(TimeType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("time", TimeType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetRegistrationKeys() {
+		assertArrayEquals(
+				new String[] {
+					"time",
+					"java.sql.Time"
+				},
+				TimeType.INSTANCE.getRegistrationKeys());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>