### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/pom.xml
+++ b/orm/plugin/runtime/pom.xml
@@ -13,6 +13,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<packaging>pom</packaging>
 	
 	<modules>
+		<module>org.jboss.tools.hibernate.orm.runtime.common</module>
 		<module>org.jboss.tools.hibernate.runtime.common</module>
 		<module>org.jboss.tools.hibernate.runtime.spi</module>
 		<module>org.jboss.tools.hibernate.runtime.v_3_5</module>


### PR DESCRIPTION
  - Add plugin 'org.jboss.tools.hibernate.orm.runtime.common' to the main build