### PR TITLE
JBIDE-28763: Implement and use the generic adapter for IPrimaryKey in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -20,6 +20,7 @@ import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
+import org.jboss.tools.hibernate.runtime.spi.IPrimaryKey;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
 import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
@@ -154,6 +155,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 
 	@Override
 	public IForeignKey createForeignKey(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+
+	@Override
+	public IPrimaryKey createPrimaryKey(Object target) {
 		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -12,7 +12,6 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Column;
-import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
@@ -30,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
-import org.jboss.tools.hibernate.runtime.spi.IPrimaryKey;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
 import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
@@ -295,6 +293,16 @@ public class FacadeFactoryTest {
 	}
 	
 	@Test
+	public void testCreatePrimaryKey() {
+		try {
+			FACADE_FACTORY.createPrimaryKey(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());
+		}
+	}
+	
+	@Test
 	public void testCreateSchemaExport() {
 		SchemaExport schemaExport = new SchemaExport();
 		ISchemaExport facade = FACADE_FACTORY.createSchemaExport(schemaExport);
@@ -366,13 +374,6 @@ public class FacadeFactoryTest {
 				new TestInvocationHandler());
 		IPOJOClass facade = FACADE_FACTORY.createPOJOClass(pojoClass);
 		assertSame(pojoClass, ((IFacade)facade).getTarget());
-	}
-	
-	@Test
-	public void testCreatePrimaryKey() {
-		PrimaryKey primaryKey = new PrimaryKey(null);
-		IPrimaryKey facade = FACADE_FACTORY.createPrimaryKey(primaryKey);
-		assertSame(primaryKey, ((IFacade)facade).getTarget());
 	}
 	
 	@Test


### PR DESCRIPTION
  - Adapt test method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryTest#testCreatePrimaryKey()' to check that 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createPrimaryKey(Object)' throws an exception
  - Implement method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createPrimaryKey(Object)' to throw an exception