### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Remove unneeded method 'NewFacadeFactory#createReverseEngineeringStrategy(String)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -74,12 +74,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 				wrapperFactory.createReverseEngineeringStrategyWrapper());				
 	}
 	
-	public IReverseEngineeringStrategy createReverseEngineeringStrategy(String className) {
-		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
-				IReverseEngineeringStrategy.class, 
-				wrapperFactory.createReverseEngineeringStrategyWrapper(className));				
-	}
-	
 	public IReverseEngineeringStrategy createReverseEngineeringStrategy(
 			String className, 
 			IReverseEngineeringStrategy delegate) {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ConfigurationFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ConfigurationFacadeTest.java
@@ -36,7 +36,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.reveng.RevengStrategy;
-import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.JdbcMetadataConfiguration;
 import org.hibernate.tool.orm.jbt.util.MetadataHelper;
@@ -315,7 +314,7 @@ public class ConfigurationFacadeTest {
 		JdbcMetadataConfiguration configuration = new JdbcMetadataConfiguration();
 		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
 		IReverseEngineeringStrategy strategyFacade = 
-				NEW_FACADE_FACTORY.createReverseEngineeringStrategy(DefaultStrategy.class.getName());
+				NEW_FACADE_FACTORY.createReverseEngineeringStrategy();
 		RevengStrategy reverseEngineeringStrategy = (RevengStrategy)((IFacade)strategyFacade).getTarget();
 		assertNotSame(
 				reverseEngineeringStrategy,

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
@@ -64,7 +63,7 @@ public class IOverrideRepositoryTest {
 	
 	@Test
 	public void testGetReverseEngineeringStrategy() throws Exception {
-		IReverseEngineeringStrategy resFacade = FACADE_FACTORY.createReverseEngineeringStrategy(DefaultStrategy.class.getName());
+		IReverseEngineeringStrategy resFacade = FACADE_FACTORY.createReverseEngineeringStrategy();
 		Object res = ((IFacade)resFacade).getTarget();
 		IReverseEngineeringStrategy result = overrideRepositoryFacade.getReverseEngineeringStrategy(resFacade);
 		DelegatingStrategy resultTarget = 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>