### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -13,10 +13,8 @@ import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.ConfigurationMetada
 public class HibernateMappingExporterExtension extends HbmExporter {
 	
 	private IExportPOJODelegate delegateExporter;
-	private IFacadeFactory facadeFactory;
 
 	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
-		this.facadeFactory = facadeFactory;
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
 				new ConfigurationMetadataDescriptor((ConfigurationFacadeImpl)cfg));
@@ -41,7 +39,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					facadeFactory.createPOJOClass(pojoClass));
+					pojoClass);
 		}
 	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -25,7 +25,6 @@ import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.v_6_0.internal.util.DummyMetadataBuildingContext;
@@ -124,7 +123,7 @@ public class HibernateMappingExporterExtensionTest {
 		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
 		assertTrue(hbmXmlFiles.length == 0);
 		assertSame(additionalContext, arguments.get("map"));
-		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+		assertSame(pojoClass, arguments.get("pojoClass"));
 	}
 	
 	@AfterEach

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.internal.export.hbm.Cfg2HbmTool;
 import org.hibernate.tool.internal.export.java.Cfg2JavaTool;
 import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
@@ -88,7 +87,7 @@ public class HibernateMappingExporterFacadeTest {
 					m.put((String)key, map.get(key));
 				}
 				hibernateMappingExporter.superExportPOJO(
-					m,(POJOClass)((IFacade)pojoClass).getTarget());
+					m,(POJOClass)pojoClass);
 			}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");


### PR DESCRIPTION
  - Get rid of IPOJOClass creation in 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtension#exportPOJO(Map,POJOClass)'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterExtensionTest#testExportPOJO()'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_6_0.internal.HibernateMappingExporterFacadeTest#testStart()'