### PR TITLE
JBIDE-28872: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_6_1 to version 6.1.7.Final

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.1.6.Final.jar,
- lib/hibernate-core-6.1.6.Final.jar,
- lib/hibernate-tools-orm-6.1.6.Final.jar,
- lib/hibernate-tools-utils-6.1.6.Final.jar
+ lib/hibernate-ant-6.1.7.Final.jar,
+ lib/hibernate-core-6.1.7.Final.jar,
+ lib/hibernate-tools-orm-6.1.7.Final.jar,
+ lib/hibernate-tools-utils-6.1.7.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.version>6.1.6.Final</hibernate.version>
+		<hibernate.version>6.1.7.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/VersionTest.java
@@ -11,12 +11,12 @@ public class VersionTest {
 	
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.1.6.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.1.7.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test
 	public void testCoreVersion() {
-		assertEquals("6.1.6.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.1.7.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ColumnFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/ColumnFacadeTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -68,7 +69,7 @@ public class ColumnFacadeTest {
 	}
 
 	@Test
-	public void testGetSqlType() {
+	public void testGetSqlType() throws Exception {
 		assertNull(columnFacade.getSqlType());
 		column.setSqlType("foobar");
 		assertEquals("foobar", columnFacade.getSqlType());
@@ -79,7 +80,9 @@ public class ColumnFacadeTest {
 		value.setTypeName("int");
 		column.setValue(value);
 		IConfiguration configurationFacade = FACADE_FACTORY.createConfiguration(configuration);
-		column.setSqlType(null);
+		Field sqlTypeNameField = Column.class.getDeclaredField("sqlTypeName"); 
+		sqlTypeNameField.setAccessible(true);
+		sqlTypeNameField.set(column, null);
 		assertEquals("integer", columnFacade.getSqlType(configurationFacade));
 	}
 	


### PR DESCRIPTION
  - Change the version identifier in pom.xml to 6.1.7.Final
  - Change the bundle classpath in 'META-INF/MANIFEST.MF' to include the proper jar files
  - Adapt the tests in 'org.jboss.tools.hibernate.runtime.v_6_1.VersionTest' accordingly
  - Change test case 'org.jboss.tools.hibernate.runtime.v_6_1.internal.ColumnFacadeTest#testGetSqlType()' to force setting the SQL type