### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Override 'AbstractFacadeFactory#createArtifactCollector(Object)' to use 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -1,7 +1,10 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.runtime.common.AbstractArtifactCollectorFacade;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
@@ -28,7 +31,14 @@ import org.jboss.tools.hibernate.runtime.spi.IType;
 import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 
 public class FacadeFactoryImpl  extends AbstractFacadeFactory {
-
+	
+	private WrapperFactory wrapperFactory = new WrapperFactory();
+	
+	@Override
+	public IArtifactCollector createArtifactCollector(Object target) {
+		return new AbstractArtifactCollectorFacade(this, wrapperFactory.createArtifactCollectorWrapper()) {};
+	}
+	
 	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/Foo.hbm.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/Foo.hbm.xml
@@ -1,1 +1,0 @@
-<hibernate-mapping package='org.jboss.tools.hibernate.orm.runtime.exp.internal'>  <class name='ConfigurationFacadeTest$Foo'>    <id name='id'/>  </class></hibernate-mapping>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/foobarfile.cfg.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/foobarfile.cfg.xml
@@ -1,1 +1,0 @@
-<hibernate-configuration>  <session-factory name='bar'>    <mapping resource='Foo.hbm.xml' />  </session-factory></hibernate-configuration>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/hibernate.cfg.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/hibernate.cfg.xml
@@ -1,1 +1,0 @@
-<hibernate-configuration>  <session-factory name='bar'>    <mapping resource='Foo.hbm.xml' />  </session-factory></hibernate-configuration>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -107,9 +108,10 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateArtifactCollector() {
-		ArtifactCollector artifactCollector = new DefaultArtifactCollector();
-		IArtifactCollector facade = facadeFactory.createArtifactCollector(artifactCollector);
-		assertSame(artifactCollector, ((IFacade)facade).getTarget());
+		IArtifactCollector facade = facadeFactory.createArtifactCollector(null);
+		Object target = ((IFacade)facade).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof DefaultArtifactCollector);
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>