### PR TITLE
JBIDE-28836: Create a plugin for the Hibernate 6.2.x runtimes - MetadataHelper

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/META-INF/MANIFEST.MF
@@ -4,13 +4,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.2 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_2;singleton:=true
 Bundle-Version: 5.4.20.qualifier
-Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10;bundle-version="5.4.19",
+Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_12,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0,
  org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1,
  org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0,
  org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0,
+ org.jboss.tools.hibernate.libs.jaxb.v_3_0,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/MetadataHelper.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/MetadataHelper.java
@@ -1,0 +1,113 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+
+public class MetadataHelper {
+	
+	public static Metadata getMetadata(Configuration configuration) {
+		Metadata result = getMetadataFromMethod(configuration);
+		if (result == null) {
+			result = getMetadataFromField(configuration);
+		}
+		if (result == null) {
+			result = buildFromMetadataSources(configuration);
+		}
+		return result;
+	}
+	
+	public static MetadataSources getMetadataSources(Configuration configuration) {
+		MetadataSources result = null;
+		Field metadataSourcesField = getField("metadataSources", configuration);
+		if (metadataSourcesField != null) {
+			try {
+				metadataSourcesField.setAccessible(true);
+				result = 
+						(MetadataSources)metadataSourcesField.get(configuration);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		if (result == null) {
+			result = new MetadataSources();
+		}
+		return result;
+	}
+	
+	private static Metadata getMetadataFromMethod(Configuration configuration) {
+		Metadata result = null;
+		Method metadataMethod = getMethod("getMetadata", configuration);
+		if (metadataMethod != null) {
+			try {
+				metadataMethod.setAccessible(true);
+				result = (Metadata)metadataMethod.invoke(
+						configuration, 
+						new Object[] {});
+			} catch (InvocationTargetException | 
+					IllegalAccessException | 
+					IllegalArgumentException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Method getMethod(String methodName, Object target) {
+		Method result = null;
+		Class<?> clazz = target.getClass();
+		try {
+			result = clazz.getMethod(methodName, new Class[] {});
+		} catch (NoSuchMethodException | SecurityException e1) {
+			// ignore;
+		}
+		return result;
+	}
+
+	private static Metadata getMetadataFromField(Configuration configuration) {
+		Metadata result = null;
+		Field metadataField = getField("metadata", configuration);
+		if (metadataField != null) {
+			try {
+				metadataField.setAccessible(true);
+				result = (Metadata)metadataField.get(configuration);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Field getField(String fieldName, Object target) {
+		Field result = null;
+		Class<?> clazz = target.getClass();
+		while (clazz != null) {
+			try {
+				result = clazz.getDeclaredField(fieldName);
+				// if it exists, exit the while loop
+				break;
+			} catch (NoSuchFieldException e) {
+				// if it doesn't exist, look in the superclass
+				clazz = clazz.getSuperclass();
+			} catch (SecurityException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return result;
+	}
+	
+	private static Metadata buildFromMetadataSources(Configuration configuration) {
+		MetadataSources metadataSources = getMetadataSources(configuration);
+		StandardServiceRegistryBuilder builder = configuration.getStandardServiceRegistryBuilder();
+		builder.applySettings(configuration.getProperties());
+		StandardServiceRegistry serviceRegistry = builder.build();
+		return metadataSources.buildMetadata(serviceRegistry);
+	}
+	
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/MetadataHelperTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/MetadataHelperTest.java
@@ -1,0 +1,98 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.junit.jupiter.api.Test;
+
+public class MetadataHelperTest {
+
+	@Test
+	public void testGetMetadataSources() {
+		MetadataSources mds1 = new MetadataSources();
+		Configuration configuration = new Configuration();
+		MetadataSources mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertNotSame(mds1, mds2);
+		configuration = new Configuration(mds1);
+		mds2 = MetadataHelper.getMetadataSources(configuration);
+		assertNotNull(mds2);
+		assertSame(mds1, mds2);
+	}
+	
+	@Test
+	public void testGetMetadata() {
+		 Configuration methodConfiguration = new MetadataMethodConfiguration();
+	     assertSame(
+	    		 MetadataMethodConfiguration.METADATA, 
+	    		 MetadataHelper.getMetadata(methodConfiguration));
+	     Configuration fieldConfiguration = new MetadataFieldConfiguration();
+	     assertSame(
+	    		 MetadataFieldConfiguration.METADATA, 
+	    		 MetadataHelper.getMetadata(fieldConfiguration));
+	     MetadataSources metadataSources = new MetadataSources();
+	     metadataSources.addInputStream(new ByteArrayInputStream(TEST_HBM_XML_STRING.getBytes()));
+	     Configuration configuration = new Configuration(metadataSources);
+	     configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
+	     configuration.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
+	     Metadata metadata = MetadataHelper.getMetadata(configuration);
+	     assertNotNull(metadata.getEntityBinding("org.jboss.tools.hibernate.runtime.v_6_2.internal.util.MetadataHelperTest$Foo"));
+	}
+	
+	private static class MetadataMethodConfiguration extends Configuration {
+		static Metadata METADATA = createMetadata();
+		@SuppressWarnings("unused")
+		public Metadata getMetadata() {
+			return METADATA;
+		}
+	}
+	
+	private static class MetadataFieldConfiguration extends Configuration {
+		static Metadata METADATA = createMetadata();
+		@SuppressWarnings("unused")
+		private Metadata metadata = METADATA;
+	}
+	
+	private static Metadata createMetadata() {
+		Metadata result = null;
+		result = (Metadata) Proxy.newProxyInstance(
+				MetadataHelperTest.class.getClassLoader(), 
+				new Class[] { Metadata.class },  
+				new InvocationHandler() {				
+					@Override
+					public Object invoke(
+							Object proxy, 
+							Method method, 
+							Object[] args) throws Throwable {
+						return null;
+					}
+				});
+		return result;
+	}
+	
+	@SuppressWarnings("unused")
+	private static class Foo {
+		public String id;
+	}
+	
+	private static final String TEST_HBM_XML_STRING =
+			"<!DOCTYPE hibernate-mapping PUBLIC" +
+			"		'-//Hibernate/Hibernate Mapping DTD 3.0//EN'" +
+			"		'http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd'>" +
+			"<hibernate-mapping package='org.jboss.tools.hibernate.runtime.v_6_2.internal.util'>" +
+			"  <class name='MetadataHelperTest$Foo'>" + 
+			"    <id name='id'/>" +
+			"  </class>" +
+			"</hibernate-mapping>";
+
+}


### PR DESCRIPTION
  - Add test class 'org.jboss.hibernate.runtime.v_6_2.internal.util.MetadataHelperTest'
  - Add implementation class 'org.jboss.hibernate.runtime.v_6_2.internal.util.MetadataHelper'
  - Add dependency on 'org.jboss.tools.hibernate.libs.jaxb.v_3_0'

Signed-off-by: Koen Aers <koen.aers@gmail.com>