### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Replace overloaded methods 'NewFacadeFactory#createReverseEngineeringStrategy(...)' by new method that makes use of 'WrapperFactory#createRevengStrategy(Objects...)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -269,7 +269,9 @@ public class ServiceImpl extends AbstractService {
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
 			IReverseEngineeringStrategy delegate) {
-		return newFacadeFactory.createReverseEngineeringStrategy(strategyName, delegate);
+		return newFacadeFactory.createReverseEngineeringStrategy(
+				strategyName, 
+				((IFacade)delegate).getTarget());
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -2,7 +2,6 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
@@ -68,19 +67,10 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
 	}
 	
-	public IReverseEngineeringStrategy createReverseEngineeringStrategy() {
+	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object...objects) {
 		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
 				IReverseEngineeringStrategy.class, 
-				wrapperFactory.createReverseEngineeringStrategyWrapper());				
-	}
-	
-	public IReverseEngineeringStrategy createReverseEngineeringStrategy(
-			String className, 
-			IReverseEngineeringStrategy delegate) {
-		Object delegateTarget = ((IFacade)delegate).getTarget();
-		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
-				IReverseEngineeringStrategy.class, 
-				wrapperFactory.createReverseEngineeringStrategyWrapper(className, delegateTarget));				
+				wrapperFactory.createRevengStrategyWrapper(objects));				
 	}
 	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -52,7 +52,6 @@ import org.hibernate.tool.orm.jbt.util.JdbcMetadataConfiguration;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
-import org.hibernate.tool.orm.jbt.wrp.NamingStrategyWrapper;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -70,14 +70,14 @@ public class NewFacadeFactoryTest {
 		Object firstTarget = ((IFacade)facade).getTarget();
 		assertNotNull(firstTarget);
 		assertTrue(firstTarget instanceof DefaultStrategy);
-		facade = facadeFactory.createReverseEngineeringStrategy(TestRevengStrategy.class.getName(), facade);
+		facade = facadeFactory.createReverseEngineeringStrategy(TestRevengStrategy.class.getName(), firstTarget);
 		Object secondTarget = ((IFacade)facade).getTarget();
 		assertNotNull(secondTarget);
 		assertTrue(secondTarget instanceof DelegatingStrategy);
 		Field delegateField = DelegatingStrategy.class.getDeclaredField("delegate");
 		delegateField.setAccessible(true);
 		assertSame(delegateField.get(secondTarget), firstTarget);
-		facade = facadeFactory.createReverseEngineeringStrategy(DefaultStrategy.class.getName(), facade);
+		facade = facadeFactory.createReverseEngineeringStrategy(DefaultStrategy.class.getName(), secondTarget);
 		Object thirdTarget = ((IFacade)facade).getTarget();
 		assertNotNull(thirdTarget);
 		assertTrue(thirdTarget instanceof DefaultStrategy);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>