### PR TITLE
JBIDE-28976: Implement and use the generic adapter for IHibernateMappingExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHibernateMappingExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHibernateMappingExporterTest.java
@@ -125,6 +125,14 @@ public class IHibernateMappingExporterTest {
 		assertSame(file, hbmExporterFacade.getOutputDirectory());
 	}
 	
+	@Test
+	public void testSetOutputDirectory() {
+		assertNull(hbmExporterTarget.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
+		File file = new File("testSetOutputDirectory");
+		hbmExporterFacade.setOutputDirectory(file);
+		assertSame(file, hbmExporterTarget.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
+	}
+	
 	private static class TestInvocationHandler implements InvocationHandler {
 		private ArrayList<PersistentClass> entities = new ArrayList<PersistentClass>();
 		private ArrayList<Table> tables = new ArrayList<Table>();


### PR DESCRIPTION
  - Add test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHibernateMappingExporterTest#testSetOutputDirectory()'