### PR TITLE
JBIDE-28604: Add method IService#createCfgExporter() to remove explicit class naming of 'org.hibernate.tool.hbm2x.HibernateConfigurationExporter'

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/NewConfigurationWizard.java
+++ b/orm/plugin/core/org.hibernate.eclipse.console/src/org/hibernate/eclipse/console/wizards/NewConfigurationWizard.java
@@ -295,7 +295,7 @@ public class NewConfigurationWizard extends Wizard implements INewWizard {
 	private InputStream openContentStream(Properties props) {
         StringWriter stringWriter = new StringWriter();
         IService service = RuntimeServiceManager.getInstance().findService(connectionInfoPage.getHibernateVersion()); 
-        IExporter hce = service.createExporter("org.hibernate.tool.hbm2x.HibernateConfigurationExporter"); //$NON-NLS-1$
+        IExporter hce = service.createCfgExporter();
  		hce.setCustomProperties(props);
 		hce.setOutput(stringWriter);
         hce.start();

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractService.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractService.java
@@ -1,11 +1,20 @@
 package org.jboss.tools.hibernate.runtime.common;
 
+import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IService;
 
 public abstract class AbstractService implements IService {
 	
+	public IExporter createCfgExporter() {
+		return createExporter(getCfgExporterClassName());
+	}
+	
 	protected UsageTracker getUsageTracker() {
 		return UsageTracker.getInstance();
+	}
+	
+	protected String getCfgExporterClassName() {
+		return "org.hibernate.tool.hbm2x.HibernateConfigurationExporter";
 	}
 	
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IService.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IService.java
@@ -31,6 +31,8 @@ public interface IService {
 
 	IConfiguration newJDBCMetaDataConfiguration();
 	
+	IExporter createCfgExporter();
+	
 	IExporter createExporter(
 			String exporterClassName);
 	

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ServiceImpl.java
@@ -483,6 +483,11 @@ public class ServiceImpl extends AbstractService {
 	public ClassLoader getClassLoader() {
 		return ServiceImpl.class.getClassLoader();
 	}
+	
+	@Override
+	protected String getCfgExporterClassName() {
+		return CfgExporter.class.getName();
+	}
 
 	private Object newReverseEngineeringStrategy(final String className, Object delegate) {
         try {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ServiceImplTest.java
@@ -369,6 +369,13 @@ public class ServiceImplTest {
 	}
 	
 	@Test
+	public void testGetCfgExporterClassName() {
+		assertEquals(
+				CfgExporter.class.getName(), 
+				service.getCfgExporterClassName());
+	}
+	
+	@Test
 	public void testSimpleValue() {
 		IValue simpleValue = service.newSimpleValue();
 		assertNotNull(simpleValue);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>