### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Implementation of new test class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.QueryExporterFacadeTest' and of the implementation class 'org.jboss.tools.hibernate.runtime.v_6_1.internal.QueryExporterFacadeImpl'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/QueryExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/QueryExporterFacadeImpl.java
@@ -1,5 +1,7 @@
 package org.jboss.tools.hibernate.runtime.v_6_1.internal;
 
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractQueryExporterFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 
@@ -7,6 +9,11 @@ public class QueryExporterFacadeImpl extends AbstractQueryExporterFacade {
 
 	public QueryExporterFacadeImpl(IFacadeFactory facadeFactory, Object target) {
 		super(facadeFactory, target);
+	}
+	
+	@Override
+	public void setFilename(String fileName) {
+		((QueryExporter)getTarget()).getProperties().put(ExporterConstants.OUTPUT_FILE_NAME, fileName);
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/QueryExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/QueryExporterFacadeTest.java
@@ -1,0 +1,46 @@
+package org.jboss.tools.hibernate.runtime.v_6_1.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class QueryExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private QueryExporter queryExporterTarget = null;
+	private IQueryExporter queryExporterFacade = null;
+
+	@BeforeEach
+	public void beforeEach() {
+		queryExporterTarget = new QueryExporter();
+		queryExporterFacade = new QueryExporterFacadeImpl(FACADE_FACTORY, queryExporterTarget);
+	}
+	
+	@Test
+	public void testSetQueries() {
+		List<String> queries = Collections.emptyList();
+		assertNotSame(queries, queryExporterTarget.getProperties().get(ExporterConstants.QUERY_LIST));
+		queryExporterFacade.setQueries(queries);
+		assertSame(queries, queryExporterTarget.getProperties().get(ExporterConstants.QUERY_LIST));
+	}
+	
+	@Test
+	public void testSetFileName() {
+		assertNotEquals("foo", queryExporterTarget.getProperties().get(ExporterConstants.OUTPUT_FILE_NAME));
+		queryExporterFacade.setFilename("foo");
+		assertEquals("foo", queryExporterTarget.getProperties().get(ExporterConstants.OUTPUT_FILE_NAME));
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>