### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IHQLCompletionHandler.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.spi/src/org/jboss/tools/hibernate/runtime/spi/IHQLCompletionHandler.java
@@ -3,6 +3,8 @@ package org.jboss.tools.hibernate.runtime.spi;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.List;
 
 public interface IHQLCompletionHandler {
 
@@ -16,11 +18,46 @@ public interface IHQLCompletionHandler {
 				new InvocationHandler() {					
 					@Override
 					public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-						return proposal.getClass().getMethod(method.getName(), new Class[] {})
+						Object result = proposal.getClass().getMethod(method.getName(), new Class[] {})
 								.invoke(proposal);
+						return wrapIfNeeded(method, result);
 					}
 				});
 		return accept(newProposal);
+	}
+	
+	default Object wrapIfNeeded(Method calledMethod, Object target) {
+		Class<?> returnClass = calledMethod.getReturnType();
+		if (getFacadeClasses().contains(calledMethod.getReturnType())) {
+			return Proxy.newProxyInstance(
+					IHQLCompletionProposal.class.getClassLoader(), 
+					new Class[] { returnClass }, 
+					new InvocationHandler() {						
+						@Override
+						public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+							try {
+								Method methodToCall = target.getClass().getMethod(method.getName(), new Class[] {});
+								if (methodToCall != null) {
+									return wrapIfNeeded(method, methodToCall.invoke(target));
+								}
+							} catch (NoSuchMethodException e) {
+								return bestGuessResult(method);
+							}
+							return null;
+						}
+					});
+		} else {
+			return target;
+		}
+	}
+	
+	default List<Class<?>> getFacadeClasses() {
+		return Arrays.asList(IProperty.class, IPersistentClass.class, IValue.class );
+	}
+	
+	default Object bestGuessResult(Method m) {
+		if (boolean.class.isAssignableFrom(m.getReturnType())) return false;
+		return null;
 	}
 	
 }


### PR DESCRIPTION
  - Add default logic to interface 'org.jboss.tools.hibernate.runtime.spi.IHQLCompletionHandler' to wrap possible unwrapped results in a facade