### PR TITLE
JBIDE-28751: Implement and use the generic adapter for IColumn in the experimental Hibernate runtime - Replace call to 'FacadeFactoryImpl#createColumn(Object)' with 'NewFacadeFactory#createColumn(String)'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeImpl.java
@@ -1,12 +1,18 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
+import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeUtil;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractForeignKeyFacade;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.Util;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 
 public class ForeignKeyFacadeImpl extends AbstractForeignKeyFacade {
@@ -20,9 +26,24 @@ public class ForeignKeyFacadeImpl extends AbstractForeignKeyFacade {
 		ArrayList<IColumn> facades = new ArrayList<IColumn>();
 		Iterator<Column> iterator = ((ForeignKey)getTarget()).getColumnIterator();
 		while (iterator.hasNext()) {
-			facades.add(getFacadeFactory().createColumn(iterator.next()));
+			Column column = iterator.next();
+			IColumn columnFacade = NewFacadeFactory.INSTANCE.createColumn(null);
+			GenericFacadeUtil.setTarget((IFacade)columnFacade, column);
+			facades.add(columnFacade);
 		}
 		return facades.iterator();
 	}
 
+	@Override
+	public boolean containsColumn(IColumn column) {
+		try {
+			Field wrappedColumnField = ColumnWrapper.class.getDeclaredField("wrappedColumn");
+			wrappedColumnField.setAccessible(true);
+			Column c = (Column)wrappedColumnField.get(((IFacade)column).getTarget());
+			return ((ForeignKey)getTarget()).containsColumn(c);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ForeignKeyFacadeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -12,8 +13,9 @@ import java.util.List;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
+import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IForeignKey;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
@@ -22,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class ForeignKeyFacadeTest {
 
-	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 	
 	private IForeignKey foreignKeyFacade = null; 
 	private ForeignKey foreignKey = null;
@@ -77,10 +79,12 @@ public class ForeignKeyFacadeTest {
 	}
 	
 	@Test
-	public void testContainsColumn() {
-		Column column = new Column();
-		column.setName("foo");
-		IColumn columnFacade = FACADE_FACTORY.createColumn(column);
+	public void testContainsColumn() throws Exception {
+		IColumn columnFacade = FACADE_FACTORY.createColumn("foo");
+		ColumnWrapper columnWrapper = (ColumnWrapper)((IFacade)columnFacade).getTarget();
+		Field field = ColumnWrapper.class.getDeclaredField("wrappedColumn");
+		field.setAccessible(true);
+		Column column = (Column)field.get(columnWrapper);
 		assertFalse(foreignKeyFacade.containsColumn(columnFacade));
 		foreignKey.addColumn(column);
 		assertTrue(foreignKeyFacade.containsColumn(columnFacade));


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>