### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
@@ -15,10 +15,8 @@ import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 public class HibernateMappingExporterExtension extends HbmExporter {
 	
 	private IExportPOJODelegate delegateExporter;
-	private IFacadeFactory facadeFactory;
 
 	public HibernateMappingExporterExtension(IFacadeFactory facadeFactory, IConfiguration cfg, File file) {
-		this.facadeFactory = facadeFactory;
 		getProperties().put(
 				METADATA_DESCRIPTOR, 
 				new ConfigurationMetadataDescriptor((Configuration)((IFacade)cfg).getTarget()));
@@ -43,7 +41,7 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					facadeFactory.createPOJOClass(pojoClass));
+					pojoClass);
 		}
 	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
@@ -27,7 +27,6 @@ import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.junit.jupiter.api.AfterEach;
@@ -128,7 +127,7 @@ public class HibernateMappingExporterExtensionTest {
 		hibernateMappingExporterExtension.exportPOJO(additionalContext, pojoClass);
 		assertTrue(hbmXmlFiles.length == 0);
 		assertSame(additionalContext, arguments.get("map"));
-		assertSame(pojoClass, ((IFacade)arguments.get("pojoClass")).getTarget());
+		assertSame(pojoClass, arguments.get("pojoClass"));
 	}
 	
 	@AfterEach
@@ -139,7 +138,7 @@ public class HibernateMappingExporterExtensionTest {
 		
 	private POJOClass createPojoClass() {
 		RootClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		Table rootTable = new Table();
+		Table rootTable = new Table("");
 		rootTable.setName("table");
 		persistentClass.setTable(rootTable);
 		persistentClass.setEntityName("Bar");

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
@@ -37,7 +37,6 @@ import org.hibernate.tool.internal.export.java.EntityPOJOClass;
 import org.hibernate.tool.internal.export.java.POJOClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.common.IFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
@@ -92,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 					m.put((String)key, map.get(key));
 				}
 				hibernateMappingExporter.superExportPOJO(
-					m,(POJOClass)((IFacade)pojoClass).getTarget());
+					m,(POJOClass)pojoClass);
 			}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
@@ -137,7 +136,7 @@ public class HibernateMappingExporterFacadeTest {
 	@Test
 	public void testExportPOJO() throws Exception {
 		RootClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		Table rootTable = new Table();
+		Table rootTable = new Table("");
 		rootTable.setName("FOO");
 		persistentClass.setTable(rootTable);
 		persistentClass.setEntityName("Foo");

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPojoClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPojoClassTest.java
@@ -22,7 +22,7 @@ public class IPojoClassTest {
 	@BeforeEach 
 	public void beforeEach() {
 		PersistentClass pc = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		pc.setClassName("foo.bar");
+		pc.setClassName("bar");
 		pojoClassTarget = new EntityPOJOClass(pc, new Cfg2JavaTool());
 		pojoClassFacade = (IPOJOClass)GenericFacadeFactory.createFacade(IPOJOClass.class, pojoClassTarget);
 	}
@@ -35,7 +35,7 @@ public class IPojoClassTest {
 	
 	@Test
 	public void testGetQualifiedDeclarationName() {
-		assertEquals("foo.bar", pojoClassFacade.getQualifiedDeclarationName());
+		assertEquals("bar", pojoClassFacade.getQualifiedDeclarationName());
 	}
 
 }


### PR DESCRIPTION
  - Get rid of IPOJOClass creation in 'org.jboss.tools.hibernate.orm.runtime.exp.internal.HibernateMappingExporterExtension#exportPOJO(Map,POJOClass)'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp .internal.HibernateMappingExporterExtensionTest#testExportPOJO()'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp .internal.HibernateMappingExporterFacadeTest#testStart()'
  - Fix test case 'org.jboss.tools.hibernate.orm.runtime.exp .internal.IPojoClassTest#testGetQualifiedDeclarationName()'