### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.2.0.CR3.jar,
- lib/hibernate-core-6.2.0.CR3.jar,
+ lib/hibernate-ant-6.2.0.CR4.jar,
+ lib/hibernate-core-6.2.0.CR4.jar,
  lib/hibernate-tools-orm-6.2.0-SNAPSHOT.jar,
  lib/hibernate-tools-orm-jbt-6.2.0-SNAPSHOT.jar,
  lib/hibernate-tools-utils-6.2.0-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.2.0.CR3</hibernate.orm.version>
+		<hibernate.orm.version>6.2.0.CR4</hibernate.orm.version>
 		<hibernate.tools.version>6.2.0-SNAPSHOT</hibernate.tools.version>
 	</properties>
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,7 +8,7 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.2.0.CR3", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.0.CR4", org.hibernate.Version.getVersionString());
 	}
 
 	@Test


### PR DESCRIPTION
  - Update hibernate tools dependency of 'org.jboss.tools.hibernate.orm.runtime.exp' to version 6.2.0.CR4