### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Create and use 'NewFacadeFactory#createReverseEngineeringStrategy(String)' which accepts the name of the reveng strategy class to use instead of 'FacadeFactoryImpl#createReverseEngineeringStrategy(Object)

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -57,14 +57,15 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
-	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object target) {
-		return new ReverseEngineeringStrategyFacadeImpl(this, target);
-	}
-
 	public IOverrideRepository createOverrideRepository(Object target) {
 		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 	
+	@Override
+	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object target) {
+		return new ReverseEngineeringStrategyFacadeImpl(this, target);
+	}
+
 	@Override
 	public ISchemaExport createSchemaExport(Object target) {
 		return new SchemaExportFacadeImpl(this, target);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -8,6 +8,7 @@ import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
+import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 
 public class NewFacadeFactory extends AbstractFacadeFactory {
 	
@@ -61,7 +62,16 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 				wrapperFactory.createOverrideRepositoryWrapper());
 	}
 
+	@Override 
+	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object target) {
+		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
+	}
 	
+	public IReverseEngineeringStrategy createReverseEngineeringStrategy(String revengStrategyClassName) {
+		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				wrapperFactory.createReverseEngineeringStrategyWrapper(revengStrategyClassName));				
+	}
 	
 	@Override
 	public ClassLoader getClassLoader() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
@@ -65,8 +64,8 @@ public class IOverrideRepositoryTest {
 	
 	@Test
 	public void testGetReverseEngineeringStrategy() throws Exception {
-		RevengStrategy res = new DefaultStrategy();
-		IReverseEngineeringStrategy resFacade = FACADE_FACTORY.createReverseEngineeringStrategy(res);
+		IReverseEngineeringStrategy resFacade = FACADE_FACTORY.createReverseEngineeringStrategy(DefaultStrategy.class.getName());
+		Object res = ((IFacade)resFacade).getTarget();
 		IReverseEngineeringStrategy result = overrideRepositoryFacade.getReverseEngineeringStrategy(resFacade);
 		DelegatingStrategy resultTarget = 
 				(DelegatingStrategy)((IFacade)result).getTarget();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -1,18 +1,24 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
 import org.hibernate.tool.internal.export.common.DefaultArtifactCollector;
 import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
+import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,5 +62,24 @@ public class NewFacadeFactoryTest {
 		assertNotNull(target);
 		assertTrue(target instanceof OverrideRepository);
 	}
+	
+	@Test
+	public void testCreateRevengStrategy() throws Exception {
+		IReverseEngineeringStrategy facade = facadeFactory.createReverseEngineeringStrategy(null);
+		Object target = ((IFacade)facade).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof DefaultStrategy);
+		facade = null;
+		assertNull(facade);
+		facade = facadeFactory.createReverseEngineeringStrategy(TestRevengStrategy.class.getName());
+		target = ((IFacade)facade).getTarget();
+		assertNotNull(target);
+		assertTrue(target instanceof DelegatingStrategy);
+		Field delegateField = DelegatingStrategy.class.getDeclaredField("delegate");
+		delegateField.setAccessible(true);
+		assertTrue(delegateField.get(target) instanceof TestRevengStrategy);
+	}
+	
+	public static class TestRevengStrategy extends DefaultStrategy {}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>