### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Provide a default implementation of 'IClassMetadata#getPropertyIndexOrNull(String)' and 'IClassMetadata#getTuplizerPropertyValue(Object,int)' in class 'org.jboss.tools.hibernate.runtime.common.AbstractClassMetadataFacade' to be used in the 4.x and 5.x runtimes

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractClassMetadataFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractClassMetadataFacade.java
@@ -136,14 +136,53 @@ implements IClassMetadata {
 
 	@Override
 	public Integer getPropertyIndexOrNull(String id) {
-		return null;
+		Integer result = null;
+		Object entityMetamodel = null;
+		if (isInstanceOfAbstractEntityPersister()) {
+			entityMetamodel = Util.invokeMethod(
+				getTarget(), 
+				"getEntityMetamodel", 
+				new Class[] {}, 
+				new Object[] {});
+		}
+		if (entityMetamodel != null) {
+			result = (Integer)Util.invokeMethod(
+					entityMetamodel, 
+					"getPropertyIndexOrNull", 
+					new Class[] { String.class }, 
+					new Object[] { id });
+		} 
+		return result;
 	}
 	
 	@Override
 	public Object getTuplizerPropertyValue(Object entity, int i) {
-		return null;
+		Object result = null;
+		Object entityMetamodel = null;
+		if (isInstanceOfAbstractEntityPersister()) {
+			entityMetamodel = Util.invokeMethod(
+				getTarget(), 
+				"getEntityMetamodel", 
+				new Class[] {}, 
+				new Object[] {});
+		}
+		if (entityMetamodel != null) {
+			Object targetTuplizer = Util.invokeMethod(
+					entityMetamodel, 
+					"getTuplizer", 
+					new Class[] {}, 
+					new Object[] {});
+			if (targetTuplizer != null) {
+				result = Util.invokeMethod(
+						targetTuplizer, 
+						"getPropertyValue", 
+						new Class[] { Object.class,  int.class }, 
+						new Object[] { entity, i });
+			}
+		}
+		return result;
 	}
-	
+
 	protected Class<?> getSessionImplementorClass() {
 		return Util.getClass(getSessionImplementorClassName(), getFacadeFactoryClassLoader());
 	}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>