### PR TITLE
JBIDE-28751: Implement and use the generic adapter for IColumn in the experimental Hibernate runtime - ColumnWrapper now needs a name argument in the constructor

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -85,10 +85,10 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 				
 	}
 	
-	public IColumn createColumn() {
+	public IColumn createColumn(String name) {
 		return (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
-				wrapperFactory.createColumnWrapper());
+				wrapperFactory.createColumnWrapper(name));
 	}
 
 	public IConfiguration createNativeConfiguration() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
@@ -37,7 +37,7 @@ public class IColumnTest {
 	
 	@BeforeEach
 	public void beforeEach() throws Exception {
-		columnFacade = FACADE_FACTORY.createColumn();
+		columnFacade = FACADE_FACTORY.createColumn(null);
 		columnTarget = (ColumnWrapper)((IFacade)columnFacade).getTarget();
 		Field columnField = ColumnWrapper.class.getDeclaredField("wrappedColumn");
 		columnField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -132,7 +132,7 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateColumn() {
-		IColumn columnFacade = facadeFactory.createColumn();
+		IColumn columnFacade = facadeFactory.createColumn(null);
 		assertNotNull(columnFacade);
 		Object columnTarget = ((IFacade)columnFacade).getTarget();
 		assertNotNull(columnTarget);


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>