### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Perform the changes for 'org.jboss.tools.hibernate.runtime.v_6_0.internal.ClassMetadataFacadeImpl' and 'org.jboss.tools.hibernate.runtime.v_6_0.internal.ClassMetadataFacadeTest'

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ClassMetadataFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ClassMetadataFacadeImpl.java
@@ -1,7 +1,9 @@
 package org.jboss.tools.hibernate.runtime.v_6_0.internal;
 
+import org.hibernate.persister.entity.EntityPersister;
 import org.jboss.tools.hibernate.runtime.common.AbstractClassMetadataFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.common.Util;
 import org.jboss.tools.hibernate.runtime.spi.IEntityMetamodel;
 
 public class ClassMetadataFacadeImpl extends AbstractClassMetadataFacade {
@@ -20,4 +22,14 @@ public class ClassMetadataFacadeImpl extends AbstractClassMetadataFacade {
 		return "org.hibernate.engine.spi.SharedSessionContractImplementor";
 	}
 
+	@Override
+	public Object getTuplizerPropertyValue(Object entity, int i) {
+		return ((EntityPersister)getTarget()).getPropertyValue(entity, i);
+	}
+	
+	@Override
+	public Integer getPropertyIndexOrNull(String id) {
+		return ((EntityPersister)getTarget()).getEntityMetamodel().getPropertyIndexOrNull(id);
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ClassMetadataFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/ClassMetadataFacadeTest.java
@@ -29,6 +29,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.metadata.ClassMetadata;
@@ -137,6 +138,17 @@ public class ClassMetadataFacadeTest {
 		assertSame(classMetadataTarget, ((IFacade)entityMetamodel).getTarget());
 	}
 
+	@Test
+	public void testGetTuplizerPropertyValue() {
+		assertSame(PROPERTY_VALUE, classMetadataFacade.getTuplizerPropertyValue(null, 0));
+	}
+	
+	@Test
+	public void testGetPropertyIndexOrNull() {
+		assertSame(0, classMetadataFacade.getPropertyIndexOrNull("bar"));
+	}
+	
+	
 	private ClassMetadata setupFooBarPersister() {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
@@ -193,6 +205,10 @@ public class ClassMetadataFacadeTest {
 		rc.setIdentifier(sv);
 		rc.setClassName(FooBar.class.getName());
 		rc.setOptimisticLockStyle(OptimisticLockStyle.NONE);
+		Property p = new Property();
+		p.setName("bar");
+		p.setValue(sv);
+		rc.addProperty(p);
 		return rc;
 	}
 	
@@ -261,6 +277,11 @@ public class ClassMetadataFacadeTest {
 		}
 		
 		@Override
+		public Object getPropertyValue(Object object, int index) {
+			return PROPERTY_VALUE;
+		}
+		
+		@Override
 		public String getIdentifierPropertyName() {
 			return "foo";
 		}
@@ -307,6 +328,10 @@ public class ClassMetadataFacadeTest {
 	
 	public class FooBar {
 		public int id = 1967;
+		public int getBar() {
+			return 0;
+		}
+		public void setBar(int b) {}
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>