### PR TITLE
JBIDE-28759: Implement and use the generic adapter for IHQLCodeAssist in the experimental Hibernate runtime

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryImpl.java
@@ -12,6 +12,7 @@ import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IForeignKey;
 import org.jboss.tools.hibernate.runtime.spi.IGenericExporter;
+import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHQLQueryPlan;
 import org.jboss.tools.hibernate.runtime.spi.IHbm2DDLExporter;
@@ -200,6 +201,11 @@ public class FacadeFactoryImpl  extends AbstractFacadeFactory {
 
 	@Override
 	public IQueryExporter createQueryExporter(Object target) {
+		throw new RuntimeException("Should use class 'NewFacadeFactory'");
+	}
+
+	@Override
+	public IHQLCodeAssist createHQLCodeAssist(Object target) {
 		throw new RuntimeException("Should use class 'NewFacadeFactory'");
 	}
 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/FacadeFactoryTest.java
@@ -12,10 +12,8 @@ import java.lang.reflect.Proxy;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.Column;
-import org.hibernate.tool.ide.completion.HQLCodeAssist;
 import org.hibernate.tool.internal.reveng.strategy.OverrideRepository;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IQuery;
 import org.junit.jupiter.api.Test;
 
@@ -359,9 +357,12 @@ public class FacadeFactoryTest {
 	
 	@Test
 	public void testCreateHQLCodeAssist() {
-		HQLCodeAssist hqlCodeAssist = new HQLCodeAssist(null);
-		IHQLCodeAssist facade = FACADE_FACTORY.createHQLCodeAssist(hqlCodeAssist);
-		assertSame(hqlCodeAssist, ((IFacade)facade).getTarget());		
+		try {
+			FACADE_FACTORY.createHQLCodeAssist(null);
+			fail();
+		} catch (Throwable t) {
+			assertEquals("Should use class 'NewFacadeFactory'", t.getMessage());
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
  - Disable method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryImpl#createHQLCodeAssist(Object)' by making it throw a runtime exception
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.FacadeFactoryTest#testCreateHQLCodeAssist()' accordingly