### PR TITLE
JBIDE-28756: Implement and use the generic adapter for IExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -113,19 +113,7 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IExporter createExporter(String exporterClassName) {
-		Exporter exporter = (Exporter)Util.getInstance(
-				exporterClassName, 
-				facadeFactory.getClassLoader());
-		if (CfgExporter.class.isAssignableFrom(exporter.getClass())) {
-			exporter.getProperties().put(
-					ExporterConstants.METADATA_DESCRIPTOR, 
-					new DummyMetadataDescriptor());
-		} else {
-			exporter.getProperties().put(
-					ExporterConstants.METADATA_DESCRIPTOR,
-					new ConfigurationMetadataDescriptor((Configuration)((IFacade)newDefaultConfiguration()).getTarget()));
-		}
-		return facadeFactory.createExporter(exporter);
+		return newFacadeFactory.createExporter(exporterClassName);
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -36,6 +36,7 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.export.ArtifactCollector;
+import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.metadata.MetadataDescriptor;
 import org.hibernate.tool.api.reveng.RevengSettings;
@@ -173,21 +174,23 @@ public class ServiceImplTest {
 	public void testCreateExporter() {
 		IExporter exporter = service.createExporter(JavaExporter.class.getName());
 		assertNotNull(exporter);
-		Object target = ((IFacade)exporter).getTarget();
-		assertNotNull(target);
-		assertTrue(target instanceof JavaExporter);
+		Object exporterWrapper = ((IFacade)exporter).getTarget();
+		assertNotNull(exporterWrapper);
+		Exporter wrappedExporter = (Exporter)((Wrapper)exporterWrapper).getWrappedObject();
+		assertTrue(wrappedExporter instanceof JavaExporter);
 		MetadataDescriptor metadataDescriptor = 
-				(MetadataDescriptor)((JavaExporter)target)
+				(MetadataDescriptor)((JavaExporter)wrappedExporter)
 					.getProperties()
 					.get(ExporterConstants.METADATA_DESCRIPTOR);
 		assertNotNull(metadataDescriptor.getProperties()); // Normal metadata descriptor
 		exporter = service.createExporter(CfgExporter.class.getName());
 		assertNotNull(exporter);
-		target = ((IFacade)exporter).getTarget();
-		assertNotNull(target);
-		assertTrue(target instanceof CfgExporter);
+		exporterWrapper = ((IFacade)exporter).getTarget();
+		assertNotNull(exporterWrapper);
+		wrappedExporter = (Exporter)((Wrapper)exporterWrapper).getWrappedObject();
+		assertTrue(wrappedExporter instanceof CfgExporter);
 		metadataDescriptor = 
-				(MetadataDescriptor)((CfgExporter)target)
+				(MetadataDescriptor)((CfgExporter)wrappedExporter)
 					.getProperties()
 					.get(ExporterConstants.METADATA_DESCRIPTOR);
 		assertNull(metadataDescriptor.getProperties()); // Dummy metadata descriptor


### PR DESCRIPTION
  - Refactor method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#createExporter(String)' to delegate to method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createExporter(String)'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImplTest#testCreateExporter()' in accordance with the above change