### PR TITLE
JBIDE-28768: Implement and use the generic adapter for ISessionFactory in the experimental Hibernate runtime - Add new test method 'ISessionFactoryTest#testGetCollectionMetadata()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
+import org.jboss.tools.hibernate.runtime.spi.ICollectionMetadata;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -184,6 +185,7 @@ public class GenericFacadeFactory {
 	private static Set<Class<?>> classesSet = new HashSet<>(
 			Arrays.asList(new Class[] {
 					IClassMetadata.class,
+					ICollectionMetadata.class,
 					IConfiguration.class,
 					INamingStrategy.class,
 					IPersistentClass.class,

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ISessionFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ISessionFactoryTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.SessionFactoryFacadeTest.Foo;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.AbstractSessionFactoryFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
 import org.jboss.tools.hibernate.runtime.spi.ICollectionMetadata;
@@ -122,5 +124,11 @@ public class ISessionFactoryTest {
 		assertNull(sessionFactoryFacade.getClassMetadata(Object.class));
 		assertNotNull(sessionFactoryFacade.getClassMetadata(Foo.class));
 	}
+	
+	@Test
+	public void testGetCollectionMetadata() throws Exception {
+		assertNull(sessionFactoryFacade.getCollectionMetadata("bars"));
+		assertNotNull(sessionFactoryFacade.getCollectionMetadata(Foo.class.getName() + ".bars"));
+	}	
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>