### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Implement method 'NewFacadeFactory#createJpaConfiguration(String,Properties)' and test method 'NewFacadeFactoryTest#testCreateJpaConfiguration()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,5 +1,7 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
+import java.util.Properties;
+
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
@@ -92,6 +94,12 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return (IConfiguration)GenericFacadeFactory.createFacade(
 				IConfiguration.class, 
 				wrapperFactory.createRevengConfigurationWrapper());
+	}
+ 	
+	public IConfiguration createJpaConfiguration(String persistenceUnit, Properties properties) {
+		return (IConfiguration)GenericFacadeFactory.createFacade(
+				IConfiguration.class, 
+				wrapperFactory.createJpaConfigurationWrapper(persistenceUnit, properties));
 	}
  	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -15,6 +15,7 @@ import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
+import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -116,6 +117,15 @@ public class NewFacadeFactoryTest {
 		Object revengConfigurationTarget = ((IFacade)revengConfigurationFacade).getTarget();
 		assertNotNull(revengConfigurationTarget);
 		assertTrue(revengConfigurationTarget instanceof RevengConfiguration);
+	}
+	
+	@Test
+	public void testCreateJpaConfiguration() {
+		IConfiguration jpaConfigurationFacade = facadeFactory.createJpaConfiguration(null, null);
+		assertNotNull(jpaConfigurationFacade);
+		Object jpaConfigurationTarget = ((IFacade)jpaConfigurationFacade).getTarget();
+		assertNotNull(jpaConfigurationTarget);
+		assertTrue(jpaConfigurationTarget instanceof JpaConfiguration);
 	}
 	
 	public static class TestRevengStrategy extends DelegatingStrategy {


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>