### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Update Hibernate core dependency to version 6.1.5.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.1.4.Final.jar,
- lib/hibernate-core-6.1.4.Final.jar,
+ lib/hibernate-ant-6.1.5.Final.jar,
+ lib/hibernate-core-6.1.5.Final.jar,
  lib/hibernate-tools-orm-6.1.5-SNAPSHOT.jar,
  lib/hibernate-tools-orm-jbt-6.1.5-SNAPSHOT.jar,
  lib/hibernate-tools-utils-6.1.5-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.1.4.Final</hibernate.orm.version>
+		<hibernate.orm.version>6.1.5.Final</hibernate.orm.version>
 		<hibernate.tools.version>6.1.5-SNAPSHOT</hibernate.tools.version>
 	</properties>
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.1.4.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.1.5.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/EntityMetamodelFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/EntityMetamodelFacadeTest.java
@@ -124,6 +124,7 @@ public class EntityMetamodelFacadeTest {
 			basicValue.setTypeName(Integer.class.getName());
 			rootClass.setIdentifier(basicValue);
 			rootClass.setOptimisticLockStyle(OptimisticLockStyle.NONE);
+			rootClass.setEntityName("foo");
 			return new FooBarMetamodel(rootClass, runtimeModelCreationContext);
 		}
 		

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeTest.java
@@ -79,6 +79,7 @@ public class ForeignKeyFacadeTest {
 	@Test
 	public void testContainsColumn() {
 		Column column = new Column();
+		column.setName("foo");
 		IColumn columnFacade = FACADE_FACTORY.createColumn(column);
 		assertFalse(foreignKeyFacade.containsColumn(columnFacade));
 		foreignKey.addColumn(column);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/PrimaryKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/PrimaryKeyFacadeTest.java
@@ -108,6 +108,7 @@ public class PrimaryKeyFacadeTest {
 	@Test
 	public void testContainsColumn() {
 		Column columnTarget = new Column();
+		columnTarget.setName("foo");
 		IColumn columnFacade = FACADE_FACTORY.createColumn(columnTarget);
 		assertFalse(primaryKeyFacade.containsColumn(columnFacade));
 		primaryKeyTarget.addColumn(columnTarget);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>