### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Add methods 'IClassMetadata#getPropertyIndexOrNull(String)' and 'IClassMetadata#getTuplizerPropertyValue(Object,int)' and provide a default implementation of both methods in 'AbstractClassMetadataFacade'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractClassMetadataFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractClassMetadataFacade.java
@@ -134,6 +134,16 @@ implements IClassMetadata {
 				new Object[] {});
 	}
 
+	@Override
+	public Integer getPropertyIndexOrNull(String id) {
+		return null;
+	}
+	
+	@Override
+	public Object getTuplizerPropertyValue(Object entity, int i) {
+		return null;
+	}
+	
 	protected Class<?> getSessionImplementorClass() {
 		return Util.getClass(getSessionImplementorClassName(), getFacadeFactoryClassLoader());
 	}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IClassMetadata.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IClassMetadata.java
@@ -14,5 +14,7 @@ public interface IClassMetadata {
 	Object getIdentifier(Object object, ISession implementor);
 	boolean isInstanceOfAbstractEntityPersister();
 	IEntityMetamodel getEntityMetamodel();
+	Integer getPropertyIndexOrNull(String id);
+	Object getTuplizerPropertyValue(Object entity, int i);
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>