### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -20,6 +20,10 @@
       %license
    </license>
 
+   <includes
+         id="org.jboss.tools.hibernate.orm.runtime.feature"
+         version="0.0.0"/>
+
    <requires>
       <import plugin="org.eclipse.core.runtime" version="0.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jdt.ui" version="0.0.0" match="greaterOrEqual"/>


### PR DESCRIPTION
  - include the feature 'org.jboss.tools.hibernate.orm.runtime.feature' into 'org.hibernate.eclipse.feature'