### PR TITLE
JBIDE-28768: Implement and use the generic adapter for ISessionFactory in the experimental Hibernate runtime - Make method 'FacadeFactoryImpl#createSessionFactory(Object)' throw an Exception and perform the according changes in 'FacadeFactoryTest#testCreateSessionFactory()' and override method 'SessionFacadeImpl#getSessionFactory()'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -74,6 +74,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
+	public ISessionFactory createSessionFactory(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+	
+	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();
 	}
@@ -156,11 +161,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 		return null;
 	}
 
-	@Override
-	public ISessionFactory createSessionFactory(Object target) {
-		return new SessionFactoryFacadeImpl(this, target);
-	}
-	
 	@Override
 	public ISession createSession(Object target) {
 		return new SessionFacadeImpl(this, target);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SessionFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/SessionFacadeImpl.java
@@ -1,9 +1,12 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
 import org.hibernate.Session;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractSessionFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.Util;
 import org.jboss.tools.hibernate.runtime.spi.ICriteria;
+import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -38,6 +41,22 @@ public class SessionFacadeImpl extends AbstractSessionFacade {
 		criteriaQuery.select(root);
 		Query query = ((Session)getTarget()).createQuery(criteriaQuery);
 		return getFacadeFactory().createCriteria(query);		
+	}
+
+	@Override
+	public ISessionFactory getSessionFactory() {
+		if (targetFactory == null) {
+			Object targetSessionFactory = Util.invokeMethod(
+					getTarget(), 
+					"getSessionFactory", 
+					new Class[] {}, 
+					new Object[] {});
+			if (targetSessionFactory != null) {
+				targetFactory = (ISessionFactory)GenericFacadeFactory
+						.createFacade(ISessionFactory.class, targetSessionFactory);
+			}
+		}
+		return targetFactory;
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -168,6 +168,16 @@ public class FacadeFactoryTest {
 	}
 	
 	@Test
+	public void testCreateSessionFactory() {
+		try {
+			FACADE_FACTORY.createSessionFactory(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());			
+		}
+	}
+	
+	@Test
 	public void testCreateSchemaExport() {
 		SchemaExport schemaExport = new SchemaExport();
 		ISchemaExport facade = FACADE_FACTORY.createSchemaExport(schemaExport);
@@ -345,17 +355,6 @@ public class FacadeFactoryTest {
 		IQuery facade = FACADE_FACTORY.createQuery(query);
 		assertTrue(facade instanceof QueryFacadeImpl);
 		assertSame(query, ((IFacade)facade).getTarget());
-	}
-	
-	@Test
-	public void testCreateSessionFactory() {
-		SessionFactory sessionFactory = (SessionFactory)Proxy.newProxyInstance(
-				FACADE_FACTORY.getClassLoader(), 
-				new Class[] { SessionFactory.class }, 
-				new TestInvocationHandler());
-		ISessionFactory facade = FACADE_FACTORY.createSessionFactory(sessionFactory);
-		assertTrue(facade instanceof SessionFactoryFacadeImpl);
-		assertSame(sessionFactory, ((IFacade)facade).getTarget());
 	}
 	
 	@Test


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>