### PR TITLE
JBIDE-28759: Implement and use the generic adapter for IHQLCodeAssist in the experimental Hibernate runtime

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCodeAssistTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCodeAssistTest.java
@@ -1,15 +1,22 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.hibernate.cfg.AvailableSettings;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hibernate.tool.ide.completion.HQLCodeAssist;
-import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionHandler;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +28,7 @@ public class IHQLCodeAssistTest {
 	@BeforeEach
 	public void beforeEach() {
 		NativeConfiguration configuration = new NativeConfiguration();
-		configuration.setProperty(AvailableSettings.DIALECT, MockDialect.class.getName());
+		configuration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
 		hqlCodeAssistFacade = (IHQLCodeAssist)GenericFacadeFactory.createFacade(
 				IHQLCodeAssist.class, 
 				WrapperFactory.createHqlCodeAssistWrapper(configuration));
@@ -33,5 +40,37 @@ public class IHQLCodeAssistTest {
 		assertNotNull(hqlCodeAssistFacade);
 		assertNotNull(hqlCodeAssistTarget);
 	}
+	
+	@Test
+	public void testCodeComplete() throws Exception {
+		TestHQLCompletionHandler completionHandler = new TestHQLCompletionHandler();
+		// First test the 'accept' method of the handler
+		assertTrue(completionHandler.acceptedProposals.isEmpty());
+		hqlCodeAssistFacade.codeComplete("foo", 0, completionHandler);
+		assertFalse(completionHandler.acceptedProposals.isEmpty());
+		// Now force the 'metadata' field to null to test the 'completionFailure' method of the handler
+		Field metadataField = HQLCodeAssist.class.getDeclaredField("metadata");
+		metadataField.setAccessible(true);
+		metadataField.set(hqlCodeAssistTarget, null);
+		assertNull(completionHandler.errorMessage);
+		hqlCodeAssistFacade.codeComplete("FROM ", 5, completionHandler);
+		assertNotNull(completionHandler.errorMessage);
+		
+	}
 
+	public class TestHQLCompletionHandler implements IHQLCompletionHandler {
+		
+		List<IHQLCompletionProposal> acceptedProposals = new ArrayList<>();
+		String errorMessage = null;
+		
+		@Override
+		public boolean accept(IHQLCompletionProposal proposal) {
+			acceptedProposals.add(proposal);
+			return true;
+		}
+		@Override
+		public void completionFailure(String errorMessage) {
+			this.errorMessage = errorMessage;
+		}		
+	}
 }


### PR DESCRIPTION
  - Add new test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHQLCodeAssistTest#testCodeComplete()'