### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Use 'GenericFacadeFactoryy.createFacade(...)' to create the IOverrideRepository instance and adapt the relevant tests

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -62,7 +62,7 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	public IOverrideRepository createOverrideRepository(Object target) {
-		return new OverrideRepositoryFacadeImpl(this, target);
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 	
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -197,7 +197,7 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IOverrideRepository newOverrideRepository() {
-		return facadeFactory.createOverrideRepository(new OverrideRepository());
+		return newFacadeFactory.createOverrideRepository();
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -2,10 +2,10 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.AbstractNamingStrategyFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
+import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 
@@ -44,6 +44,17 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return (INamingStrategy)GenericFacadeFactory.createFacade(
 				INamingStrategy.class, 
 				wrapperFactory.createNamingStrategyWrapper(namingStrategyClassName));
+	}
+	
+	@Override
+	public IOverrideRepository createOverrideRepository(Object target) {
+		throw new RuntimeException("Use 'NewFacadeFactory#createOverrideRepository()");		
+	}
+	
+	public IOverrideRepository createOverrideRepository() {
+		return (IOverrideRepository)GenericFacadeFactory.createFacade(
+				IOverrideRepository.class, 
+				wrapperFactory.createOverrideRepositoryWrapper());
 	}
 
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -57,7 +57,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
-import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IPrimaryKey;
@@ -144,10 +143,12 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateOverrideRepository() {
-		OverrideRepository overrideRepository = new OverrideRepository();
-		IOverrideRepository facade = FACADE_FACTORY.createOverrideRepository(overrideRepository);
-		assertTrue(facade instanceof OverrideRepositoryFacadeImpl);
-		assertSame(overrideRepository, ((IFacade)facade).getTarget());		
+		try {
+			FACADE_FACTORY.createOverrideRepository(new OverrideRepository());
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());			
+		}
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
+import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +46,14 @@ public class NewFacadeFactoryTest {
 		Object target = ((IFacade)facade).getTarget();
 		assertNotNull(target);
 		assertTrue(target instanceof DefaultNamingStrategy);
+	}
+	
+	@Test
+	public void testCreateOverrideRepository() {
+		IOverrideRepository facade = facadeFactory.createOverrideRepository();
+		Object target = ((IFacade)facade).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof OverrideRepository);
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>