### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractHibernateMappingExporterFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/AbstractHibernateMappingExporterFacade.java
@@ -45,13 +45,14 @@ implements IHibernateMappingExporter {
 
 	@Override
 	public void exportPOJO(Map<Object, Object> map, Object pojoClass) {
-		// pojoClass should be a IFacade instance
-		assert pojoClass instanceof IFacade;
-		Object pojoClassTarget = Util.invokeMethod(
+		Object pojoClassTarget = pojoClass;
+		if (pojoClass instanceof IFacade) {
+			pojoClassTarget = Util.invokeMethod(
 				pojoClass, 
 				"getTarget", 
 				new Class[] {}, 
 				new Object[] {});
+		}
 		Util.invokeMethod(
 				getTarget(), 
 				"superExportPOJO", 


### PR DESCRIPTION
  - Change the implementation of 'org.jboss.tools.hibernate.runtime.common.AbstractHibernateMappingExporterFacade#exportPOJO(Map<Object,Object>,Object)' to add a non-facade case