### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Add new class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory' and test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactoryTest' to create facades generically

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -1,0 +1,42 @@
+package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+
+public class GenericFacadeFactory {
+	
+	public static IFacade createFacade(Class<?> facadeClass, Object target) {
+		return (IFacade)Proxy.newProxyInstance(
+					GenericFacadeFactory.class.getClassLoader(), 
+					new Class[] { facadeClass, IFacade.class }, 
+					new InvocationHandler() {						
+						@Override
+						public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+							if ("getTarget".equals(method.getName())) {
+								return target;
+							} else {
+								Method targetMethod = target.getClass().getMethod(
+										method.getName(), 
+										constructArgumentClasses(args));
+								return targetMethod.invoke(target, args);
+							}
+						}
+					});
+	}
+	
+	private static Class<?>[] constructArgumentClasses(Object[] args) {
+		Class<?>[] result = null;
+		if (args != null) {
+			result = new Class<?>[args.length];
+			for (int i = 0; i < args.length; i++) {
+				result[i] = args[i].getClass();
+			}
+		}
+		return result;
+	}
+	
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactoryTest.java
@@ -1,0 +1,27 @@
+package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.junit.jupiter.api.Test;
+
+public class GenericFacadeFactoryTest {
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testCreateFacade() {
+		ArrayList<String> list = new ArrayList<String>();
+		List<String> listFacade = (List<String>)GenericFacadeFactory.createFacade( List.class, list);
+		assertTrue(listFacade.isEmpty());
+		assertTrue(listFacade instanceof IFacade);
+		assertSame(list, ((IFacade)listFacade).getTarget());
+		list.add("foo");
+		assertFalse(listFacade.isEmpty());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>