### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimeZoneTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TimeZoneType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeZoneType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeZoneType.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import java.util.TimeZone;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.TimeZoneJavaType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+
+public class TimeZoneType extends AbstractSingleColumnStandardBasicType<TimeZone> {
+
+	public static final TimeZoneType INSTANCE = new TimeZoneType();
+
+	public TimeZoneType() {
+		super(VarcharJdbcType.INSTANCE, TimeZoneJavaType.INSTANCE);
+	}
+
+	public String getName() {
+		return "timezone";
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeZoneTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TimeZoneTypeTest.java
@@ -1,0 +1,26 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeZoneTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(TimeZoneType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("timezone", TimeZoneType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testRegisterUnderJavaType() {
+		assertTrue(TimeZoneType.INSTANCE.registerUnderJavaType());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>