### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Rename test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ReverseEngineeringStrategyFacadeTest' into 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringStrategyTest' and make use of 'NewFacadeFactory'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
@@ -8,24 +8,23 @@ import java.lang.reflect.Field;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
-import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
-import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.junit.jupiter.api.Test;
 
-public class ReverseEngineeringStrategyFacadeTest {
+public class IReverseEngineeringStrategyTest {
 
-	private static IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	private static NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	
 	@Test
 	public void testSetSettings() throws Exception {
-		RevengStrategy revengStrategyTarget = new DefaultStrategy();
+		IReverseEngineeringStrategy revengStrategyFacade = FACADE_FACTORY.createReverseEngineeringStrategy();
+		RevengStrategy revengStrategyTarget = (RevengStrategy)((IFacade)revengStrategyFacade).getTarget();
 		RevengSettings revengSettingsTarget = new RevengSettings(revengStrategyTarget);
 		IReverseEngineeringSettings revengSettingsFacade = 
 				FACADE_FACTORY.createReverseEngineeringSettings(revengSettingsTarget);
-		IReverseEngineeringStrategy revengStrategyFacade = 
-				new ReverseEngineeringStrategyFacadeImpl(FACADE_FACTORY, revengStrategyTarget);
 		Field field = AbstractStrategy.class.getDeclaredField("settings");
 		field.setAccessible(true);
 		assertNotSame(field.get(revengStrategyTarget), revengSettingsTarget);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>