### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -232,7 +232,7 @@ public class IPersistentClassTest {
 		propertyClosureIterator = specialRootClassFacade.getPropertyClosureIterator();
 		assertTrue(propertyClosureIterator.hasNext());
 		propertyFacade = propertyClosureIterator.next();
-		assertSame(propertyTarget, ((IFacade)propertyFacade).getTarget());
+		assertSame(propertyTarget, ((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject());
 	}
 	
 	@Test
@@ -275,7 +275,7 @@ public class IPersistentClassTest {
 		propertyIterator = specialRootClassFacade.getPropertyIterator();
 		assertTrue(propertyIterator.hasNext());
 		propertyFacade = propertyIterator.next();
-		assertSame(propertyTarget, ((IFacade)propertyFacade).getTarget());
+		assertSame(propertyTarget, ((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -544,7 +544,9 @@ public class ServiceImplTest {
 		assertNotNull(target);
 		assertTrue(target instanceof Wrapper);
 		assertTrue(((Wrapper)target).getWrappedObject() instanceof SpecialRootClass);
-		assertEquals(property, specialRootClass.getProperty());
+		assertEquals(
+				((Wrapper)((IFacade)property).getTarget()).getWrappedObject(), 
+				((Wrapper)((IFacade)specialRootClass.getProperty()).getTarget()).getWrappedObject());
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -237,8 +237,8 @@ public class NewFacadeFactoryTest {
 		Object specialRootClassTarget = ((PersistentClassWrapper)specialRootClassWrapper).getWrappedObject();
 		assertTrue(specialRootClassTarget instanceof SpecialRootClass);
 		assertSame(
-				((SpecialRootClass)specialRootClassTarget).getProperty(), 
-				((IFacade)propertyFacade).getTarget());
+				((Wrapper)((SpecialRootClass)specialRootClassTarget).getProperty()).getWrappedObject(), 
+				((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject());
 	}
 	
 	@Test


### PR DESCRIPTION
  - Adapt some tests because the jbt bridge now wraps the returned property instances 
    * IPersistentClassTest#testGetPropertyIterator() 
    * IPersistentClassTest#testGetPropertyClosureIterator() 
    * ServiceImplTest#testNewSpecialRootClass() 
    * NewFacadeFactoryTest#testCreateSpecialRootClass()