### PR TITLE
JBIDE-28809: Collapse the IEntityMetamodel interface in IClassMetadata - Perform the changes for 'org.jboss.tools.hibernate.runtime.v_5_2.internal.ClassMetadataFacadeTest'

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ClassMetadataFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/ClassMetadataFacadeTest.java
@@ -31,6 +31,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
@@ -139,6 +140,16 @@ public class ClassMetadataFacadeTest {
 		assertEquals("foobar", entityMetamodelTarget.getName());
 	}
 	
+	@Test
+	public void testGetTuplizerPropertyValue() {
+		assertEquals(0, classMetadataFacade.getTuplizerPropertyValue(new FooBar(), 0));
+	}
+	
+	@Test
+	public void testGetPropertyIndexOrNull() {
+		assertSame(0, classMetadataFacade.getPropertyIndexOrNull("bar"));
+	}
+	
 	private ClassMetadata setupFooBarPersister() {
 		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
 		ssrb.applySetting(AvailableSettings.DIALECT, TestDialect.class.getName());
@@ -185,6 +196,10 @@ public class ClassMetadataFacadeTest {
 		rc.setIdentifier(sv);
 		rc.setClassName(FooBar.class.getName());
 		rc.setOptimisticLockStyle(OptimisticLockStyle.NONE);
+		Property p = new Property();
+		p.setName("bar");
+		p.setValue(sv);
+		rc.addProperty(p);
 		return rc;
 	}
 	
@@ -278,6 +293,10 @@ public class ClassMetadataFacadeTest {
 	
 	public class FooBar {
 		public int id = 1967;
+		public int getBar() {
+			return 0;
+		}
+		public void setBar(int b) {}
 	}
 	
 	public static class TestDialect extends Dialect {}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>