### PR TITLE
JBIDE-28746: Implement and use the generic adapter for IConfiguration in the experimental Hibernate runtime - Remove references to class 'ConfigurationFacadeImpl' from 'ExporterFacadeImpl', 'ExporterFacadeTest' and 'ConfigurationMetadataDescriptorTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeImpl.java
@@ -22,7 +22,7 @@ public class ExporterFacadeImpl extends AbstractExporterFacade {
 		setCustomProperties(configuration.getProperties());
 		((Exporter)getTarget()).getProperties().put(
 				ExporterConstants.METADATA_DESCRIPTOR, 
-				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)configuration));
+				new ConfigurationMetadataDescriptor(configuration));
 	}
 	
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeTest.java
@@ -13,7 +13,6 @@ import java.io.Writer;
 import java.lang.reflect.Field;
 import java.util.Properties;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
@@ -24,6 +23,7 @@ import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMeta
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
@@ -32,9 +32,7 @@ import org.junit.jupiter.api.Test;
 
 public class ExporterFacadeTest {
 	
-	private static final FacadeFactoryImpl FACADE_FACTORY = new FacadeFactoryImpl();
-	
-	private static final NewFacadeFactory NEW_FACADE_FACTORY = NewFacadeFactory.INSTANCE;
+	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	
 	private Exporter exporterTarget = null;
 	private ExporterFacadeImpl exporterFacade = null;
@@ -55,9 +53,8 @@ public class ExporterFacadeTest {
 		exporterTarget = new CfgExporter();
 		exporterFacade = new ExporterFacadeImpl(FACADE_FACTORY, exporterTarget);
 		Properties properties = new Properties();
-		Configuration configurationTarget = new Configuration();
-		configurationTarget.setProperties(properties);
-		ConfigurationFacadeImpl configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
+		IConfiguration configurationFacade = FACADE_FACTORY.createNativeConfiguration();
+		configurationFacade.setProperties(properties);
 		exporterFacade.setConfiguration(configurationFacade);	
 		assertSame(properties, ((CfgExporter)exporterTarget).getCustomProperties());
 		Object object = exporterTarget.getProperties().get(ExporterConstants.METADATA_DESCRIPTOR);
@@ -68,14 +65,14 @@ public class ExporterFacadeTest {
 		field.setAccessible(true);
 		object = field.get(configurationMetadataDescriptor);
 		assertNotNull(object);
-		assertTrue(object instanceof ConfigurationFacadeImpl);
+		assertTrue(object instanceof IConfiguration);
 		assertSame(object, configurationFacade);
 	}
 	
 	@Test
 	public void testSetArtifactCollector() {
 		assertNull(exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
-		IArtifactCollector artifactCollectorFacade = NEW_FACADE_FACTORY.createArtifactCollector();
+		IArtifactCollector artifactCollectorFacade = FACADE_FACTORY.createArtifactCollector();
 		exporterFacade.setArtifactCollector(artifactCollectorFacade);
 		assertNotNull(exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ConfigurationMetadataDescriptorTest.java
@@ -42,7 +42,6 @@ public class ConfigurationMetadataDescriptorTest {
 	public void beforeEach() {
 		configurationFacade = FACADE_FACTORY.createNativeConfiguration();
 		configurationTarget = (Configuration)((IFacade)configurationFacade).getTarget();
-		configurationFacade = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
 		configurationMetadataDescriptor = new ConfigurationMetadataDescriptor(configurationFacade);
 	}
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>