### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Hibernate Runtime Common Utilities
+Bundle-Vendor: Red Hat
+Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.common;singleton:=true
+Bundle-Version: 5.4.22.qualifier
+Bundle-Localization: plugin
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/build.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = .,\
+               META-INF/

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion> 
+
+	<parent>
+		<groupId>org.jboss.tools.hibernatetools.orm.plugin</groupId>
+		<artifactId>runtime</artifactId>
+		<version>5.4.22-SNAPSHOT</version>
+	</parent>
+	
+	<groupId>org.jboss.tools.hibernatetools.orm.plugin.runtime</groupId>
+	
+	<artifactId>org.jboss.tools.hibernate.orm.runtime.common</artifactId> 
+	
+	<packaging>eclipse-plugin</packaging>
+
+</project>


### PR DESCRIPTION
  - Initial creation of plugin 'org.jboss.tools.hibernate.orm.runtime.common' that will hold the generic functionality