### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
@@ -246,10 +246,11 @@ public class NewHibernateMappingFileWizard extends Wizard implements INewWizard,
 				exportPojo(map, pojoClass);
 			}
 			@Override public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+				exportPojo(map, pojoClass, ((IPOJOClass)pojoClass).getQualifiedDeclarationName());
+			}
+			@Override public void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName) {
 				File outputdir4FileOld = target.getOutputDirectory();
-				File outputdir4FileNew = createNewOutputDir4File(
-						((IPOJOClass)pojoClass).getQualifiedDeclarationName(), 
-						outputdir4FileOld);
+				File outputdir4FileNew = createNewOutputDir4File(fullyQualifiedName, outputdir4FileOld);
 				target.setOutputDirectory(outputdir4FileNew);
 				target.exportPOJO(map, pojoClass);
 				target.setOutputDirectory(outputdir4FileOld);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
@@ -9,5 +9,9 @@ public interface IExportPOJODelegate {
 	default void exportPojo(Map<Object, Object> map, Object pojoClass) {
 		exportPOJO(map, (IPOJOClass)pojoClass);
 	}
+	
+	default void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName) {
+		exportPojo(map, pojoClass);
+	}
 
 }


### PR DESCRIPTION
  - Add new method 'org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate#exportPojo(Map<Object,Object>,Object,String)' with default implementation'