### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Override 'AbstractFacadeFactory#createCfg2HbmTool(Object)' to use 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -3,8 +3,10 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractArtifactCollectorFacade;
+import org.jboss.tools.hibernate.runtime.common.AbstractCfg2HbmToolFacade;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
+import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
@@ -37,6 +39,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	@Override
 	public IArtifactCollector createArtifactCollector(Object target) {
 		return new AbstractArtifactCollectorFacade(this, wrapperFactory.createArtifactCollectorWrapper()) {};
+	}
+	
+	@Override
+	public ICfg2HbmTool createCfg2HbmTool(Object target) {
+		return new AbstractCfg2HbmToolFacade(this, wrapperFactory.createCfg2HbmWrapper()) {};
 	}
 	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -116,9 +116,10 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateCfg2HbmTool() {
-		Cfg2HbmTool cfg2HbmTool = new Cfg2HbmTool();
-		ICfg2HbmTool facade = facadeFactory.createCfg2HbmTool(cfg2HbmTool);
-		assertSame(cfg2HbmTool,  ((IFacade)facade).getTarget());
+		ICfg2HbmTool facade = facadeFactory.createCfg2HbmTool(null);
+		Object target = ((IFacade)facade).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof Cfg2HbmTool);
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>