### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IQueryExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IQueryExporterTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.internal.export.query.QueryExporter;
+import org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
-import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IQueryExporter;
@@ -26,7 +26,9 @@ public class IQueryExporterTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		queryExporterFacade = (IQueryExporter)GenericFacadeFactory.createFacade(IQueryExporter.class, WrapperFactory.createQueryExporterWrapper());
+		queryExporterFacade = (IQueryExporter)GenericFacadeFactory.createFacade(
+				IQueryExporter.class, 
+				QueryExporterWrapperFactory.create(new QueryExporter()));
 		Object queryExporterWrapper = ((IFacade)queryExporterFacade).getTarget();
 		queryExporterTarget = (QueryExporter)((Wrapper)queryExporterWrapper).getWrappedObject();
 	}


### PR DESCRIPTION
  - Use 'org.hibernate.tool.orm.jbt.wrp.QueryExporterWrapperFactory#create(QueryExporter)' instead of 'org.hibernate.tool.orm.jbt.wrp.WrapperFactory#createQueryExporterWrapper()' in test setup of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IQueryExporterTest'