### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Add test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TrueFalseTypeTest' and implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy.TrueFalseType'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TrueFalseType.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TrueFalseType.java
@@ -1,0 +1,29 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.ConvertedBasicType;
+import org.hibernate.type.TrueFalseConverter;
+import org.hibernate.type.descriptor.java.BooleanJavaType;
+import org.hibernate.type.descriptor.jdbc.CharJdbcType;
+
+public class TrueFalseType extends AbstractSingleColumnStandardBasicType<Boolean>
+		implements ConvertedBasicType<Boolean> {
+
+	public static final TrueFalseType INSTANCE = new TrueFalseType();
+
+	public TrueFalseType() {
+		super(CharJdbcType.INSTANCE, new BooleanJavaType('T', 'F'));
+	}
+
+	@Override
+	public String getName() {
+		return "true_false";
+	}
+
+	@Override
+	public BasicValueConverter<Boolean, ?> getValueConverter() {
+		return TrueFalseConverter.INSTANCE;
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TrueFalseTypeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/legacy/TrueFalseTypeTest.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.hibernate.type.TrueFalseConverter;
+import org.junit.jupiter.api.Test;
+
+public class TrueFalseTypeTest {
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(TrueFalseType.INSTANCE);
+	}
+	
+	@Test
+	public void testGetName() {
+		assertEquals("true_false", TrueFalseType.INSTANCE.getName());
+	}
+	
+	@Test
+	public void testGetValueConverter() {
+		assertSame(TrueFalseConverter.INSTANCE, TrueFalseType.INSTANCE.getValueConverter());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>