### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Use 'NewFacadeFactory#createRevengConfiguration()' in the implementation of 'ServiceImpl#newJDBCMetaDataConfiguration()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -150,7 +150,7 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IConfiguration newJDBCMetaDataConfiguration() {
-		return facadeFactory.createConfiguration(new RevengConfiguration());
+		return newFacadeFactory.createRevengConfiguration();
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>