### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Use 'IConfiguration' instead of 'ConfigurationFacadeImpl' in implementation and test of 'ColumnFacadeImpl#getSqlType(IConfiguration)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ColumnFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ColumnFacadeImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Value;
+import org.hibernate.tool.orm.jbt.util.MetadataHelper;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.jboss.tools.hibernate.runtime.common.AbstractColumnFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -42,8 +43,8 @@ public class ColumnFacadeImpl extends AbstractColumnFacade {
 		ssrb.applySettings(properties);
 		StandardServiceRegistry ssr = ssrb.build();
 		DialectFactory df = ssr.getService(DialectFactory.class);
-		Dialect dialectTarget = df.buildDialect(transform(properties), null);
-		Metadata metadata = ((ConfigurationFacadeImpl)configuration).getMetadata();
+		Dialect dialectTarget = df.buildDialect(transform(properties), null);		
+		Metadata metadata = MetadataHelper.getMetadata(configurationTarget);
 		TypeConfiguration tc = ((MetadataImpl)metadata).getTypeConfiguration();
 		return targetColumn.getSqlType(
 				tc,

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ColumnFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ColumnFacadeTest.java
@@ -26,8 +26,8 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Value;
 import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 
 public class ColumnFacadeTest {
 
-	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	
 	private IColumn columnFacade = null; 
 	private Column column = null;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>