### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Use 'NewFacadeFactory#createJpaConfiguration(...)' in the implementation of 'ServiceImpl#newJpaConfiguration(...)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -110,8 +110,7 @@ public class ServiceImpl extends AbstractService {
 			String entityResolver, 
 			String persistenceUnit,
 			Map<Object, Object> overrides) {
-		return facadeFactory.createConfiguration(
-				new JpaConfiguration(persistenceUnit, overrides));
+		return newFacadeFactory.createJpaConfiguration(persistenceUnit, overrides);
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,6 +1,6 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
-import java.util.Properties;
+import java.util.Map;
 
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
@@ -96,7 +96,7 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 				wrapperFactory.createRevengConfigurationWrapper());
 	}
  	
-	public IConfiguration createJpaConfiguration(String persistenceUnit, Properties properties) {
+	public IConfiguration createJpaConfiguration(String persistenceUnit, Map<?,?> properties) {
 		return (IConfiguration)GenericFacadeFactory.createFacade(
 				IConfiguration.class, 
 				wrapperFactory.createJpaConfigurationWrapper(persistenceUnit, properties));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>