### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Perform the changes for 'org.jboss.tools.hibernate.runtime.v_5_6.internal.ClassMetadataFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/ClassMetadataFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/ClassMetadataFacadeTest.java
@@ -29,6 +29,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
@@ -137,6 +138,17 @@ public class ClassMetadataFacadeTest {
 		assertSame(classMetadataTarget, ((IFacade)entityMetamodel).getTarget());
 	}
 
+	@Test
+	public void testGetTuplizerPropertyValue() {
+		assertEquals(0, classMetadataFacade.getTuplizerPropertyValue(new FooBar(), 0));
+	}
+	
+	@Test
+	public void testGetPropertyIndexOrNull() {
+		assertSame(0, classMetadataFacade.getPropertyIndexOrNull("bar"));
+	}
+	
+	
 	private ClassMetadata setupFooBarPersister() {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
 		builder.applySetting(AvailableSettings.DIALECT, MockDialect.class.getName());
@@ -192,6 +204,10 @@ public class ClassMetadataFacadeTest {
 		rc.setIdentifier(sv);
 		rc.setClassName(FooBar.class.getName());
 		rc.setOptimisticLockStyle(OptimisticLockStyle.NONE);
+		Property p = new Property();
+		p.setName("bar");
+		p.setValue(sv);
+		rc.addProperty(p);
 		return rc;
 	}
 	
@@ -287,6 +303,10 @@ public class ClassMetadataFacadeTest {
 	
 	public class FooBar {
 		public int id = 1967;
+		public int getBar() {
+			return 0;
+		}
+		public void setBar(int b) {}
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>