### PR TITLE
JBIDE-28951: For JBIDE 4.28.0.AM1: Prepare for 4.28.0.AM1 [hibernate]

### DIFF
--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Antlr for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.antlr.v_2_7_7
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/antlr-2.7.7.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr.v_2_7_7/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.antlr.v_2_7_7</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Antlr4 Runtime for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/antlr4-runtime-4.10.1.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Beanshell for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.bsh.v_2_0_b4
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/bsh-core-2.0b4.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.bsh.v_2_0_b4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.bsh.v_2_0_b4</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.byte-buddy.v_1_12/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.byte-buddy.v_1_12/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Byte Buddy 1.12.x for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.byte-buddy.v_1_12
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/byte-buddy-1.12.10.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.byte-buddy.v_1_12/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.byte-buddy.v_1_12/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.byte-buddy.v_1_12</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.classmate.v_1_5/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.classmate.v_1_5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Classmate 1.5.x for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.classmate.v_1_5
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/classmate-1.5.1.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.classmate.v_1_5/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.classmate.v_1_5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.classmate.v_1_5</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.commons-collections4.v_4_4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.commons-collections4.v_4_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Commons Collections4 for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.commons-collections4.v_4_4
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/commons-collections4-4.4.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.commons-collections4.v_4_4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.commons-collections4.v_4_4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.commons-collections4.v_4_4</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Dom4j for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.dom4j.v_1_6_1
 Bundle-Vendor: Red Hat
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/dom4j-1.6.1.jar,
  .

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_1_6_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.dom4j.v_1_6_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Dom4j 2.1.x for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.dom4j.v_2_1
 Bundle-Vendor: Red Hat
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/dom4j-2.1.3.jar
 Export-Package: org.dom4j,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.dom4j.v_2_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.dom4j.v_2_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Freemarker 2.3 for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.freemarker.v_2_3
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/freemarker-2.3.31.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.freemarker.v_2_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.freemarker.v_2_3</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_1_4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_1_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: H2 Database for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.h2.v_1_4
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/h2-1.4.200.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_1_4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_1_4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.h2.v_1_4</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_2_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_2_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: H2 Database 2.1.x for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.h2.v_2_1
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/h2-2.1.214.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_2_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.h2.v_2_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.h2.v_2_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Commons Annotations for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/hibernate-commons-annotations-5.1.2.Final.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_5_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Commons Annotations Version 6.0.x  for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.hibernate.annotations.common.annotationfactory,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.hibernate-commons-annotations.v_6_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jakarta Acttivation API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jakarta.activation-api-2.0.1.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jakarta-activation-api.v_2_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jakarta Persistence API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jakarta.persistence-api-3.0.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jakarta Persistence API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jakarta.persistence-api-3.1.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jakarta Transaction API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jakarta.transaction-api-2.0.0.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jakarta-transaction-api.v_2_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jakarta Transaction API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jakarta.xml.bind-api-3.0.1.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jakarta-xml-bind-api.v_3_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jandex.v_2_4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jandex.v_2_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Java Persistence API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jandex.v_2_4
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jandex-2.4.0.Final.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jandex.v_2_4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jandex.v_2_4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jandex.v_2_4</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.javassist.v_3_28/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.javassist.v_3_28/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Javassist for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.javassist.v_3_28
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/javassist-3.28.0-GA.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.javassist.v_3_28/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.javassist.v_3_28/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.javassist.v_3_28</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Activation API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jaxb.v_2_3;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_2_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jaxb.v_2_3</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_3_0/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_3_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JAXB 3.0 implementation for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jaxb.v_3_0;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_3_0/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jaxb.v_3_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jaxb.v_3_0</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Logging for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jboss-logging.v_3_4
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jboss-logging-3.4.3.Final.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jboss-logging.v_3_4/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jboss-logging.v_3_4</artifactId>

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jpa.v_2_2/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jpa.v_2_2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Java Persistence API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jpa.v_2_2
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/javax.persistence-api-2.2.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jpa.v_2_2/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jpa.v_2_2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jpa.v_2_2</artifactId> 

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JTidy for JBoss Tools Hibernate
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jtidy-r8-20060801.jar
 Export-Package: org.w3c.tidy,

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.jtidy.v_r8-20060801</artifactId>

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.transaction-api.v_1_2/META-INF/MANIFEST.MF
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.transaction-api.v_1_2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Transaction API for JBoss Tools Hibernate
 Bundle-SymbolicName: org.jboss.tools.hibernate.libs.transaction-api.v_1_2
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar

--- a/common/plugin/lib/org.jboss.tools.hibernate.libs.transaction-api.v_1_2/pom.xml
+++ b/common/plugin/lib/org.jboss.tools.hibernate.libs.transaction-api.v_1_2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 		<artifactId>lib</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin.lib</groupId>
 	<artifactId>org.jboss.tools.hibernate.libs.transaction-api.v_1_2</artifactId> 

--- a/common/plugin/lib/pom.xml
+++ b/common/plugin/lib/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.common</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common.plugin</groupId>
 	<artifactId>lib</artifactId>

--- a/common/plugin/pom.xml
+++ b/common/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>common</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.common</groupId>
 	<artifactId>plugin</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>common</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>docs</artifactId>

--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.eclipse.feature"
       label="%featureName"
-      version="5.4.20.qualifier"
+      version="5.4.21.qualifier"
       provider-name="%providerName"
       plugin="org.hibernate.eclipse"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.hibernate.eclipse.feature/pom.xml
+++ b/features/org.hibernate.eclipse.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.features</groupId>
 	<artifactId>org.hibernate.eclipse.feature</artifactId> 

--- a/features/org.hibernate.eclipse.test.feature/feature.xml
+++ b/features/org.hibernate.eclipse.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.eclipse.test.feature"
       label="%featureName"
-      version="5.4.20.qualifier"
+      version="5.4.21.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/features/org.hibernate.eclipse.test.feature/pom.xml
+++ b/features/org.hibernate.eclipse.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.plugins</groupId>
 	<artifactId>org.hibernate.eclipse.test.feature</artifactId> 

--- a/features/org.hibernate.search.eclipse.feature/feature.xml
+++ b/features/org.hibernate.search.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.hibernate.search.eclipse.feature"
       label="%featureName"
-      version="5.4.20.qualifier"
+      version="5.4.21.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.hibernate.search"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.hibernate.search.eclipse.feature/pom.xml
+++ b/features/org.hibernate.search.eclipse.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
   <groupId>org.jboss.tools.hibernatesearchtools.features</groupId>
   <artifactId>org.hibernate.search.eclipse.feature</artifactId>

--- a/features/org.jboss.tools.hibernate.search.test.feature/feature.xml
+++ b/features/org.jboss.tools.hibernate.search.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.hibernate.search.test.feature"
       label="%featureName"
-      version="5.4.20.qualifier"
+      version="5.4.21.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/features/org.jboss.tools.hibernate.search.test.feature/pom.xml
+++ b/features/org.jboss.tools.hibernate.search.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>features</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatesearchtools.features</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>features</artifactId>

--- a/itests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
+++ b/itests/org.jboss.tools.hibernate.ui.bot.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate UI tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.ui.bot.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.ui.bot.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/itests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
+++ b/itests/org.jboss.tools.hibernate.ui.bot.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>itests</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.itests</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui.bot.test</artifactId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>itests</artifactId>

--- a/orm/plugin/core/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.console; singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.hibernate.eclipse.console.HibernateConsolePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.console/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.console/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.console</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.help/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.help; singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.hibernate.eclipse.help.HelpPlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.help/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.help/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.help</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.jdt.ui;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.hibernate.eclipse.jdt.ui.Activator
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.jdt.ui</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse.mapper/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse.mapper/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.mapper; singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.hibernate.eclipse.mapper.MapperPlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse.mapper/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse.mapper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse.mapper</artifactId> 

--- a/orm/plugin/core/org.hibernate.eclipse/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.hibernate.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.hibernate.eclipse.HibernatePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin

--- a/orm/plugin/core/org.hibernate.eclipse/pom.xml
+++ b/orm/plugin/core/org.hibernate.eclipse/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.hibernate.eclipse</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.core;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.wst.validation;bundle-version="1.2.501",

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.core</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Jdt UI
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.ui;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.jpt.ui.HibernateJptUIPlugin
 Require-Bundle: 
  org.hibernate.eclipse.console;bundle-version="5.0.0",

--- a/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.jpt.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.ui/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  org.eclipse.jdt.ui;bundle-version="3.10.100",
  org.hibernate.eclipse.console;bundle-version="5.0.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0"
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Export-Package: org.jboss.tools.hibernate.ui.diagram,
  org.jboss.tools.hibernate.ui.diagram.editors,
  org.jboss.tools.hibernate.ui.diagram.editors.actions,

--- a/orm/plugin/core/org.jboss.tools.hibernate.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.100",
  org.jboss.tools.common.model.ui;bundle-version="3.7.0",
  org.jboss.tools.hibernate.xml;bundle-version="5.0.0",
  org.eclipse.wst.xml.ui;bundle-version="1.1.500"
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.xml.ui</artifactId> 

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml/META-INF/MANIFEST.MF
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.100",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.jboss.tools.common;bundle-version="3.7.0",
  org.jboss.tools.common.model;bundle-version="3.7.0"
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/orm/plugin/core/org.jboss.tools.hibernate.xml/pom.xml
+++ b/orm/plugin/core/org.jboss.tools.hibernate.xml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.xml</artifactId> 

--- a/orm/plugin/core/pom.xml
+++ b/orm/plugin/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 	<artifactId>core</artifactId>

--- a/orm/plugin/pom.xml
+++ b/orm/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>orm</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 	<artifactId>plugin</artifactId>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Tools Service Provider Interface
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.common;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.common</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Tools Service Provider Interface
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.spi;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jboss.tools.hibernate.runtime.spi
 Require-Bundle: org.eclipse.core.runtime

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.spi</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 3.5 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.apache.commons.logging,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_5</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 3.6 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_6;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.jboss.tools.hibernate.libs.antlr.v_2_7_7,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_6</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 4.0 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.apache.commons.collections,
  org.apache.commons.logging,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_0</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 4.3 libraries
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr.v_2_7_7,
  org.jboss.tools.hibernate.libs.commons-collections4.v_4_4,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_3</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.0 libraries
 Bundle-Vendor: Red Hat
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_0;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_0</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.1 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_1;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/hibernate-core-5.1.16.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_1</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.2 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_2;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/hibernate-core-5.2.18.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_2</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.3 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_3;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_3</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.4 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_4</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.5 libraries
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.5
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_5</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 5.6 libraries
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.6
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_6;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_6</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.0 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_0</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.1
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.1 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_1;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_1</artifactId> 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.2
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate 6.2 libraries
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_2;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.byte-buddy.v_1_12,
  org.jboss.tools.hibernate.libs.classmate.v_1_5,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_2</artifactId> 

--- a/orm/plugin/runtime/pom.xml
+++ b/orm/plugin/runtime/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 	<artifactId>runtime</artifactId>

--- a/orm/plugin/ui/org.jboss.tools.hibernate.orm.ui/META-INF/MANIFEST.MF
+++ b/orm/plugin/ui/org.jboss.tools.hibernate.orm.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate ORM UI
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.ui;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.jboss.tools.hibernate.orm.ui

--- a/orm/plugin/ui/org.jboss.tools.hibernate.orm.ui/pom.xml
+++ b/orm/plugin/ui/org.jboss.tools.hibernate.orm.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 		<artifactId>ui</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin.ui</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.ui</artifactId> 

--- a/orm/plugin/ui/pom.xml
+++ b/orm/plugin/ui/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
 	<artifactId>ui</artifactId>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.hibernatetools</groupId>

--- a/orm/test/core/org.hibernate.eclipse.jdt.ui.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.hibernate.eclipse.jdt.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.hibernate.eclipse.jdt.ui.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.hibernate.eclipse.console;bundle-version="5.0.0",

--- a/orm/test/core/org.hibernate.eclipse.jdt.ui.test/pom.xml
+++ b/orm/test/core/org.hibernate.eclipse.jdt.ui.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.hibernate.eclipse.jdt.ui.test</artifactId> 

--- a/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.jpt.core.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.wst.common.project.facet.ui;bundle-version="1.4.500",
  org.eclipse.jpt.jpa.core;bundle-version="3.4.0",

--- a/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/pom.xml
+++ b/orm/test/core/org.jboss.tools.hibernate.jpt.core.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.jpt.core.test</artifactId> 

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.hibernate.orm.test;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-ClassPath: .,
  lib/jmock-2.5.1.jar,
  lib/jmock-legacy-2.5.1.jar,

--- a/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
+++ b/orm/test/core/org.jboss.tools.hibernate.orm.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.test</artifactId> 

--- a/orm/test/core/pom.xml
+++ b/orm/test/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 	<artifactId>core</artifactId>

--- a/orm/test/pom.xml
+++ b/orm/test/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>orm</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 	<artifactId>test</artifactId>

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Service Plugin Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.spi.test;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.spi
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.spi.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.spi.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 3.5 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_5.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_5;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_5.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime Version 3.6 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_3_6.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_3_6
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_3_6.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 4.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_0.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_0.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 4.3 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_4_3.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_4_3.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_0.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_0.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.1 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_1.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_1.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.2 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_2.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_2.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.3 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_3.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_3
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_3.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.4 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_4.test
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.4.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_4
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_4.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.5 Tests
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.5.test
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_5.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_5
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_5.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 5.6 Tests
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.5.6.test
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_5_6.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_6
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_5_6.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 6.0 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_0.test
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.0.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_0.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 6.1 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_1.test
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.1.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_1
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_1.test</artifactId> 

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Runtime 6.2 Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.runtime.v_6_2.test
 Automatic-Module-Name: org.jboss.tools.hibernate.runtime.v.6.2.test
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_6_2
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.jboss.tools.hibernate.libs.h2.v_1_4,

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.runtime.v_6_2.test</artifactId> 

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>

--- a/orm/test/util/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
+++ b/orm/test/util/org.jboss.tools.hibernate.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Hibernate UI Tests
 Bundle-SymbolicName: org.jboss.tools.hibernate.reddeer
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/orm/test/util/org.jboss.tools.hibernate.reddeer/pom.xml
+++ b/orm/test/util/org.jboss.tools.hibernate.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 		<artifactId>util</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.jboss.tools.hibernate.reddeer</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/orm/test/util/pom.xml
+++ b/orm/test/util/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.orm</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
 	<artifactId>util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	</parent>
 	<artifactId>hibernatetools</artifactId>
 	<name>jbosstools-hibernate</name>
-	<version>5.4.20-SNAPSHOT</version>
+	<version>5.4.21-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-hibernate.git</tycho.scmUrl>

--- a/search/plugin/core/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
+++ b/search/plugin/core/org.jboss.tools.hibernate.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: jbosstools-hibernate-search
 Bundle-SymbolicName: org.jboss.tools.hibernate.search;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: bdshadow
 Export-Package: org.jboss.tools.hibernate.search,

--- a/search/plugin/core/org.jboss.tools.hibernate.search/pom.xml
+++ b/search/plugin/core/org.jboss.tools.hibernate.search/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.search</artifactId>

--- a/search/plugin/core/pom.xml
+++ b/search/plugin/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 	<artifactId>core</artifactId>

--- a/search/plugin/pom.xml
+++ b/search/plugin/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>search</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search</groupId>
 	<artifactId>plugin</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Search Tools Service Provider Interface
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.common;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Vendor: bdshadow
 Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.hibernate.search.runtime.spi;bundle-version="2.0.0",

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.common</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.spi
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.spi;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-Activator: org.jboss.tools.hibernate.search.runtime.spi.internal.HibernateSearchServicePlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.spi</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_4_0
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_4_0;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_0;bundle-version="5.1.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_4_0/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.v_4_0</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_3
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_3;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_4_3;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_3/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.runtime.v_5_3</artifactId>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_5.1
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_5.1;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_1;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5.1/pom.xml
@@ -6,7 +6,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_5
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_5;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_0;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/META-INF/MANIFEST.MF
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: hibernate.search.runtime.v_5_7
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.runtime.v_5_7;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Fragment-Host: org.jboss.tools.hibernate.runtime.v_5_2;bundle-version="5.1.2"
 Bundle-Vendor: bdshadow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/pom.xml
+++ b/search/plugin/runtime/org.jboss.tools.hibernate.search.runtime.v_5_7/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 		<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 		<artifactId>runtime</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
   </parent>
   
 	<groupId>org.jboss.tools.hibernatetools.search.plugin.runtime</groupId>

--- a/search/plugin/runtime/pom.xml
+++ b/search/plugin/runtime/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.plugin</groupId>
 	<artifactId>runtime</artifactId>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>search</artifactId>

--- a/search/test/core/org.jboss.tools.hibernate.search.test/META-INF/MANIFEST.MF
+++ b/search/test/core/org.jboss.tools.hibernate.search.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hibernate Search Plugin Test
 Bundle-SymbolicName: org.jboss.tools.hibernate.search.test;singleton:=true
-Bundle-Version: 5.4.20.qualifier
+Bundle-Version: 5.4.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.hibernate.eclipse,

--- a/search/test/core/org.jboss.tools.hibernate.search.test/pom.xml
+++ b/search/test/core/org.jboss.tools.hibernate.search.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search.test</groupId>
 		<artifactId>core</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatesearchtools.search.test.core</groupId>
 	<artifactId>org.jboss.tools.hibernate.search.test</artifactId>

--- a/search/test/core/pom.xml
+++ b/search/test/core/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools.search</groupId>
 		<artifactId>test</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search.test</groupId>
 	<artifactId>core</artifactId>

--- a/search/test/pom.xml
+++ b/search/test/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools.hibernatetools</groupId>
 		<artifactId>search</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools.search</groupId>
 	<artifactId>test</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>hibernatetools.site</artifactId> 

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>test-framework</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>hibernatetools</artifactId>
-		<version>5.4.20-SNAPSHOT</version>
+		<version>5.4.21-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.hibernatetools</groupId>
 	<artifactId>all-tests</artifactId>


### PR DESCRIPTION
  - Bump the version identifiers to '5.4.21-SNAPSHOT'