### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.2.0.CR1.jar,
- lib/hibernate-core-6.2.0.CR1.jar,
+ lib/hibernate-ant-6.2.0.CR2.jar,
+ lib/hibernate-core-6.2.0.CR2.jar,
  lib/hibernate-tools-orm-6.2.0-SNAPSHOT.jar,
  lib/hibernate-tools-orm-jbt-6.2.0-SNAPSHOT.jar,
  lib/hibernate-tools-utils-6.2.0-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.2.0.CR1</hibernate.orm.version>
+		<hibernate.orm.version>6.2.0.CR2</hibernate.orm.version>
 		<hibernate.tools.version>6.2.0-SNAPSHOT</hibernate.tools.version>
 	</properties>
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.2.0.CR1", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.0.CR2", org.hibernate.Version.getVersionString());
 	}
 
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
@@ -61,14 +61,17 @@ public class IColumnTest {
 
 	@Test
 	public void testGetSqlType() {
+		// IColumn#getSqlType()
 		assertNull(columnFacade.getSqlType());
 		columnTarget.setSqlType("foobar");
 		assertEquals("foobar", columnFacade.getSqlType());
+		// IColumn#getSqlType(IConfiguration)
+		columnFacade = FACADE_FACTORY.createColumn(null);
+		columnTarget = (ColumnWrapper)((IFacade)columnFacade).getTarget();
+		columnTarget.setValue(createValue());
 		IConfiguration configurationFacade = FACADE_FACTORY.createNativeConfiguration();
 		configurationFacade.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
 		configurationFacade.setProperty(AvailableSettings.CONNECTION_PROVIDER, MockConnectionProvider.class.getName());
-		columnTarget.setValue(createValue());
-		columnTarget.setSqlType(null);
 		assertEquals("integer", columnFacade.getSqlType(configurationFacade));
 	}
 	


### PR DESCRIPTION
  - Update dependency on Hibernate ORM to version 6.2.0.CR2

Signed-off-by: Koen Aers <koen.aers@gmail.com>