### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Implementation of new test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.Hbm2DDLExporterFacadeTest' and of the implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.Hbm2DDLExporterFacadeImpl'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/Hbm2DDLExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/Hbm2DDLExporterFacadeImpl.java
@@ -1,5 +1,7 @@
 package org.jboss.tools.hibernate.runtime.v_6_1.internal;
 
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractHbm2DDLExporterFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 
@@ -7,6 +9,10 @@ public class Hbm2DDLExporterFacadeImpl extends AbstractHbm2DDLExporterFacade {
 
 	public Hbm2DDLExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
 		super(facadeFactory, target);
+	}
+	
+	public void setExport(boolean b) {
+		((DdlExporter)getTarget()).getProperties().put(ExporterConstants.EXPORT_TO_DATABASE, b);
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/Hbm2DDLExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/Hbm2DDLExporterFacadeTest.java
@@ -1,0 +1,41 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class Hbm2DDLExporterFacadeTest {
+	
+	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private IHbm2DDLExporter ddlExporterFacade = null;
+	private DdlExporter ddlExporterTarget = null;
+	
+	@BeforeEach
+	public void before() {
+		ddlExporterTarget = new DdlExporter();
+		ddlExporterFacade = new Hbm2DDLExporterFacadeImpl(FACADE_FACTORY, ddlExporterTarget) {};
+	}
+	
+	@Test 
+	public void testGetProperties() {
+		assertNotNull(ddlExporterFacade.getProperties());
+	}
+	
+	@Test
+	public void testSetExport() {
+		assertNull(ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+		ddlExporterFacade.setExport(false);
+		assertFalse((Boolean)ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+		ddlExporterFacade.setExport(true);
+		assertTrue((Boolean)ddlExporterFacade.getProperties().get(ExporterConstants.EXPORT_TO_DATABASE));
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>