### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Experimental Hibernate Runtime 
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.exp;singleton:=true
-Bundle-Version: 5.4.19.qualifier
+Bundle-Version: 5.4.20.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
@@ -12,7 +12,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,
  org.jboss.tools.hibernate.libs.freemarker.v_2_3,
  org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0,
- org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0,
+ org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1,
  org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0,
  org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0,
  org.jboss.tools.hibernate.libs.jandex.v_2_4,
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.1.5.Final.jar,
- lib/hibernate-core-6.1.5.Final.jar,
- lib/hibernate-tools-orm-6.1.6-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.1.6-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.1.6-SNAPSHOT.jar
+ lib/hibernate-ant-6.2.0.CR1.jar,
+ lib/hibernate-core-6.2.0.CR1.jar,
+ lib/hibernate-tools-orm-6.2.0-SNAPSHOT.jar,
+ lib/hibernate-tools-orm-jbt-6.2.0-SNAPSHOT.jar,
+ lib/hibernate-tools-utils-6.2.0-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.19-SNAPSHOT</version>
+		<version>5.4.20-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.runtime.exp</artifactId> 
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.1.5.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.1.6-SNAPSHOT</hibernate.tools.version>
+		<hibernate.orm.version>6.2.0.CR1</hibernate.orm.version>
+		<hibernate.tools.version>6.2.0-SNAPSHOT</hibernate.tools.version>
 	</properties>
 
 	<build>
@@ -106,5 +106,4 @@
 		</plugins>
 	</build>
 
-<version>5.4.19-SNAPSHOT</version>
 </project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Experimental Hibernate Runtime Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.exp.test
 Automatic-Module-Name: org.jboss.tools.hibernate.orm.runtime.exp.test
-Bundle-Version: 5.4.19.qualifier
+Bundle-Version: 5.4.20.qualifier
 Fragment-Host: org.jboss.tools.hibernate.orm.runtime.exp
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.19-SNAPSHOT</version>
+		<version>5.4.20-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.runtime.exp.test</artifactId> 
@@ -27,5 +27,4 @@
 		</plugins>
 	</build>
 	
-<version>5.4.19-SNAPSHOT</version>
 </project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.1.5.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.0.CR1", org.hibernate.Version.getVersionString());
 	}
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.1.6-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.2.0-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 }


### PR DESCRIPTION
  - Update version identifiers of plugin 'org.jboss.tools.hibernate.orm.runtime.exp' to 5.4.20-SNAPSHOT
  - Update version identifiers of test fragment 'org.jboss.tools.hibernatetools.orm.test' to 5.4.20-SNAPSHOT
  - Update Maven dependency of plugin 'org.jboss.tools.hibernate.orm.runtime.exp' on Hibernate ORM to 6.2.0.CR1
  - Update Maven dependency of plugin 'org.jboss.tools.hibernate.orm.runtime.exp' on Hibernate Tools to 6.2.0-SNAPSHOT
  - Change plugin dependency of plugin 'org.jboss.tools.hibernate.orm.runtime.exp' on the jakarta persistence API to version 3.1.x

Signed-off-by: Koen Aers <koen.aers@gmail.com>