### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Add new test method 'VersionTest#testToolsVersion()' and add dependency on 'org.hibernate.tool:hibernate-tools-orm:6.1.2.Final'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Bundle-Version: 5.4.18.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.jboss.tools.hibernate.orm.runtime.exp
-Bundle-ClassPath: lib/hibernate-core-6.1.2.Final.jar
+Bundle-ClassPath: lib/hibernate-core-6.1.2.Final.jar,
+ lib/hibernate-tools-orm-6.1.2.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -13,6 +13,7 @@
 
 	<properties>
 		<hibernate.orm.version>6.1.2.Final</hibernate.orm.version>
+		<hibernate.tools.version>6.1.2.Final</hibernate.tools.version>
 	</properties>
 
 	<build>
@@ -31,6 +32,11 @@
 				</executions>
 				<configuration>
 					<artifactItems>
+						<artifactItem>
+							<groupId>org.hibernate.tool</groupId>
+							<artifactId>hibernate-tools-orm</artifactId>
+							<version>${hibernate.tools.version}</version>
+						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.orm</groupId>
 							<artifactId>hibernate-core</artifactId>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -11,4 +11,9 @@ public class VersionTest {
 		assertEquals("6.1.2.Final", org.hibernate.Version.getVersionString());
 	}
 
+	@Test
+	public void testToolsVersion() {
+		assertEquals("6.1.2.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+	}
+	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>