### PR TITLE
JBIDE-28836: Create a plugin for the Hibernate 6.2.x runtimes - GenericExporterFacade

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/GenericExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/GenericExporterFacadeImpl.java
@@ -1,5 +1,7 @@
 package org.jboss.tools.hibernate.runtime.v_6_2.internal;
 
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.jboss.tools.hibernate.runtime.common.AbstractGenericExporterFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 
@@ -9,4 +11,35 @@ public class GenericExporterFacadeImpl extends AbstractGenericExporterFacade {
 		super(facadeFactory, target);
 	}
 	
+	@Override 
+	public void setFilePattern(String filePattern) {
+		((GenericExporter)getTarget()).getProperties().setProperty(
+				ExporterConstants.FILE_PATTERN, 
+				filePattern);
+	}
+
+	@Override 
+	public void setTemplateName(String templateName) {
+		((GenericExporter)getTarget()).getProperties().setProperty(
+				ExporterConstants.TEMPLATE_NAME, 
+				templateName);
+	}
+
+	@Override 
+	public void setForEach(String forEach) {
+		((GenericExporter)getTarget()).getProperties().setProperty(
+				ExporterConstants.FOR_EACH, 
+				forEach);
+	}
+	
+	@Override
+	public String getFilePattern() {
+		return ((GenericExporter)getTarget()).getProperties().getProperty(ExporterConstants.FILE_PATTERN);
+	}
+	
+	@Override
+	public String getTemplateName() {
+		return ((GenericExporter)getTarget()).getProperties().getProperty(ExporterConstants.TEMPLATE_NAME);
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/GenericExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/GenericExporterFacadeTest.java
@@ -1,0 +1,61 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.hibernate.tool.api.export.ExporterConstants;
+import org.hibernate.tool.internal.export.common.GenericExporter;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GenericExporterFacadeTest {
+
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+	
+	private IGenericExporter genericExporterFacade = null; 
+	private GenericExporter genericExporter = null;
+	
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		genericExporter = new GenericExporter();
+		genericExporterFacade = new GenericExporterFacadeImpl(FACADE_FACTORY, genericExporter) {};
+	}
+	
+	@Test
+	public void testSetFilePattern() {
+		assertNull(genericExporter.getProperties().get(ExporterConstants.FILE_PATTERN));
+		genericExporterFacade.setFilePattern("foobar");
+		assertEquals("foobar", genericExporter.getProperties().get(ExporterConstants.FILE_PATTERN));
+	}
+	
+	@Test
+	public void testSetTemplate() {
+		assertNull(genericExporter.getProperties().get(ExporterConstants.TEMPLATE_NAME));
+		genericExporterFacade.setTemplateName("barfoo");
+		assertEquals("barfoo", genericExporter.getProperties().get(ExporterConstants.TEMPLATE_NAME));
+	}
+	
+	@Test
+	public void testSetForEach() {
+		assertNull(genericExporter.getProperties().get(ExporterConstants.FOR_EACH));
+		genericExporterFacade.setForEach("foobar");
+		assertEquals("foobar", genericExporter.getProperties().get(ExporterConstants.FOR_EACH));
+	}
+	
+	@Test
+	public void testGetFilePattern() {
+		assertNull(genericExporterFacade.getFilePattern());
+		genericExporter.getProperties().put(ExporterConstants.FILE_PATTERN, "foobar");
+		assertEquals("foobar", genericExporterFacade.getFilePattern());
+	}
+	
+	@Test
+	public void testGetTemplateName() {
+		assertNull(genericExporterFacade.getTemplateName());
+		genericExporter.getProperties().put(ExporterConstants.TEMPLATE_NAME, "foobar");
+		assertEquals("foobar", genericExporterFacade.getTemplateName());
+	}
+	
+}


### PR DESCRIPTION
  - Add test class 'org.jboss.hibernate.runtime.v_6_2.internal.GenericExporterFacadeTest'
  - Complete implementation class 'org.jboss.hibernate.runtime.v_6_2.internal.GenericExporterFacadeImpl'

Signed-off-by: Koen Aers <koen.aers@gmail.com>