### PR TITLE
JBIDE-28759: Implement and use the generic adapter for IHQLCodeAssist in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -100,8 +100,7 @@ public class ServiceImpl extends AbstractService {
 	public IHQLCodeAssist newHQLCodeAssist(IConfiguration hcfg) {
 		IHQLCodeAssist result = null;
 		if (hcfg instanceof IConfiguration) {
-			result = facadeFactory.createHQLCodeAssist(
-					new HQLCodeAssist(MetadataHelper.getMetadata((Configuration)((IFacade)hcfg).getTarget())));
+			result = newFacadeFactory.createHQLCodeAssist(hcfg);
 		}
 		return result;
 	}


### PR DESCRIPTION
  - Implement method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newHQLCodeAssist(IConfiguration)' by delegating to 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createHQLCodeAssist(IConfiguration)'