### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Adapt 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImplTest#testNamingStrategy()' for changes in orm-jbt module

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -213,10 +213,10 @@ public class ServiceImplTest {
 		namingStrategy = null;
 		assertNull(namingStrategy);
 		try {
-			namingStrategy = service.newNamingStrategy("some unexistant class");
+			namingStrategy = service.newNamingStrategy("some unexistent class");
 		} catch (Throwable t) {
 			assertTrue(t.getMessage().contains(
-					"java.lang.ClassNotFoundException: some unexistant class cannot be found"));
+					"Exception while looking up class 'some unexistent class'"));
 		}
 		assertNull(namingStrategy);
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>