### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Move 'VersionTest' from package 'org.jboss.tools.hibernate.orm.runtime.exp.test' to 'org.jboss.tools.hibernate.orm.runtime.exp'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.hibernate.orm.runtime.exp.test;
+package org.jboss.tools.hibernate.orm.runtime.exp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>