### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Use 'NewFacadeFactory#createNativeConfiguration()' in the implementation of 'ServiceImpl#newDefaultConfiguration()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
@@ -19,7 +19,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		this.facadeFactory = facadeFactory;
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
-				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)cfg));
+				new ConfigurationMetadataDescriptor((IConfiguration)cfg));
 		if (file != null) {
 			getProperties().put(OUTPUT_FILE_NAME, file);
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SchemaExportFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SchemaExportFacadeImpl.java
@@ -3,9 +3,12 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import java.util.EnumSet;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.schema.TargetType;
 import org.jboss.tools.hibernate.runtime.common.AbstractSchemaExportFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 
@@ -20,7 +23,8 @@ public class SchemaExportFacadeImpl extends AbstractSchemaExportFacade {
 	}
 
 	public void setConfiguration(IConfiguration configuration) {
-		metadata = ((ConfigurationFacadeImpl)configuration).getMetadata();
+		metadata = MetadataHelper.getMetadata((Configuration)((IFacade)configuration).getTarget());
+//		metadata = ((ConfigurationFacadeImpl)configuration).getMetadata();
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -59,6 +59,7 @@ import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
@@ -116,7 +117,7 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public IConfiguration newDefaultConfiguration() {
 		getUsageTracker().trackNewConfigurationEvent(HIBERNATE_VERSION);
-		return facadeFactory.createConfiguration(new Configuration());
+		return newFacadeFactory.createNativeConfiguration();
 	}
 
 	@Override
@@ -140,9 +141,9 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public IHQLCodeAssist newHQLCodeAssist(IConfiguration hcfg) {
 		IHQLCodeAssist result = null;
-		if (hcfg instanceof ConfigurationFacadeImpl) {
+		if (hcfg instanceof IConfiguration) {
 			result = facadeFactory.createHQLCodeAssist(
-					new HQLCodeAssist(((ConfigurationFacadeImpl)hcfg).getMetadata()));
+					new HQLCodeAssist(MetadataHelper.getMetadata((Configuration)((IFacade)hcfg).getTarget())));
 		}
 		return result;
 	}
@@ -164,7 +165,7 @@ public class ServiceImpl extends AbstractService {
 		} else {
 			exporter.getProperties().put(
 					ExporterConstants.METADATA_DESCRIPTOR,
-					new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)newDefaultConfiguration()));
+					new ConfigurationMetadataDescriptor(newDefaultConfiguration()));
 		}
 		return facadeFactory.createExporter(exporter);
 	}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptor.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptor.java
@@ -1,32 +1,25 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
-import java.lang.reflect.Field;
-import java.util.HashMap;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.internal.MetadataImpl;
-import org.hibernate.mapping.PersistentClass;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.ConfigurationFacadeImpl;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 
 public class ConfigurationMetadataDescriptor implements MetadataDescriptor {
 
-	ConfigurationFacadeImpl configurationFacade;
+	IConfiguration configurationFacade;
 	
-	public ConfigurationMetadataDescriptor(ConfigurationFacadeImpl configurationFacade) {
+	public ConfigurationMetadataDescriptor(IConfiguration configurationFacade) {
 		this.configurationFacade = configurationFacade;
 	}
 
 	@Override
 	public Metadata createMetadata() {
-		Metadata result = configurationFacade.getMetadata();
-		if (result != null) {
-			result = patch(result);
-		}
-		return result;
+		return MetadataHelper.getMetadata((Configuration)((IFacade)configurationFacade).getTarget());
 	}
 
 	@Override
@@ -34,29 +27,4 @@ public class ConfigurationMetadataDescriptor implements MetadataDescriptor {
 		return configurationFacade.getProperties();
 	}
 
-	private Metadata patch(Metadata metadata) {
-		try {
-			if (metadata instanceof MetadataImpl ) {
-				MetadataImpl metadataImpl = (MetadataImpl)metadata;
-				Field entityBindingMapField = metadataImpl.getClass().getDeclaredField("entityBindingMap");
-				if (entityBindingMapField != null) {
-					entityBindingMapField.setAccessible(true);
-					Object object = entityBindingMapField.get(metadataImpl);
-					if (object instanceof HashMap<?, ?>) {
-						@SuppressWarnings("unchecked")
-						HashMap<String, PersistentClass> map = (HashMap<String, PersistentClass>)object;
-						for (IPersistentClass ipc : configurationFacade.getAddedClasses()) {
-							PersistentClass pc = (PersistentClass)((IFacade)ipc).getTarget();
-							map.put(pc.getEntityName(), pc);
-						}
-					}
-				}
-			}
-			return metadata;
-		}
-		catch (Throwable t) {
-			throw new RuntimeException("Problem while creating metadata", t);
-		}
-	} 
-	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
@@ -398,6 +398,9 @@ public class IConfigurationTest {
 				"org.jboss.tools.hibernate.orm.runtime.exp.internal.IConfigurationTest$Foo";
 		Metadata metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNull(metadata.getEntityBinding(fooClassName));
+		Field metadataField = NativeConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		metadataField.set(nativeConfigurationTarget, null);
 		nativeConfigurationFacade.configure(cfgXmlFile);
 		metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNotNull(metadata.getEntityBinding(fooClassName));
@@ -443,6 +446,9 @@ public class IConfigurationTest {
 				"org.jboss.tools.hibernate.orm.runtime.exp.internal.IConfigurationTest$Foo";
 		Metadata metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNull(metadata.getEntityBinding(fooClassName));
+		Field metadataField = NativeConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		metadataField.set(nativeConfigurationTarget, null);
 		nativeConfigurationFacade.configure();
 		metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNotNull(metadata.getEntityBinding(fooClassName));
@@ -486,6 +492,9 @@ public class IConfigurationTest {
 		// For native configuration		
 		Metadata metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNull(metadata.getEntityBinding(fooClassName));
+		Field metadataField = NativeConfiguration.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		metadataField.set(nativeConfigurationTarget, null);
 		nativeConfigurationFacade.addClass(NEW_FACADE_FACTORY.createPersistentClass(Foo.class));
 		metadata = MetadataHelper.getMetadata(nativeConfigurationTarget);
 		assertNotNull(metadata.getEntityBinding(fooClassName));

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SchemaExportFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SchemaExportFacadeTest.java
@@ -14,16 +14,21 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.schema.TargetType;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SchemaExportFacadeTest {
 	
 	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	private static final NewFacadeFactory NEW_FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 
 	
 	private SchemaExportFacadeImpl schemaExportFacade = null;
@@ -44,13 +49,13 @@ public class SchemaExportFacadeTest {
 	
 	@Test
 	public void testSetConfiguration() {
-		Configuration configurationTarget = new Configuration();
+		IConfiguration configurationFacade = NEW_FACADE_FACTORY.createNativeConfiguration();
+		Configuration configurationTarget = (Configuration)((IFacade)configurationFacade).getTarget();
 		configurationTarget.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
 		configurationTarget.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
-		ConfigurationFacadeImpl configuration = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
-		Metadata metadata = configuration.getMetadata();
+		Metadata metadata = MetadataHelper.getMetadata(configurationTarget);
 		assertNull(schemaExportFacade.metadata);
-		schemaExportFacade.setConfiguration(configuration);
+		schemaExportFacade.setConfiguration(configurationFacade);
 		assertSame(metadata, schemaExportFacade.metadata);
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -49,6 +49,7 @@ import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
@@ -133,7 +134,7 @@ public class ServiceImplTest {
 				(HibernateMappingExporterExtension)((IFacade)hibernateMappingExporter).getTarget();
 		assertSame(file, hmee.getProperties().get(ExporterConstants.OUTPUT_FILE_NAME));
 		assertSame(
-				((ConfigurationFacadeImpl)configuration).getMetadata(), 
+				MetadataHelper.getMetadata((Configuration)((IFacade)configuration).getTarget()),
 				hmee.getMetadata());
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptorTest.java
@@ -3,21 +3,18 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.PrintWriter;
 import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.RootClass;
-import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.ConfigurationFacadeImpl;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl;
-import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,16 +31,17 @@ public class ConfigurationMetadataDescriptorTest {
 		public String id;
 	}
 	
-	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
+	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	
 	private ConfigurationMetadataDescriptor configurationMetadataDescriptor = null;
 	
 	private Configuration configurationTarget = null;
-	private ConfigurationFacadeImpl configurationFacade = null;
+	private IConfiguration configurationFacade = null;
 	
 	@BeforeEach
 	public void beforeEach() {
-		configurationTarget = new Configuration();
+		configurationFacade = FACADE_FACTORY.createNativeConfiguration();
+		configurationTarget = (Configuration)((IFacade)configurationFacade).getTarget();
 		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
 		configurationMetadataDescriptor = new ConfigurationMetadataDescriptor(configurationFacade);
 	}
@@ -62,22 +60,18 @@ public class ConfigurationMetadataDescriptorTest {
 	}
 	
 	@Test
-	public void testCreateMetadata() {
-		MetadataSources metadataSources = new MetadataSources();
-		metadataSources.addInputStream(new ByteArrayInputStream(TEST_HBM_XML_STRING.getBytes()));
-		Configuration configuration = new Configuration(metadataSources);
-		configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
-		configuration.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
-		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configuration);
-		PersistentClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		persistentClass.setEntityName("Bar");
-		IPersistentClass persistentClassFacade = 
-				FACADE_FACTORY.createPersistentClass(persistentClass);	
-		configurationFacade.addClass(persistentClassFacade);
+	public void testCreateMetadata() throws Exception {
+		File testFile = File.createTempFile("test", "hbm.xml");
+		PrintWriter printWriter = new PrintWriter(testFile);
+		printWriter.write(TEST_HBM_XML_STRING);
+		printWriter.close();
+		testFile.deleteOnExit();
+		configurationFacade.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
+		configurationFacade.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
+		configurationFacade.addFile(testFile);
 		configurationMetadataDescriptor = new ConfigurationMetadataDescriptor(configurationFacade);
 		Metadata metadata = configurationMetadataDescriptor.createMetadata();
 		assertNotNull(metadata.getEntityBinding(Foo.class.getName()));
-		assertNotNull(metadata.getEntityBinding("Bar"));
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>