### PR TITLE
JBIDE-29026: Update hibernate tools dependency of org.jboss.tools.hibernate.runtime.v_6_2 to version 6.2.4.Final

### DIFF
--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -390,4 +390,10 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
 </feature>


### PR DESCRIPTION
  - Add missing dependency on plugin 'org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1'