### PR TITLE
JBIDE-28769: Implement and use the generic adapter for ITable in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
@@ -1,0 +1,13 @@
+package org.jboss.tools.hibernate.orm.runtime.exp.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.runtime.spi.ITable;
+
+public interface IDatabaseReader extends IFacade {
+	
+	Map<String, List<ITable>> collectDatabaseTables();
+
+}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,8 +1,10 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import java.util.Map;
+import java.util.Properties;
 
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
@@ -166,6 +168,16 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 
 				wrapperFactory.createListWrapper(((IFacade)persistentClass).getTarget()));
+	}
+
+	public IDatabaseReader createDatabaseReader(
+			Properties properties, 
+			IReverseEngineeringStrategy strategy) {
+		return (IDatabaseReader)GenericFacadeFactory.createFacade(
+				IDatabaseReader.class, 
+				wrapperFactory.createDatabaseReaderWrapper(
+						properties,
+						((IFacade)strategy).getTarget()));
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -1,10 +1,12 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.util.Properties;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
 import org.hibernate.cfg.NamingStrategy;
@@ -31,6 +33,7 @@ import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.IDatabaseReader;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
@@ -265,6 +268,21 @@ public class NewFacadeFactoryTest {
 		assertNotNull(listFacade);
 		assertTrue(listWrapper instanceof List);
 		assertSame(rootClass, ((List)listWrapper).getOwner());
+	}
+	
+	@Test
+	public void testCreateDatabaseReader() {
+		Properties properties = new Properties();
+		properties.put("hibernate.connection.url", "jdbc:h2:mem:test");
+		IReverseEngineeringStrategy revengStrategyFacade = 
+				facadeFactory.createReverseEngineeringStrategy();
+		IDatabaseReader databaseReaderFacade = 
+				facadeFactory.createDatabaseReader(properties, revengStrategyFacade);
+		assertNotNull(databaseReaderFacade);
+		Object databaseReaderWrapper = ((IFacade)databaseReaderFacade).getTarget();
+		assertEquals(
+				"org.hibernate.tool.orm.jbt.wrp.DatabaseReaderWrapperFactory$DatabaseReaderWrapperImpl",
+				databaseReaderWrapper.getClass().getName());
 	}
 	
 	public static class TestRevengStrategy extends DelegatingStrategy {


### PR DESCRIPTION
  - Add new interface 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IDatabaseReader' with method 'collectDatabaseTables()'
  - Add new test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateDatabaseReader()'
  - Add new implementation method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createDatabaseReader(Properties,IReverseEngineeringStrategy)'
  - Adapt the implementation of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#collectDatabaseTables(Properties,IReverseEngineeringStrategy)'