### PR TITLE
JBIDE-28549: Create a Runtime Plugin for Hibernate 6.1 - Use plugin bundle localization and externalize the 'hibernate.version' property in the 'plugin.properties' file

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.1 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_1;singleton:=true
 Bundle-Version: 5.4.18.qualifier
+Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_12,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/plugin.properties
@@ -1,0 +1,1 @@
+hibernate.version=6.1

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/plugin.xml
@@ -5,7 +5,7 @@
          point="org.jboss.tools.hibernate.runtime.spi.services">
       <service
             class="org.jboss.tools.hibernate.runtime.v_6_1.internal.ServiceImpl"
-            name="6.1">
+            name="%hibernate.version">
       </service>
    </extension>
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>