### PR TITLE
JBIDE-28758: Remove interface IPOJOClass and replace it by untyped Object

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
+++ b/orm/plugin/core/org.hibernate.eclipse.jdt.ui/src/org/hibernate/eclipse/jdt/ui/wizards/NewHibernateMappingFileWizard.java
@@ -75,7 +75,6 @@ import org.hibernate.eclipse.nature.HibernateNature;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.IPOJOClass;
 import org.jboss.tools.hibernate.runtime.spi.IService;
 import org.jboss.tools.hibernate.runtime.spi.RuntimeServiceManager;
 
@@ -242,9 +241,6 @@ public class NewHibernateMappingFileWizard extends Wizard implements INewWizard,
 	protected class HibernateMappingExporterWrapper { 
 		protected IJavaProject proj;
 		private IExportPOJODelegate delegate = new IExportPOJODelegate() {	
-			@Override public void exportPojo(Map<Object, Object> map, Object pojoClass) {
-				exportPojo(map, pojoClass, ((IPOJOClass)pojoClass).getQualifiedDeclarationName());
-			}
 			@Override public void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName) {
 				File outputdir4FileOld = target.getOutputDirectory();
 				File outputdir4FileNew = createNewOutputDir4File(fullyQualifiedName, outputdir4FileOld);

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtension.java
@@ -41,7 +41,8 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IExportPOJODelegate.java
@@ -4,10 +4,6 @@ import java.util.Map;
 
 public interface IExportPOJODelegate {
 
-	void exportPojo(Map<Object, Object> map, Object pojoClass);
+	void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName);
 	
-	default void exportPojo(Map<Object, Object> map, Object pojoClass, String fullyQualifiedName) {
-		exportPojo(map, pojoClass);
-	}
-
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_5/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_3_6/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_0/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_4_3/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtension.java
@@ -33,7 +33,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_0/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 	

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_1/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 	void createMetadata(IConfiguration cfg) {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_2/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtension.java
@@ -43,7 +43,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_3/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_4/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtension.java
@@ -36,7 +36,8 @@ extends HibernateMappingExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_5/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,8 @@ public class HibernateMappingExporterExtension extends HibernateMappingExporter 
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 	

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_5_6/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtension.java
@@ -35,7 +35,8 @@ public class HibernateMappingExporterExtension extends HibernateMappingExporter 
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 	

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,8 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,8 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtension.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtension.java
@@ -39,7 +39,8 @@ public class HibernateMappingExporterExtension extends HbmExporter {
 		} else {
 			delegateExporter.exportPojo(
 					(Map<Object, Object>)map, 
-					pojoClass);
+					pojoClass,
+					pojoClass.getQualifiedDeclarationName());
 		}
 	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterExtensionTest.java
@@ -53,7 +53,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -112,7 +112,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/HibernateMappingExporterFacadeTest.java
@@ -84,7 +84,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -124,7 +124,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterExtensionTest.java
@@ -67,7 +67,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -122,7 +122,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/internal/HibernateMappingExporterFacadeTest.java
@@ -87,7 +87,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -127,7 +127,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterExtensionTest.java
@@ -67,7 +67,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -122,7 +122,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/internal/HibernateMappingExporterFacadeTest.java
@@ -88,7 +88,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -128,7 +128,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterExtensionTest.java
@@ -72,7 +72,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -127,7 +127,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/internal/HibernateMappingExporterFacadeTest.java
@@ -90,7 +90,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<Object, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -130,7 +130,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterExtensionTest.java
@@ -72,7 +72,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -127,7 +127,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/internal/HibernateMappingExporterFacadeTest.java
@@ -90,7 +90,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -130,7 +130,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterExtensionTest.java
@@ -79,7 +79,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -134,7 +134,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/internal/HibernateMappingExporterFacadeTest.java
@@ -91,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -131,7 +131,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterExtensionTest.java
@@ -79,7 +79,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -134,7 +134,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/internal/HibernateMappingExporterFacadeTest.java
@@ -91,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -131,7 +131,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterExtensionTest.java
@@ -79,7 +79,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -134,7 +134,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/internal/HibernateMappingExporterFacadeTest.java
@@ -91,7 +91,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -131,7 +131,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterExtensionTest.java
@@ -73,7 +73,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -128,7 +128,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -125,7 +125,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterExtensionTest.java
@@ -73,7 +73,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -128,7 +128,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -125,7 +125,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterExtensionTest.java
@@ -73,7 +73,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -128,7 +128,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -125,7 +125,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterExtensionTest.java
@@ -73,7 +73,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -128,7 +128,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/internal/HibernateMappingExporterFacadeTest.java
@@ -81,7 +81,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -125,7 +125,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterExtensionTest.java
@@ -49,7 +49,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -108,7 +108,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { 
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { 
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/internal/HibernateMappingExporterFacadeTest.java
@@ -80,7 +80,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -120,7 +120,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterExtensionTest.java
@@ -49,7 +49,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -108,7 +108,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/internal/HibernateMappingExporterFacadeTest.java
@@ -80,7 +80,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -120,7 +120,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtensionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterExtensionTest.java
@@ -49,7 +49,7 @@ public class HibernateMappingExporterExtensionTest {
 		delegateField.setAccessible(true);
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) { }
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
 		};
 		assertNull(delegateField.get(hibernateMappingExporterExtension));
 		hibernateMappingExporterExtension.setDelegate(exportPojoDelegate);
@@ -108,7 +108,7 @@ public class HibernateMappingExporterExtensionTest {
 		final HashMap<Object, Object> arguments = new HashMap<Object, Object>();
 		IExportPOJODelegate exportPojoDelegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {
 				arguments.put("map", map);
 				arguments.put("pojoClass", pojoClass);
 			}
@@ -134,7 +134,7 @@ public class HibernateMappingExporterExtensionTest {
 		
 	private POJOClass createPojoClass() {
 		RootClass persistentClass = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		Table rootTable = new Table();
+		Table rootTable = new Table("");
 		rootTable.setName("table");
 		persistentClass.setTable(rootTable);
 		persistentClass.setEntityName("Bar");

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterFacadeTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/internal/HibernateMappingExporterFacadeTest.java
@@ -80,7 +80,7 @@ public class HibernateMappingExporterFacadeTest {
 		assertTrue(dummyDir.exists());
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {
 				assertTrue(dummyDir.delete());
 				Map<String, Object> m = new HashMap<>();
 				for (Object key : map.keySet()) {
@@ -120,7 +120,7 @@ public class HibernateMappingExporterFacadeTest {
 	public void testSetExportPOJODelegate() throws Exception {
 		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
 			@Override
-			public void exportPojo(Map<Object, Object> map, Object pojoClass) {}
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) {}
 		};
 		Field delegateField = HibernateMappingExporterExtension.class.getDeclaredField("delegateExporter");
 		delegateField.setAccessible(true);


### PR DESCRIPTION
  - Use method 'org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate#exportPojo(Map<Object,Object>,Object,String)' in the implementation of method 'org.jboss.tools.hibernate.runtime.v_x_y.internal.HibernateMappingExporterExtension#exportPOJO(Map,POJOClass)'
  - Remove method 'org.jboss.tools.hibernate.runtime.spi.IExportPOJODelegate#exportPojo(Map<Object,Object>,Object)'
  - Adapt the test cases in 'org.jboss.tools.hibernate.runtime.v_x_y.internal.HibernateMappingExporterExtensionTest' and 'org.jboss.tools.hibernate.runtime.v_x_y.internal.HibernateMappingExporterFacadeTest' to account for the above changes