### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Update dependency on Hibernate Tools to 6.1.5-SNAPSHOT

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -23,6 +23,6 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
 Bundle-ClassPath: .,
  lib/hibernate-ant-6.1.4.Final.jar,
  lib/hibernate-core-6.1.4.Final.jar,
- lib/hibernate-tools-orm-6.1.4-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.1.4-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.1.4-SNAPSHOT.jar
+ lib/hibernate-tools-orm-6.1.5-SNAPSHOT.jar,
+ lib/hibernate-tools-orm-jbt-6.1.5-SNAPSHOT.jar,
+ lib/hibernate-tools-utils-6.1.5-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -13,7 +13,7 @@
 
 	<properties>
 		<hibernate.orm.version>6.1.4.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.1.4-SNAPSHOT</hibernate.tools.version>
+		<hibernate.tools.version>6.1.5-SNAPSHOT</hibernate.tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -13,7 +13,7 @@ public class VersionTest {
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.1.4-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.1.5-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>