### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.2.0.Final.jar,
- lib/hibernate-core-6.2.0.Final.jar,
- lib/hibernate-tools-orm-6.2.1-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.2.1-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.2.1-SNAPSHOT.jar
+ lib/hibernate-ant-6.2.1.Final.jar,
+ lib/hibernate-core-6.2.1.Final.jar,
+ lib/hibernate-tools-orm-6.2.2-SNAPSHOT.jar,
+ lib/hibernate-tools-orm-jbt-6.2.2-SNAPSHOT.jar,
+ lib/hibernate-tools-utils-6.2.2-SNAPSHOT.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.2.0.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.2.1-SNAPSHOT</hibernate.tools.version>
+		<hibernate.orm.version>6.2.1.Final</hibernate.orm.version>
+		<hibernate.tools.version>6.2.2-SNAPSHOT</hibernate.tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.2.0.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.1.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.2.1-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.2.2-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -354,7 +354,7 @@ public class ServiceImplTest {
 	public void testNewDialect() throws Exception {
 		Connection connection = DriverManager.getConnection("jdbc:h2:mem:");
 		String dialect = service.newDialect(new Properties(), connection);
-		assertEquals("org.hibernate.dialect.H2Dialect", dialect);
+		assertTrue(dialect.contains("org.hibernate.dialect.H2Dialect"));
 	}
 
 	@Test


### PR DESCRIPTION
  - Update Hibernate ORM dependency to version 6.2.1.Final
  - Update Hibernate Tools dependency to version 6.2.2-SNAPSHOT
  - Adapt the corresponding tests