### PR TITLE
JBIDE-28628: Create an experimental Hibernate runtime that will use the new Hibernate Tools ORM to JBoss Tools adapter layer

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.common,
  org.jboss.tools.hibernate.runtime.spi
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.2.5.Final.jar,
- lib/hibernate-core-6.2.5.Final.jar,
- lib/hibernate-tools-orm-6.2.6-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.2.6-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.2.6-SNAPSHOT.jar
+ lib/hibernate-ant-6.2.6.Final.jar,
+ lib/hibernate-core-6.2.6.Final.jar,
+ lib/hibernate-tools-orm-6.2.6.Final.jar,
+ lib/hibernate-tools-orm-jbt-6.2.6.Final.jar,
+ lib/hibernate-tools-utils-6.2.6.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.2.5.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.2.6-SNAPSHOT</hibernate.tools.version>
+		<hibernate.orm.version>6.2.6.Final</hibernate.orm.version>
+		<hibernate.tools.version>6.2.6.Final</hibernate.tools.version>
 	</properties>
 
 	<build>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -8,12 +8,12 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.2.5.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.6.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.2.6-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.2.6.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 }


### PR DESCRIPTION
  - Update dependency on Hibernate ORM to 6.2.6.Final
  - Update dependency on Hibernate Tools to 6.2.6.final