### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer - Rename test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ReverseEngineeringSettingsFacadeTest' to 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringSettingsTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
@@ -12,7 +12,7 @@ import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ReverseEngineeringSettingsFacadeTest {
+public class IReverseEngineeringSettingsTest {
 
 	private static NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>