### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/features/org.jboss.tools.hibernate.orm.runtime.feature/pom.xml
+++ b/features/org.jboss.tools.hibernate.orm.runtime.feature/pom.xml
@@ -7,7 +7,7 @@
 		<artifactId>features</artifactId>
 		<version>5.4.22-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.hibernatesearchtools.features</groupId>
+	<groupId>org.jboss.tools.hibernatetools.features</groupId>
 	<artifactId>org.jboss.tools.hibernate.orm.runtime.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/site/category.xml
+++ b/site/category.xml
@@ -9,6 +9,7 @@
    <feature id="org.hibernate.eclipse.feature.source"><category name="jbosstools-hibernate"/></feature>
    <feature id="org.hibernate.eclipse.test.feature.source"><category name="jbosstools-hibernate"/></feature>
    <feature id="org.jboss.tools.hibernate.search.test.feature"><category name="jbosstools-hibernate"/></feature>
+   <feature id="org.jboss.tools.hibernate.orm.runtime.feature"><category name="jbosstools-hibernate"/></feature>
    <category-def name="jbosstools-hibernate" label="JBoss Tools hibernatetools Nightly Build Update Site">
       <description>
          JBoss Tools hibernatetools Nightly Build Update Site: contains all features in this build.


### PR DESCRIPTION
  - Fix typo in 'pom.xml' of 'org.jboss.tools.hibernate.orm.runtime.feature' feature
  - Add feature 'org.jboss.tools.hibernate.orm.runtime.feature' to the 'jbosstools-hibernate' site