### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IGenericExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IGenericExporterTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.common.GenericExporter;
+import org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapperFactory;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
-import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
@@ -23,7 +23,7 @@ public class IGenericExporterTest {
 	public void beforeEach() {
 		genericExporterFacade = (IGenericExporter)GenericFacadeFactory.createFacade(
 				IGenericExporter.class, 
-				WrapperFactory.createGenericExporterWrapper());
+				GenericExporterWrapperFactory.create(new GenericExporter()));
 		Object genericExporterWrapper = ((IFacade)genericExporterFacade).getTarget();
 		genericExporterTarget = (GenericExporter)((Wrapper)genericExporterWrapper).getWrappedObject();
 	}


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.GenericExporterWrapperFactory#create(GenericExporter)' in place of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createGenericExporterWrapper()' in test setup of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IGenericExporterTest'