### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -30,6 +30,7 @@ import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IPrimaryKey;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
+import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISession;
@@ -275,6 +276,7 @@ public class GenericFacadeFactory {
 					IPrimaryKey.class,
 					IProperty.class,
 					IQuery.class,
+					IQueryExporter.class,
 					IReverseEngineeringStrategy.class,
 					IReverseEngineeringSettings.class,
 					ISession.class,


### PR DESCRIPTION
  - Add class 'org.jboss.tools.hibernate.runtime.spi.IQueryExporter' to the list of classes that can be returned as the result of a generic function in 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory'