### PR TITLE
JBIDE-28768: Implement and use the generic adapter for ISessionFactory in the experimental Hibernate runtime - Add test method 'ISessionFactoryTest#testOpenSession()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -18,6 +18,7 @@ import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
+import org.jboss.tools.hibernate.runtime.spi.ISession;
 import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
@@ -186,6 +187,7 @@ public class GenericFacadeFactory {
 					IPersistentClass.class,
 					IReverseEngineeringStrategy.class,
 					IReverseEngineeringSettings.class,
+					ISession.class,
 					ISessionFactory.class,
 					ITable.class,
 					IValue.class

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ISessionFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ISessionFactoryTest.java
@@ -21,6 +21,7 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
 import org.jboss.tools.hibernate.runtime.spi.ICollectionMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
+import org.jboss.tools.hibernate.runtime.spi.ISession;
 import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +104,13 @@ public class ISessionFactoryTest {
 		Map<String, ICollectionMetadata> allCollectionMetadata = sessionFactoryFacade.getAllCollectionMetadata();
 		assertEquals(1, allCollectionMetadata.size());
 		assertNotNull(allCollectionMetadata.get(Foo.class.getName() + ".bars"));
+	}
+	
+	@Test
+	public void testOpenSession() throws Exception {
+		ISession sessionFacade = sessionFactoryFacade.openSession();
+		assertNotNull(sessionFacade);
+		assertTrue(sessionFacade instanceof ISession);
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>