### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.common;singleton:=tru
 Bundle-Version: 5.4.22.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Export-Package: org.jboss.tools.hibernate.orm.runtime.common

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.libs.jaxb.v_3_0,
  org.jboss.tools.hibernate.libs.jboss-logging.v_3_4,
  org.jboss.tools.hibernate.runtime.common,
- org.jboss.tools.hibernate.runtime.spi
+ org.jboss.tools.hibernate.runtime.spi,
+ org.jboss.tools.hibernate.orm.runtime.common
 Bundle-ClassPath: .,
  lib/hibernate-ant-6.2.6.Final.jar,
  lib/hibernate-core-6.2.6.Final.jar,

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
@@ -3,7 +3,7 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.tools.hibernate.runtime.common.IFacade;
+import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 
 public interface IDatabaseReader extends IFacade {

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.jboss.tools.hibernate.runtime.spi;bundle-version="5.0.0",
  org.jboss.tools.usage;bundle-version="2.1.0",
- org.jboss.tools.hibernate.orm.runtime.common
+ org.jboss.tools.hibernate.orm.runtime.common;visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.hibernate.runtime.common
 Bundle-Activator: org.jboss.tools.hibernate.runtime.common.internal.HibernateRuntimeCommon

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacade.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.common/src/org/jboss/tools/hibernate/runtime/common/IFacade.java
@@ -1,7 +1,3 @@
 package org.jboss.tools.hibernate.runtime.common;
 
-public interface IFacade {
-	
-	Object getTarget();
-
-}
+public interface IFacade extends org.jboss.tools.hibernate.orm.runtime.common.IFacade {}


### PR DESCRIPTION
  - Export package 'org.jboss.tools.hibernate.orm.runtime.common' from plugin 'org.jboss.tools.hibernate.orm.runtime.common'
  - Add dependency on plugin 'org.jboss.tools.hibernate.orm.runtime.common' to 'org.jboss.tools.hibernate.orm.runtime.exp'
  - Add dependency on plugin 'org.jboss.tools.hibernate.orm.runtime.common' to 'org.jboss.tools.hibernate.runtime.common' and re-export this dependency for (temporary) use in the legacy runtime and core plugins
  - Refactor the interface 'org.jboss.tools.hibernate.runtime.common.IFacade' as an (empty) extension of 'org.jboss.tools.hibernate.orm.runtime.common.IFacade'