### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Bundle-Version: 5.4.22.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jboss.tools.hibernate.orm.runtime.common
+Require-Bundle: org.jboss.tools.hibernate.runtime.spi


### PR DESCRIPTION
  - Add dependency on plugin 'org.jboss.tools.hibernate.runtime.spi' to 'org.jboss.tools.hibernate.orm.runtime.common'