### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Perform the changes for 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ClassMetadataFacadeImpl' and 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ClassMetadataFacadeTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ClassMetadataFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ClassMetadataFacadeImpl.java
@@ -1,5 +1,6 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
+import org.hibernate.persister.entity.EntityPersister;
 import org.jboss.tools.hibernate.runtime.common.AbstractClassMetadataFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IEntityMetamodel;
@@ -20,4 +21,14 @@ public class ClassMetadataFacadeImpl extends AbstractClassMetadataFacade {
 		return "org.hibernate.engine.spi.SharedSessionContractImplementor";
 	}
 
+	@Override
+	public Object getTuplizerPropertyValue(Object entity, int i) {
+		return ((EntityPersister)getTarget()).getPropertyValue(entity, i);
+	}
+	
+	@Override
+	public Integer getPropertyIndexOrNull(String id) {
+		return ((EntityPersister)getTarget()).getEntityMetamodel().getPropertyIndexOrNull(id);
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ClassMetadataFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ClassMetadataFacadeTest.java
@@ -30,6 +30,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.metadata.ClassMetadata;
@@ -144,6 +145,17 @@ public class ClassMetadataFacadeTest {
 		assertSame(classMetadataTarget, ((IFacade)entityMetamodel).getTarget());
 	}
 
+	@Test
+	public void testGetTuplizerPropertyValue() {
+		assertSame(PROPERTY_VALUE, classMetadataFacade.getTuplizerPropertyValue(null, 0));
+	}
+	
+	@Test
+	public void testGetPropertyIndexOrNull() {
+		assertSame(0, classMetadataFacade.getPropertyIndexOrNull("bar"));
+	}
+	
+	
 	private ClassMetadata setupFooBarPersister() {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
@@ -200,6 +212,10 @@ public class ClassMetadataFacadeTest {
 		rc.setIdentifier(sv);
 		rc.setClassName(FooBar.class.getName());
 		rc.setOptimisticLockStyle(OptimisticLockStyle.NONE);
+		Property p = new Property();
+		p.setName("bar");
+		p.setValue(sv);
+		rc.addProperty(p);
 		return rc;
 	}
 	
@@ -268,6 +284,11 @@ public class ClassMetadataFacadeTest {
 		}
 		
 		@Override
+		public Object getPropertyValue(Object object, int index) {
+			return PROPERTY_VALUE;
+		}
+		
+		@Override
 		public String getIdentifierPropertyName() {
 			return "foo";
 		}
@@ -314,6 +335,10 @@ public class ClassMetadataFacadeTest {
 	
 	public class FooBar {
 		public int id = 1967;
+		public int getBar() {
+			return 0;
+		}
+		public void setBar(int b) {}
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>