### PR TITLE
JBIDE-28755: Implement and use the generic adapter for IQueryExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IQueryExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IQueryExporterTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -26,7 +27,8 @@ public class IQueryExporterTest {
 	@BeforeEach
 	public void beforeEach() {
 		queryExporterFacade = (IQueryExporter)GenericFacadeFactory.createFacade(IQueryExporter.class, WrapperFactory.createQueryExporterWrapper());
-		queryExporterTarget = (QueryExporter)((IFacade)queryExporterFacade).getTarget();
+		Object queryExporterWrapper = ((IFacade)queryExporterFacade).getTarget();
+		queryExporterTarget = (QueryExporter)((Wrapper)queryExporterWrapper).getWrappedObject();
 	}
 	
 	@Test


### PR DESCRIPTION
  - Adapt the test case setup of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IQueryExporterTest' to take care of a change in the implementation of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory'