### PR TITLE
JBIDE-28723: Missing dependency in library plugin 'org.jboss.tools.hibernate.libs.jaxb.v_2_3_5' - Add dependency on 'javax.activation:javax.activation-api:1.2.0'

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/jakarta.xml.bind-api-2.3.3.jar,
- lib/jaxb-osgi-2.3.5.jar
+ lib/jaxb-osgi-2.3.5.jar,
+ lib/javax.activation-api-1.2.0.jar
 Export-Package: com.sun.codemodel,
  com.sun.codemodel.fmt,
  com.sun.codemodel.util,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/pom.xml
@@ -12,6 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<properties>
+	    <activation.version>1.2.0</activation.version>
 	    <jaxb-api.version>2.3.3</jaxb-api.version>
 	    <jaxb-osgi.version>2.3.5</jaxb-osgi.version>
 	</properties>
@@ -32,6 +33,11 @@
 	            </executions>
 	            <configuration>
 	                <artifactItems>
+	                    <artifactItem>
+	                        <groupId>javax.activation</groupId>
+	                        <artifactId>javax.activation-api</artifactId>
+	                        <version>${activation.version}</version>
+	                    </artifactItem>
 						<artifactItem>
 							<groupId>jakarta.xml.bind</groupId>
 							<artifactId>jakarta.xml.bind-api</artifactId>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>