### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -174,6 +174,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 	
 	@Override
+	public IQueryTranslator createQueryTranslator(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+
+	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();
 	}
@@ -214,10 +219,4 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 		return new QueryFacadeImpl(this, target);
 	}
 	
-	@Override
-	public IQueryTranslator createQueryTranslator(Object target) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 }


### PR DESCRIPTION
  - Method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createQueryTranslator(Object)' throws a RuntimeException