### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Make method 'FacadeFactoryImpl#createConfiguration(Object)' throw an Exception as the methods 'NewFacadeFactory#create...Configuration(...)' should be used instead

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -64,6 +64,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
+	public IConfiguration createConfiguration(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+
+	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();
 	}
@@ -101,11 +106,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	@Override
 	public IColumn createColumn(Object target) {
 		return new ColumnFacadeImpl(this, target);
-	}
-
-	@Override
-	public IConfiguration createConfiguration(Object target) {
-		return new ConfigurationFacadeImpl(this, target);
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -150,6 +150,16 @@ public class FacadeFactoryTest {
 	}
 	
 	@Test
+	public void testCreateConfiguration() {
+		try {
+			FACADE_FACTORY.createConfiguration(new Configuration());
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());			
+		}
+	}
+	
+	@Test
 	public void testCreateSchemaExport() {
 		SchemaExport schemaExport = new SchemaExport();
 		ISchemaExport facade = FACADE_FACTORY.createSchemaExport(schemaExport);
@@ -225,14 +235,6 @@ public class FacadeFactoryTest {
 		IColumn facade = FACADE_FACTORY.createColumn(column);
 		assertTrue(facade instanceof ColumnFacadeImpl);
 		assertSame(column, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateConfiguration() {
-		Configuration configuration = new Configuration();
-		IConfiguration facade = FACADE_FACTORY.createConfiguration(configuration);
-		assertTrue(facade instanceof ConfigurationFacadeImpl);
-		assertSame(configuration, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>