### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
@@ -13,11 +13,9 @@ public class HibernateMappingExporterExtension
 extends HibernateMappingExporter {
 	
 	private IExportPOJODelegate delegateExporter;
-	private IFacadeFactory facadeFactory;
 	
 	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, Configuration cfg, File file) {
 		super(cfg, file);
-		this.facadeFactory = facadeFactory;
 	}
 	
 	public void setDelegate(IExportPOJODelegate delegate) {
@@ -35,7 +33,7 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					facadeFactory.createPOJOClass(pojoClass));
+					pojoClass);
 		}
 	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
@@ -29,7 +29,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,9 +57,6 @@ public class HibernateMappingExporterExtensionTest {
 	
 	@Test
 	public void testConstruction() throws Exception {
-		Field facadeFactoryField = HibernateMappingExporterExtension.class.getDeclaredField("facadeFactory");
-		facadeFactoryField.setAccessible(true);
-		assertSame(FACADE_FACTORY, facadeFactoryField.get(hibernateMappingExporterExtension));
 		assertSame(((IFacade)configurationFacade).getTarget(), hibernateMappingExporterExtension.getConfiguration());
 		assertSame(tempDir, hibernateMappingExporterExtension.getOutputDirectory());
 	}
@@ -141,7 +137,7 @@ public class HibernateMappingExporterExtensionTest {
 		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
 		assertTrue(hbmXmlFiles.length == 0);
 		assertSame(additionalContext, arguments.get("map"));
-		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+		assertSame(pojoClass, arguments.get("pojoClass"));
 	}
 	
 	private POJOClass createPojoClass() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
@@ -25,7 +25,6 @@ import org.hibernate.tool.hbm2x.Cfg2JavaTool;
 import org.hibernate.tool.hbm2x.TemplateHelper;
 import org.hibernate.tool.hbm2x.pojo.EntityPOJOClass;
 import org.hibernate.tool.hbm2x.pojo.POJOClass;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
@@ -95,7 +94,7 @@ public class HibernateMappingExporterFacadeTest {
 					m.put((String)key, map.get(key));
 				}
 				hibernateMappingExporter.superExportPOJO(
-					m,(POJOClass)((IFacade)pojoClass).getTarget());
+					m,(POJOClass)pojoClass);
 			}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");


### PR DESCRIPTION
  - Get rid of IPOJOClass creation in 'org.jboss.tools.hibernate.runtime.v_3_5.internal.HibernateMappingExporterExtension#exportPOJO(Map,POJOClass)'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_3_5.internal.HibernateMappingExporterExtensionTest#testConstruction()'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_3_5.internal.HibernateMappingExporterExtensionTest#testExportPOJO()'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_3_5.internal.HibernateMappingExporterFacadeTest#testStart()'