### PR TITLE
JBIDE-28976: Implement and use the generic adapter for IHibernateMappingExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHibernateMappingExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHibernateMappingExporterTest.java
@@ -101,22 +101,6 @@ public class IHibernateMappingExporterTest {
 		assertTrue(delegateHasExported);
 	}
 	
-	private static class TestMetadataDescriptor implements MetadataDescriptor {
-		@Override
-		public Metadata createMetadata() {
-			return (Metadata)Proxy.newProxyInstance(
-					getClass().getClassLoader(), 
-					new Class<?>[] { Metadata.class }, 
-					new TestInvocationHandler());
-		}
-		@Override
-		public Properties getProperties() {
-			Properties properties = new Properties();
-			properties.put(Environment.DIALECT, "org.hibernate.dialect.H2Dialect");
-			return properties;
-		}	
-	}
-	
 	@Test
 	public void testGetOutputDirectory() {
 		assertNull(hbmExporterFacade.getOutputDirectory());
@@ -131,6 +115,35 @@ public class IHibernateMappingExporterTest {
 		File file = new File("testSetOutputDirectory");
 		hbmExporterFacade.setOutputDirectory(file);
 		assertSame(file, hbmExporterTarget.getProperties().get(ExporterConstants.DESTINATION_FOLDER));
+	}
+	
+	@Test
+	public void testSetExportPOJODelegate() throws Exception {
+		IExportPOJODelegate delegate = new IExportPOJODelegate() {			
+			@Override
+			public void exportPojo(Map<Object, Object> map, Object pojoClass, String qualifiedDeclarationName) { }
+		};
+		Field delegateField = HbmExporterWrapper.class.getDeclaredField("delegateExporter");
+		delegateField.setAccessible(true);
+		assertNull(delegateField.get(hbmExporterTarget));
+		hbmExporterFacade.setExportPOJODelegate(delegate);
+		assertSame(delegate, delegateField.get(hbmExporterTarget));
+	}
+	
+	private static class TestMetadataDescriptor implements MetadataDescriptor {
+		@Override
+		public Metadata createMetadata() {
+			return (Metadata)Proxy.newProxyInstance(
+					getClass().getClassLoader(), 
+					new Class<?>[] { Metadata.class }, 
+					new TestInvocationHandler());
+		}
+		@Override
+		public Properties getProperties() {
+			Properties properties = new Properties();
+			properties.put(Environment.DIALECT, "org.hibernate.dialect.H2Dialect");
+			return properties;
+		}	
 	}
 	
 	private static class TestInvocationHandler implements InvocationHandler {


### PR DESCRIPTION
  - Add test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHibernateMappingExporterTest#testSetExportPOJODelegate()'