### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Use 'GenericFacadeFactoryy.createFacade(...)' to create the IArtifactCollector instance

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -21,7 +21,9 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	}
 	
 	public IArtifactCollector createArtifactCollector() {
-		return new AbstractArtifactCollectorFacade(this, wrapperFactory.createArtifactCollectorWrapper()) {};
+		return (IArtifactCollector)GenericFacadeFactory.createFacade(
+				IArtifactCollector.class, 
+				wrapperFactory.createArtifactCollectorWrapper());
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>