### PR TITLE
JBIDE-28756: Implement and use the generic adapter for IExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -184,6 +184,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
+	public IExporter createExporter(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+	
+	@Override
 	public ClassLoader getClassLoader() {
 		return FacadeFactoryImpl.class.getClassLoader();
 	}
@@ -203,11 +208,6 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 		return new QueryExporterFacadeImpl(this, target);
 	}
 
-	@Override
-	public IExporter createExporter(Object target) {
-		return new ExporterFacadeImpl(this, target);
-	}
-	
 	@Override
 	public IHQLQueryPlan createHQLQueryPlan(Object target) {
 		// TODO Auto-generated method stub

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -326,6 +326,16 @@ public class FacadeFactoryTest {
 	}
 	
 	@Test
+	public void testCreateExporter() {
+		try {
+			FACADE_FACTORY.createExporter(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());
+		}
+	}
+	
+	@Test
 	public void testCreateGenericExporter() {
 		GenericExporter genericExporter = new GenericExporter();
 		IGenericExporter facade = FACADE_FACTORY.createGenericExporter(genericExporter);
@@ -346,17 +356,6 @@ public class FacadeFactoryTest {
 		IQueryExporter facade = FACADE_FACTORY.createQueryExporter(queryExporter);
 		assertTrue(facade instanceof QueryExporterFacadeImpl);
 		assertSame(queryExporter, ((IFacade)facade).getTarget());		
-	}
-	
-	@Test
-	public void testCreateExporter() {
-		Exporter exporter = (Exporter)Proxy.newProxyInstance(
-				FACADE_FACTORY.getClassLoader(), 
-				new Class[] { Exporter.class }, 
-				new TestInvocationHandler());
-		IExporter facade = FACADE_FACTORY.createExporter(exporter);
-		assertTrue(facade instanceof ExporterFacadeImpl);
-		assertSame(exporter, ((IFacade)facade).getTarget());		
 	}
 	
 	@Test


### PR DESCRIPTION
  - Disable method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createExporter(Object)' by making it throw a runtime exception
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryTest#testCreateExporter()' accordingly