### PR TITLE
JBIDE-28755: Implement and use the generic adapter for IQueryExporter in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -199,13 +199,13 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 	}
 
 	@Override
-	public ClassLoader getClassLoader() {
-		return FacadeFactoryImpl.class.getClassLoader();
+	public IQueryExporter createQueryExporter(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 
 	@Override
-	public IQueryExporter createQueryExporter(Object target) {
-		return new QueryExporterFacadeImpl(this, target);
+	public ClassLoader getClassLoader() {
+		return FacadeFactoryImpl.class.getClassLoader();
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -13,12 +13,10 @@ import java.lang.reflect.Proxy;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Column;
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
-import org.hibernate.tool.internal.export.query.QueryExporter;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
-import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Query;
@@ -351,10 +349,12 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateQueryExporter() {
-		QueryExporter queryExporter = new QueryExporter();
-		IQueryExporter facade = FACADE_FACTORY.createQueryExporter(queryExporter);
-		assertTrue(facade instanceof QueryExporterFacadeImpl);
-		assertSame(queryExporter, ((IFacade)facade).getTarget());		
+		try {
+			FACADE_FACTORY.createQueryExporter(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
  - Disable method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createQueryExporter(Object)' by making it throw a runtime exception
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryTest#testCreateQueryExporter()' accordingly