### PR TITLE
JBIDE-28836: Create a plugin for the Hibernate 6.2.x runtimes - JdbcMetadataConfiguration

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/JdbcMetadataConfiguration.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/JdbcMetadataConfiguration.java
@@ -1,0 +1,65 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal.util;
+
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataConstants;
+import org.hibernate.tool.api.metadata.MetadataDescriptorFactory;
+import org.hibernate.tool.api.reveng.RevengStrategy;
+
+public class JdbcMetadataConfiguration {
+
+	Properties properties = new Properties();
+	RevengStrategy revengStrategy;
+	Metadata metadata;
+
+	public Properties getProperties() {
+		return properties;
+	}
+	
+	public void setProperties(Properties properties) {
+		this.properties = properties;
+	}
+	
+	public Object getProperty(String key) {
+		return this.properties.get(key);
+	}
+	
+	public void setProperty(String key, String value) {
+		properties.put(key, value);
+	}
+
+	public void addProperties(Properties properties) {
+		this.properties.putAll(properties);
+	}
+
+	public Object getReverseEngineeringStrategy() {
+		return revengStrategy;
+	}
+
+	public void setReverseEngineeringStrategy(RevengStrategy strategy) {
+		this.revengStrategy = strategy;
+	}
+
+	public boolean preferBasicCompositeIds() {
+		Object preferBasicCompositeIds = properties.get(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS);
+		return preferBasicCompositeIds == null ? true : ((Boolean)preferBasicCompositeIds).booleanValue();
+	}
+
+	public void setPreferBasicCompositeIds(boolean preferBasicCompositeIds) {
+		properties.put(
+				MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, 
+				Boolean.valueOf(preferBasicCompositeIds));
+	}
+
+	public Metadata getMetadata() {
+		return metadata;
+	}
+
+	public void readFromJdbc() {
+		metadata = MetadataDescriptorFactory
+				.createReverseEngineeringDescriptor(revengStrategy, properties)
+				.createMetadata();
+	}
+		
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/META-INF/MANIFEST.MF
@@ -6,5 +6,6 @@ Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.2.test
 Bundle-Version: 5.4.20.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_2
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit.jupiter.api
+Require-Bundle: org.junit.jupiter.api,
+ org.jboss.tools.hibernate.libs.h2.v_2_1
 Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/JdbcMetadataConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/util/JdbcMetadataConfigurationTest.java
@@ -1,0 +1,154 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+
+import org.h2.Driver;
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.api.metadata.MetadataConstants;
+import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JdbcMetadataConfigurationTest {
+
+	private JdbcMetadataConfiguration jdbcMetadataConfiguration = null;
+	
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		DriverManager.registerDriver(new Driver());		
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		jdbcMetadataConfiguration = new JdbcMetadataConfiguration();
+	}
+	
+	@Test
+	public void testInstance() {
+		assertNotNull(jdbcMetadataConfiguration);
+	}
+	
+	@Test
+	public void testGetProperties() {
+		Properties properties = new Properties();
+		assertNotNull(jdbcMetadataConfiguration.properties);
+		assertNotSame(properties,  jdbcMetadataConfiguration.getProperties());
+		jdbcMetadataConfiguration.properties = properties;
+		assertSame(properties, jdbcMetadataConfiguration.getProperties());
+	}
+	
+	@Test
+	public void testSetProperties() {
+		Properties properties = new Properties();
+		assertNotNull(jdbcMetadataConfiguration.properties);
+		assertNotSame(properties,  jdbcMetadataConfiguration.getProperties());
+		jdbcMetadataConfiguration.setProperties(properties);
+		assertSame(properties, jdbcMetadataConfiguration.getProperties());
+	}
+	
+	@Test
+	public void testGetProperty() {
+		assertNull(jdbcMetadataConfiguration.getProperty("foo"));
+		jdbcMetadataConfiguration.properties.put("foo", "bar");
+		assertEquals("bar", jdbcMetadataConfiguration.getProperty("foo"));
+	}
+
+	@Test
+	public void testSetProperty() {
+		assertNull(jdbcMetadataConfiguration.properties.get("foo"));
+		jdbcMetadataConfiguration.setProperty("foo", "bar");
+		assertEquals("bar", jdbcMetadataConfiguration.properties.get("foo"));
+	}
+	
+	@Test
+	public void testAddProperties() {
+		Properties properties = new Properties();
+		properties.put("foo", "bar");
+		assertNull(jdbcMetadataConfiguration.properties.get("foo"));
+		jdbcMetadataConfiguration.addProperties(properties);
+		assertEquals("bar", jdbcMetadataConfiguration.properties.get("foo"));
+	}
+	
+	@Test
+	public void testGetReverseEngineeringStrategy() {
+		RevengStrategy strategy = new DefaultStrategy();
+		assertNull(jdbcMetadataConfiguration.getReverseEngineeringStrategy());
+		jdbcMetadataConfiguration.revengStrategy = strategy;
+		assertSame(strategy, jdbcMetadataConfiguration.getReverseEngineeringStrategy());
+	}
+	
+	@Test
+	public void testSetReverseEngineeringStrategy() {
+		RevengStrategy strategy = new DefaultStrategy();
+		assertNull(jdbcMetadataConfiguration.revengStrategy);
+		jdbcMetadataConfiguration.setReverseEngineeringStrategy(strategy);
+		assertSame(strategy, jdbcMetadataConfiguration.revengStrategy);
+	}
+	
+	@Test
+	public void testPreferBasicCompositeIds() {
+		assertTrue(jdbcMetadataConfiguration.preferBasicCompositeIds());
+		jdbcMetadataConfiguration.properties.put(MetadataConstants.PREFER_BASIC_COMPOSITE_IDS, false);
+		assertFalse(jdbcMetadataConfiguration.preferBasicCompositeIds());
+	}
+	
+	@Test
+	public void testSetPreferBasicCompositeIds() {
+		assertNull(
+				jdbcMetadataConfiguration.properties.get(
+						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
+		jdbcMetadataConfiguration.setPreferBasicCompositeIds(true);
+		assertEquals(
+				true, 
+				jdbcMetadataConfiguration.properties.get(
+						MetadataConstants.PREFER_BASIC_COMPOSITE_IDS));
+	}
+	
+	@Test
+	public void testGetMetadata() {
+		Metadata metadata = (Metadata)Proxy.newProxyInstance(
+				getClass().getClassLoader(), 
+				new Class[] { Metadata.class }, 
+				new InvocationHandler() {					
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						return null;
+					}
+				});
+		assertNull(jdbcMetadataConfiguration.getMetadata());
+		jdbcMetadataConfiguration.metadata = metadata;
+		assertSame(metadata, jdbcMetadataConfiguration.getMetadata());
+	}
+	
+	@Test
+	public void testReadFromJdbc() throws Exception {
+		Connection connection = DriverManager.getConnection("jdbc:h2:mem:test");
+		Statement statement = connection.createStatement();
+		statement.execute("CREATE TABLE FOO(id int primary key, bar varchar(255))");
+		jdbcMetadataConfiguration.properties.put("hibernate.connection.url", "jdbc:h2:mem:test");
+		jdbcMetadataConfiguration.revengStrategy = new DefaultStrategy();
+		assertNull(jdbcMetadataConfiguration.metadata);
+		jdbcMetadataConfiguration.readFromJdbc();
+		assertNotNull(jdbcMetadataConfiguration.metadata);
+		statement.execute("DROP TABLE FOO");
+		statement.close();
+		connection.close();
+	}
+
+}


### PR DESCRIPTION
  - Add test class 'org.jboss.hibernate.runtime.v_6_2.internal.util.JdbcMetadataConfigurationTest'
  - Add implementation class 'org.jboss.hibernate.runtime.v_6_2.internal.util.JdbcMetadataConfiguration'
  - Add dependency on 'org.jboss.tools.hibernate.libs.h2.v_2_1'

Signed-off-by: Koen Aers <koen.aers@gmail.com>