### PR TITLE
JBIDE-28667: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_6_1 to version 6.1.3.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.1.2.Final.jar,
- lib/hibernate-core-6.1.2.Final.jar,
- lib/hibernate-tools-orm-6.1.2.Final.jar,
- lib/hibernate-tools-utils-6.1.2.Final.jar
+ lib/hibernate-ant-6.1.3.Final.jar,
+ lib/hibernate-core-6.1.3.Final.jar,
+ lib/hibernate-tools-orm-6.1.3.Final.jar,
+ lib/hibernate-tools-utils-6.1.3.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>6.1.2.Final</hibernate.version>
+		<hibernate.version>6.1.3.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/VersionTest.java
@@ -11,12 +11,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.1.2.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.1.3.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.1.2.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.1.3.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>