### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -131,7 +131,7 @@ public class GenericFacadeFactory {
 		if (args != null) {
 			result = new Object[args.length];
 			for (int i = 0; i < args.length; i++) {
-				if (IFacade.class.isAssignableFrom(args[i].getClass())) {
+				if (args[i] != null && IFacade.class.isAssignableFrom(args[i].getClass())) {
 					Object target = ((IFacade)args[i]).getTarget();
 					Class<?> targetClass = target.getClass();
 					if (Proxy.isProxyClass(targetClass)) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ReflectUtil.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/ReflectUtil.java
@@ -58,7 +58,7 @@ public class ReflectUtil {
     }
 
     private static boolean isAssignableTo(Class<?> from, Class<?> to) {
-        if (to.isAssignableFrom(from)) {
+        if (from == null || to.isAssignableFrom(from)) {
             return true;
         }
         if (from.isPrimitive()) {


### PR DESCRIPTION
  - Handle 'null' argument in 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ReflectUtil#isAssignableTo(Class<?>,Class<?>)'
  - Handle 'null' argument in 'org.jboss.tools.hibernate.orm.runtime.exp.interna l.util.GenericFacadeFactory#unwrapFacades(Object[])'