### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeImpl.java
@@ -2,9 +2,10 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
 import java.io.File;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor;
+import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.jboss.tools.hibernate.runtime.common.AbstractExporterFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
@@ -22,7 +23,7 @@ public class ExporterFacadeImpl extends AbstractExporterFacade {
 		setCustomProperties(configuration.getProperties());
 		((Exporter)getTarget()).getProperties().put(
 				ExporterConstants.METADATA_DESCRIPTOR, 
-				new ConfigurationMetadataDescriptor(configuration));
+				new ConfigurationMetadataDescriptor((Configuration)((IFacade)configuration).getTarget()));
 	}
 	
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
@@ -3,9 +3,11 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import java.io.File;
 import java.util.Map;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.internal.export.hbm.HbmExporter;
 import org.hibernate.tool.internal.export.java.POJOClass;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor;
+import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
+import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
@@ -19,7 +21,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		this.facadeFactory = facadeFactory;
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
-				new ConfigurationMetadataDescriptor((IConfiguration)cfg));
+				new ConfigurationMetadataDescriptor((Configuration)((IFacade)cfg).getTarget()));
 		if (file != null) {
 			getProperties().put(OUTPUT_FILE_NAME, file);
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -26,10 +26,10 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
+import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataDescriptor;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
 import org.hibernate.tool.orm.jbt.util.MetadataHelper;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractService;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -131,7 +131,7 @@ public class ServiceImpl extends AbstractService {
 		} else {
 			exporter.getProperties().put(
 					ExporterConstants.METADATA_DESCRIPTOR,
-					new ConfigurationMetadataDescriptor(newDefaultConfiguration()));
+					new ConfigurationMetadataDescriptor((Configuration)((IFacade)newDefaultConfiguration()).getTarget()));
 		}
 		return facadeFactory.createExporter(exporter);
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ExporterFacadeTest.java
@@ -13,13 +13,14 @@ import java.io.Writer;
 import java.lang.reflect.Field;
 import java.util.Properties;
 
+import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.query.QueryExporter;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor;
+import org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
@@ -61,12 +62,12 @@ public class ExporterFacadeTest {
 		assertNotNull(object);
 		assertTrue(object instanceof ConfigurationMetadataDescriptor);
 		ConfigurationMetadataDescriptor configurationMetadataDescriptor = (ConfigurationMetadataDescriptor)object;
-		Field field = ConfigurationMetadataDescriptor.class.getDeclaredField("configurationFacade");
+		Field field = ConfigurationMetadataDescriptor.class.getDeclaredField("configuration");
 		field.setAccessible(true);
 		object = field.get(configurationMetadataDescriptor);
 		assertNotNull(object);
-		assertTrue(object instanceof IConfiguration);
-		assertSame(object, configurationFacade);
+		assertTrue(object instanceof Configuration);
+		assertSame(object, ((IFacade)configurationFacade).getTarget());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
@@ -26,6 +26,7 @@ import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
@@ -42,7 +43,10 @@ public class HibernateMappingExporterExtensionTest {
 
 	@BeforeEach
 	public void beforeEach() throws Exception {
-		hibernateMappingExporterExtension = new HibernateMappingExporterExtension(FACADE_FACTORY, null, null);
+		hibernateMappingExporterExtension = new HibernateMappingExporterExtension(
+				FACADE_FACTORY, 
+				NewFacadeFactory.INSTANCE.createNativeConfiguration(), 
+				null);
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
@@ -36,6 +36,7 @@ import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
@@ -58,7 +59,10 @@ public class HibernateMappingExporterFacadeTest {
 	@BeforeEach
 	public void beforeEacy() throws Exception {
 		outputDir = Files.createTempDirectory("output").toFile();
-		hibernateMappingExporter = new HibernateMappingExporterExtension(FACADE_FACTORY, null, null);
+		hibernateMappingExporter = new HibernateMappingExporterExtension(
+				FACADE_FACTORY, 
+				NewFacadeFactory.INSTANCE.createNativeConfiguration(), 
+				null);
 		hibernateMappingExporterFacade = 
 				new HibernateMappingExporterFacadeImpl(FACADE_FACTORY, hibernateMappingExporter);
 	}


### PR DESCRIPTION
  - Replace the use of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.ConfigurationMetadataDescriptor' with 'org.hibernate.tool.orm.jbt.util.ConfigurationMetadataDescriptor'