### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
@@ -242,9 +242,6 @@ public class NewHibernateMappingFileWizard extends Wizard implements INewWizard,
 	protected class HibernateMappingExporterWrapper { 
 		protected IJavaProject proj;
 		private IExportPOJODelegate delegate = new IExportPOJODelegate() {	
-			@Override public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
-				exportPojo(map, pojoClass);
-			}
 			@Override public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				exportPojo(map, pojoClass, ((IPOJOClass)pojoClass).getQualifiedDeclarationName());
 			}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
@@ -41,7 +41,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
@@ -4,11 +4,7 @@ import java.util.Map;
 
 public interface IExportPOJODelegate {
 
-	void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass);
-	
-	default void exportPojo(Map<Object, Object> map, Object pojoClass) {
-		exportPOJO(map, (IPOJOClass)pojoClass);
-	}
+	void exportPojo(Map<Object, Object> map, Object pojoClass);
 	
 	default void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName) {
 		exportPojo(map, pojoClass);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
@@ -36,7 +36,7 @@ extends HibernateMappingExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,7 @@ public class HibernateMappingExporterExtension extends HibernateMappingExporter 
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,7 @@ public class HibernateMappingExporterExtension extends HibernateMappingExporter 
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		if (delegateExporter == null) {
 			super.exportPOJO(map, pojoClass);
 		} else {
-			delegateExporter.exportPOJO(
+			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
 					facadeFactory.createPOJOClass(pojoClass));
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
@@ -30,7 +30,6 @@ import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +54,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -114,7 +113,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
@@ -85,7 +85,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -125,7 +125,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
@@ -71,7 +71,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -126,7 +126,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
@@ -88,7 +88,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -128,7 +128,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtensionTest.java
@@ -29,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -71,7 +70,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -126,7 +125,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterFacadeTest.java
@@ -89,7 +89,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -129,7 +129,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtensionTest.java
@@ -31,7 +31,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -76,7 +75,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -131,7 +130,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterFacadeTest.java
@@ -91,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -131,7 +131,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtensionTest.java
@@ -31,7 +31,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -76,7 +75,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -131,7 +130,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterFacadeTest.java
@@ -91,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -131,7 +131,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtensionTest.java
@@ -32,7 +32,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,7 +82,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -138,7 +137,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterFacadeTest.java
@@ -92,7 +92,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -132,7 +132,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtensionTest.java
@@ -32,7 +32,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,7 +82,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -138,7 +137,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterFacadeTest.java
@@ -92,7 +92,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -132,7 +132,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtensionTest.java
@@ -32,7 +32,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,7 +82,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -138,7 +137,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterFacadeTest.java
@@ -92,7 +92,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -132,7 +132,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtensionTest.java
@@ -29,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_5_3.internal.util.ConfigurationMetadataDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +77,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -133,7 +132,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterFacadeTest.java
@@ -82,7 +82,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -126,7 +126,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtensionTest.java
@@ -78,7 +78,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -133,7 +133,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterFacadeTest.java
@@ -82,7 +82,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -126,7 +126,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtensionTest.java
@@ -29,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_5_5.internal.util.ConfigurationMetadataDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +77,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -133,7 +132,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterFacadeTest.java
@@ -82,7 +82,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -126,7 +126,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
@@ -29,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_5_6.internal.util.ConfigurationMetadataDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +77,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -133,7 +132,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterFacadeTest.java
@@ -82,7 +82,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -126,7 +126,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.internal.export.java.POJOClass;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.DummyMetadataBuildingContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +50,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -110,7 +109,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -121,7 +121,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.internal.export.java.POJOClass;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_6_1.internal.util.DummyMetadataBuildingContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +50,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -110,7 +109,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -121,7 +121,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtensionTest.java
@@ -28,7 +28,6 @@ import org.hibernate.tool.internal.export.java.POJOClass;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.v_6_2.internal.util.DummyMetadataBuildingContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +50,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -110,7 +109,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -121,7 +121,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPOJO(Map<Object, Object> map, IPOJOClass pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);


### PR DESCRIPTION
  - Remove method 'org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate#exportPOJO(Map<Object,Object>,IPOJOClass)'
  - Adapt 'org.hibernate.eclipse.jdt.ui.wizards.NewHibernateMappingFileWizard.HibernateMappingExporterWrapper' to account for the above removal
  - Fix the uses of the removed method in the instances of 'org.jboss.tools.hibernate.runtime.v_x_y.internal.HibernateMappingExporterExtension'
  - Fix the tests to account for the removed method