### PR TITLE
JBIDE-28836: Create a plugin for the Hibernate 6.2.x runtimes - SchemaExportFacade

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/SchemaExportFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/SchemaExportFacadeImpl.java
@@ -1,12 +1,31 @@
 package org.jboss.tools.hibernate.runtime.v_6_2.internal;
 
+import java.util.EnumSet;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.TargetType;
 import org.jboss.tools.hibernate.runtime.common.AbstractSchemaExportFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 
 public class SchemaExportFacadeImpl extends AbstractSchemaExportFacade {
 
+	SchemaExport target = null;
+	Metadata metadata = null;
+
 	public SchemaExportFacadeImpl(IFacadeFactory facadeFactory, Object target) {
 		super(facadeFactory, target);
+		this.target = (SchemaExport)target;
+	}
+
+	public void setConfiguration(IConfiguration configuration) {
+		metadata = ((ConfigurationFacadeImpl)configuration).getMetadata();
+	}
+
+	@Override
+	public void create() {
+		target.create(EnumSet.of(TargetType.DATABASE), metadata);
 	}
 
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/SchemaExportFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/SchemaExportFacadeTest.java
@@ -1,0 +1,91 @@
+package org.jboss.tools.hibernate.runtime.v_6_2.internal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.EnumSet;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.TargetType;
+import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
+import org.jboss.tools.hibernate.runtime.v_6_2.internal.util.MockConnectionProvider;
+import org.jboss.tools.hibernate.runtime.v_6_2.internal.util.MockDialect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SchemaExportFacadeTest {
+	
+	private static final IFacadeFactory FACADE_FACTORY = new FacadeFactoryImpl();
+
+	
+	private SchemaExportFacadeImpl schemaExportFacade = null;
+	private SchemaExport schemaExportTarget = null;
+	
+	@BeforeEach
+	public void before() {
+		schemaExportTarget = new SchemaExport();
+		schemaExportFacade = new SchemaExportFacadeImpl(FACADE_FACTORY, schemaExportTarget);
+	}
+	
+	@Test
+	public void testCreation() {
+		assertNotNull(schemaExportFacade);
+		assertNull(schemaExportFacade.metadata);
+		assertSame(schemaExportFacade.target, schemaExportTarget);
+	}
+	
+	@Test
+	public void testSetConfiguration() {
+		Configuration configurationTarget = new Configuration();
+		configurationTarget.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
+		configurationTarget.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
+		ConfigurationFacadeImpl configuration = new ConfigurationFacadeImpl(FACADE_FACTORY, configurationTarget);
+		Metadata metadata = configuration.getMetadata();
+		assertNull(schemaExportFacade.metadata);
+		schemaExportFacade.setConfiguration(configuration);
+		assertSame(metadata, schemaExportFacade.metadata);
+	}
+	
+	@Test
+	public void testCreate() {
+		TestSchemaExport target = new TestSchemaExport();
+		schemaExportFacade.target = target;
+		schemaExportFacade.metadata = createTestMetadata();
+		assertNull(target.metadata);
+		assertNull(target.targetTypes);
+		schemaExportFacade.create();	
+		assertSame(target.metadata, schemaExportFacade.metadata);
+		assertTrue(target.targetTypes.contains(TargetType.DATABASE));
+	}
+	
+	private static class TestSchemaExport extends SchemaExport {
+		Metadata metadata = null;
+		EnumSet<TargetType> targetTypes = null;
+		@Override
+		public void create(EnumSet<TargetType> targetTypes, Metadata metadata) {
+			this.targetTypes = targetTypes;
+			this.metadata = metadata;
+		}
+	}
+	
+	private static Metadata createTestMetadata() {
+		return (Metadata)Proxy.newProxyInstance(
+				SchemaExportFacadeTest.class.getClassLoader(), 
+				new Class[] { Metadata.class },  
+				new InvocationHandler() {					
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						return null;
+					}
+				});
+	}
+
+}


### PR DESCRIPTION
  - Add test class 'org.jboss.hibernate.runtime.v_6_2.internal.SchemaExportFacadeTest'
  - Complete implementation class 'org.jboss.hibernate.runtime.v_6_2.internal.SchemaExportFacadeImpl'

Signed-off-by: Koen Aers <koen.aers@gmail.com>