### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Replace test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.Cfg2HbmToolFacadeTest' by 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ICfg2HbmToolTest' (remove reference to AbstractCfg2HbmToolFacade)

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
@@ -6,35 +6,31 @@ import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
-import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
-import org.jboss.tools.hibernate.runtime.common.AbstractCfg2HbmToolFacade;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractPropertyFacade;
-import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class Cfg2HbmToolFacadeTest {
-	
-	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
-	
-	private ICfg2HbmTool cfg2HbmToolFacade = null;
-	private Cfg2HbmTool cfg2HbmToolTarget = null;
+public class ICfg2HbmToolTest {
+
+	private static final NewFacadeFactory FACADE_FACTORY = new NewFacadeFactory();
+
+	private ICfg2HbmTool facade = null;
 	
 	@BeforeEach
-	public void before() {
-		cfg2HbmToolTarget = new Cfg2HbmTool();
-		cfg2HbmToolFacade = new AbstractCfg2HbmToolFacade(FACADE_FACTORY, cfg2HbmToolTarget) {};
+	public void beforeEach() {
+		facade = FACADE_FACTORY.createCfg2HbmTool();
 	}
-	
+
 	@Test
 	public void testGetTagPersistentClass() {
 		PersistentClass target = new RootClass(DummyMetadataBuildingContext.INSTANCE);
 		IPersistentClass persistentClass = FACADE_FACTORY.createPersistentClass(target);
-		assertEquals("class", cfg2HbmToolFacade.getTag(persistentClass));
+		assertEquals("class", facade.getTag(persistentClass));
 	}
 
 	@Test
@@ -47,7 +43,7 @@ public class Cfg2HbmToolFacadeTest {
 		p.setPersistentClass(rc);
 		rc.setVersion(p);
 		IProperty property = new AbstractPropertyFacade(FACADE_FACTORY, p) {};
-		assertEquals("version", cfg2HbmToolFacade.getTag(property));
+		assertEquals("version", facade.getTag(property));
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>