### PR TITLE
JBIDE-28774: Implement and use the generic adapter for IGenericExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -189,13 +189,13 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 	
 	@Override
-	public ClassLoader getClassLoader() {
-		return FacadeFactoryImpl.class.getClassLoader();
+	public IGenericExporter createGenericExporter(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 
 	@Override
-	public IGenericExporter createGenericExporter(Object target) {
-		return new GenericExporterFacadeImpl(this, target);
+	public ClassLoader getClassLoader() {
+		return FacadeFactoryImpl.class.getClassLoader();
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -12,15 +12,11 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Column;
-import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
-import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.export.ddl.DdlExporter;
 import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.spi.IExporter;
-import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
@@ -337,9 +333,12 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateGenericExporter() {
-		GenericExporter genericExporter = new GenericExporter();
-		IGenericExporter facade = FACADE_FACTORY.createGenericExporter(genericExporter);
-		assertSame(genericExporter, ((IFacade)facade).getTarget());		
+		try {
+			FACADE_FACTORY.createGenericExporter(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
  - Disable method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createGenericExporter(Object' by making it throw a runtime exception
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryTest#testCreateGenericExporter()' accordingly