### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Create new test class 'org.jboss.tools.hibernate.orm.runtime.exp.test.VersionTest' and add dependency on 'org.hibernate.orm:hibernate-core:6.1.2.Final'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Bundle-Version: 5.4.18.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.jboss.tools.hibernate.orm.runtime.exp
+Bundle-ClassPath: lib/hibernate-core-6.1.2.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/build.properties
@@ -1,0 +1,3 @@
+bin.includes = .,\
+               META-INF/,\
+               lib/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -10,4 +10,48 @@
 	<artifactId>org.jboss.tools.hibernate.orm.runtime.exp</artifactId> 
 	
 	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<hibernate.orm.version>6.1.2.Final</hibernate.orm.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>get-libs</id>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<phase>generate-resources</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.hibernate.orm</groupId>
+							<artifactId>hibernate-core</artifactId>
+							<version>${hibernate.orm.version}</version>
+						</artifactItem>
+					</artifactItems>
+					<skip>false</skip>
+					<outputDirectory>${basedir}/lib</outputDirectory>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/lib</directory>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/test/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/test/VersionTest.java
@@ -1,0 +1,14 @@
+package org.jboss.tools.hibernate.orm.runtime.exp.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class VersionTest {
+	
+	@Test 
+	public void testCoreVersion() {
+		assertEquals("6.1.2.Final", org.hibernate.Version.getVersionString());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>