### PR TITLE
JBIDE-28759: Implement and use the generic adapter for IHQLCodeAssist in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/core/org.hibernate.eclipse/src/org/hibernate/eclipse/console/common/HQLCompletionHandler.java
+++ b/orm/plugin/core/org.hibernate.eclipse/src/org/hibernate/eclipse/console/common/HQLCompletionHandler.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.swt.graphics.Image;
 import org.hibernate.console.ImageConstants;
-import org.hibernate.eclipse.console.common.CompletionProposal;
 import org.hibernate.eclipse.console.utils.EclipseImages;
 import org.hibernate.eclipse.console.workbench.HibernateWorkbenchHelper;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionHandler;

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IHQLCompletionHandler.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IHQLCompletionHandler.java
@@ -1,9 +1,26 @@
 package org.jboss.tools.hibernate.runtime.spi;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 public interface IHQLCompletionHandler {
 
 	boolean accept(IHQLCompletionProposal proposal);
 	void completionFailure(String errorMessage);
-
+	
+	default boolean accept(Object proposal) {
+		IHQLCompletionProposal newProposal = (IHQLCompletionProposal)Proxy.newProxyInstance(
+				IHQLCompletionHandler.class.getClassLoader(), 
+				new Class[] { IHQLCompletionProposal.class }, 
+				new InvocationHandler() {					
+					@Override
+					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						return proposal.getClass().getMethod(method.getName(), new Class[] {})
+								.invoke(proposal);
+					}
+				});
+		return accept(newProposal);
+	}
+	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCompletionHandlerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCompletionHandlerTest.java
@@ -1,0 +1,111 @@
+package org.jboss.tools.hibernate.orm.runtime.exp.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionHandler;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
+import org.jboss.tools.hibernate.runtime.spi.IProperty;
+import org.junit.jupiter.api.Test;
+
+public class IHQLCompletionHandlerTest {
+	
+	private IHQLCompletionHandler hqlCompletionHandler = new TestHqlCompletionHandler();
+	private TestHqlCompletionInfo hqlCompletionInfo = new TestHqlCompletionInfo();
+	
+	@Test
+	public void testAccept() {
+		Object completionProposal = new TestHqlCompletionProposal();
+		assertNull(hqlCompletionInfo.completion);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.replaceStart);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.replaceEnd);
+		assertNull(hqlCompletionInfo.simpleName);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.completionKind);
+		assertNull(hqlCompletionInfo.entityName);
+		assertNull(hqlCompletionInfo.shortEntityName);
+		assertNull(hqlCompletionInfo.property);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.aliasRefKind);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.entityNameKind);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.propertyKind);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.keywordKind);
+		assertEquals(Integer.MIN_VALUE, hqlCompletionInfo.functionKind);
+		hqlCompletionHandler.accept(completionProposal);
+		assertEquals("foobar", hqlCompletionInfo.completion);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.replaceStart);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.replaceEnd);
+		assertEquals("foobar", hqlCompletionInfo.simpleName);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.completionKind);
+		assertEquals("foobar", hqlCompletionInfo.entityName);
+		assertEquals("foobar", hqlCompletionInfo.shortEntityName);
+		assertNotNull(hqlCompletionInfo.property);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.aliasRefKind);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.entityNameKind);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.propertyKind);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.keywordKind);
+		assertEquals(Integer.MAX_VALUE, hqlCompletionInfo.functionKind);
+	}
+	
+	class TestHqlCompletionInfo {
+		String completion = null;
+		int replaceStart = Integer.MIN_VALUE;
+		int replaceEnd = Integer.MIN_VALUE;
+		String simpleName = null;
+		int completionKind = Integer.MIN_VALUE;
+		String entityName = null; 
+		String shortEntityName = null; 
+		IProperty property = null; 
+		
+		int aliasRefKind = Integer.MIN_VALUE;
+		int entityNameKind = Integer.MIN_VALUE;
+		int propertyKind = Integer.MIN_VALUE;
+		int keywordKind = Integer.MIN_VALUE;
+		int functionKind = Integer.MIN_VALUE;		
+	}
+	
+	class TestHqlCompletionHandler implements IHQLCompletionHandler {
+		
+		@Override
+		public boolean accept(IHQLCompletionProposal proposal) {
+			hqlCompletionInfo.completion = proposal.getCompletion();
+			hqlCompletionInfo.replaceStart = proposal.getReplaceStart();
+			hqlCompletionInfo.replaceEnd = proposal.getReplaceEnd();
+			hqlCompletionInfo.simpleName = proposal.getSimpleName();
+			hqlCompletionInfo.completionKind = proposal.getCompletionKind();
+			hqlCompletionInfo.entityName = proposal.getEntityName();
+			hqlCompletionInfo.shortEntityName = proposal.getShortEntityName();
+			hqlCompletionInfo.property = proposal.getProperty();
+			hqlCompletionInfo.aliasRefKind = proposal.aliasRefKind();
+			hqlCompletionInfo.entityNameKind = proposal.entityNameKind();
+			hqlCompletionInfo.propertyKind = proposal.propertyKind();
+			hqlCompletionInfo.keywordKind = proposal.keywordKind();
+			hqlCompletionInfo.functionKind = proposal.functionKind();
+			return false;
+		}
+
+		@Override
+		public void completionFailure(String errorMessage) {}
+		
+	}
+	
+	public class TestHqlCompletionProposal {
+		public String getCompletion() { return "foobar"; }
+		public int getReplaceStart() { return Integer.MAX_VALUE; }
+		public int getReplaceEnd() { return Integer.MAX_VALUE; }
+		public String getSimpleName() { return "foobar"; }
+		public int getCompletionKind() { return Integer.MAX_VALUE; }
+		public String getEntityName() { return "foobar"; }
+		public String getShortEntityName() { return "foobar"; }
+		public IProperty getProperty() { return NewFacadeFactory.INSTANCE.createProperty(); }
+		
+		public int aliasRefKind() { return Integer.MAX_VALUE; }
+		public int entityNameKind() { return Integer.MAX_VALUE; }
+		public int propertyKind() { return Integer.MAX_VALUE; }
+		public int keywordKind() { return Integer.MAX_VALUE; }
+		public int functionKind() { return Integer.MAX_VALUE; }
+	}
+	
+	
+
+}


### PR DESCRIPTION
  - Remove unneeded import in class 'org.hibernate.eclipse.console.common.HQLCompletionHandler'
  - Add new test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHQLCompletionHandlerTest'
  - Add new default method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHQLCompletionHandler#accept(Object)'