### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IDatabaseReader.java
@@ -3,10 +3,9 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 
-public interface IDatabaseReader extends IFacade {
+public interface IDatabaseReader {
 	
 	Map<String, List<ITable>> collectDatabaseTables();
 


### PR DESCRIPTION
  - Interface 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IDatabaseReader' no longer implements 'org.jboss.tools.hibernate.orm.runtime.common.IFacade'