### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Implementation of new test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.HibernateMappingExporterExtensionTest' and of the implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.HibernateMappingExporterExtension'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_12,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
+ org.jboss.tools.hibernate.libs.freemarker.v_2_3,
  org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0,
  org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0,
  org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
@@ -1,0 +1,47 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal;
+
+import java.io.File;
+import java.util.Map;
+
+import org.hibernate.tool.internal.export.hbm.HbmExporter;
+import org.hibernate.tool.internal.export.java.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
+import org.jboss.tools.hibernate.runtime.v_6_1.internal.util.ConfigurationMetadataDescriptor;
+
+public class HibernateMappingExporterExtension extends HbmExporter {
+	
+	private IExportPOJODelegate delegateExporter;
+	private IFacadeFactory facadeFactory;
+
+	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
+		this.facadeFactory = facadeFactory;
+		getProperties().put(
+				METADATA_DESCRIPTOR, 
+				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)cfg));
+		if (file != null) {
+			getProperties().put(OUTPUT_FILE_NAME, file);
+		}
+	}
+	
+	public void setDelegate(IExportPOJODelegate delegate) {
+		delegateExporter = delegate;
+	}
+
+	public void superExportPOJO(Map<String, Object> map, POJOClass pojoClass) {
+		super.exportPOJO(map, pojoClass);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	protected void exportPOJO(Map map, POJOClass pojoClass) {
+		if (delegateExporter == null) {
+			super.exportPOJO(map, pojoClass);
+		} else {
+			delegateExporter.exportPOJO(
+					(Map<Object, Object>)map, 
+					facadeFactory.createPOJOClass(pojoClass));
+		}
+	}
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
@@ -1,0 +1,159 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.api.version.Version;
+import org.hibernate.tool.internal.export.common.AbstractExporter;
+import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
+import org.hibernate.tool.internal.export.common.TemplateHelper;
+import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
+import org.hibernate.tool.internal.export.java.EntityPOJOClass;
+import org.hibernate.tool.internal.export.java.POJOClass;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
+import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
+import org.jboss.tools.hibernate.runtime.v_6_1.internal.util.DummyMetadataBuildingContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HibernateMappingExporterExtensionTest {
+
+	private static IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private HibernateMappingExporterExtension hibernateMappingExporterExtension;
+
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		hibernateMappingExporterExtension = new HibernateMappingExporterExtension(FACADE_FACTORY, null, null);
+	}
+	
+	@Test
+	public void testSetDelegate() throws Exception {
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+		};
+		assertNull(delegateField.get(hibernateMappingExporterExtension));
+		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
+		assertSame(exportPojoDelegate, delegateField.get(hibernateMappingExporterExtension));
+	}
+	
+	@Test
+	public void testSuperExportPOJO() throws Exception {
+		initializeTemplateHelper();
+		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		Map<String, Object> additionalContext = new HashMap<String, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.CURRENT_VERSION);
+		additionalContext.put("c2h", c2h);
+		hibernateMappingExporterExtension.superExportPOJO(additionalContext, createPojoClass());
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals("foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+	}
+	
+	@Test
+	public void testExportPOJO() throws Exception {
+		initializeTemplateHelper();
+		POJOClass pojoClass = createPojoClass();
+		// first without a delegate exporter
+		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		File[] hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Map<Object, Object> additionalContext = new HashMap<Object, Object>();
+		Cfg2HbmTool c2h = new Cfg2HbmTool();
+		additionalContext.put("date", new Date().toString());
+		additionalContext.put("version", Version.CURRENT_VERSION);
+		additionalContext.put("c2h", c2h);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertFalse(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		assertTrue(hbmXmlFiles.length == 1);
+		assertEquals("foo" + File.separator + "Bar.hbm.xml", hbmXmlFiles[0].getPath());
+		assertTrue(new File("foo" + File.separator + "Bar.hbm.xml").exists());
+		// then with a delegate exporter
+		artifactCollector = new DefaultArtifactCollector();
+		hibernateMappingExporterExtension.getProperties().put(
+				ExporterConstants.ARTIFACT_COLLECTOR, 
+				artifactCollector);
+		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
+		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+				arguments.put("map", map);
+				arguments.put("pojoClass", pojoClass);
+			}
+		};
+		hbmXmlFiles = artifactCollector.getFiles("hbm.xml");
+		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		delegateField.set(hibernateMappingExporterExtension, exportPojoDelegate);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertNull(arguments.get("map"));
+		assertNull(arguments.get("pojoClass"));
+		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
+		assertTrue(hbmXmlFiles.length == 0);
+		assertSame(additionalContext, arguments.get("map"));
+		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+	}
+	
+	@AfterEach
+	public void afterEach() {
+		new File("foo" + File.separator + "Bar.hbm.xml").delete();
+		new File("foo").delete();
+	}
+		
+	private POJOClass createPojoClass() {
+		RootClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
+		Table rootTable = new Table();
+		rootTable.setName("table");
+		persistentClass.setTable(rootTable);
+		persistentClass.setEntityName("Bar");
+		persistentClass.setClassName("foo.Bar");
+		return new EntityPOJOClass(persistentClass, new Cfg2JavaTool());		
+	}
+	
+	private void initializeTemplateHelper() throws Exception {
+		Method setTemplateHelperMethod = AbstractExporter.class.getDeclaredMethod(
+				"setTemplateHelper", 
+				new Class[] { TemplateHelper.class });
+		setTemplateHelperMethod.setAccessible(true);
+		TemplateHelper templateHelper = new TemplateHelper();
+		templateHelper.init(null, new String[0]);
+		setTemplateHelperMethod.invoke(
+				hibernateMappingExporterExtension, 
+				new Object[] { templateHelper });		
+	}
+	
+}	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>