### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -127,7 +127,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public INamingStrategy newNamingStrategy(String strategyClassName) {
-		return newFacadeFactory.createNamingStrategy(strategyClassName);
+		return (INamingStrategy)GenericFacadeFactory.createFacade(
+				INamingStrategy.class, 
+				WrapperFactory.createNamingStrategyWrapper(strategyClassName));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -48,12 +48,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("Use 'NewFacadeFactory#createNamingStrategy(String)");
 	}
 	
-	public INamingStrategy createNamingStrategy(String namingStrategyClassName) {
-		return (INamingStrategy)GenericFacadeFactory.createFacade(
-				INamingStrategy.class, 
-				WrapperFactory.createNamingStrategyWrapper(namingStrategyClassName));
-	}
-	
 	@Override
 	public IOverrideRepository createOverrideRepository(Object target) {
 		throw new RuntimeException("Use 'NewFacadeFactory#createOverrideRepository()");		

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
@@ -40,6 +40,8 @@ import org.hibernate.tool.orm.jbt.util.MockConnectionProvider;
 import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
@@ -266,8 +268,9 @@ public class IConfigurationTest {
 	
 	@Test
 	public void testSetNamingStrategy() throws Exception {
-		INamingStrategy namingStrategyFacade = 
-				NEW_FACADE_FACTORY.createNamingStrategy(DefaultNamingStrategy.class.getName());
+		INamingStrategy namingStrategyFacade = (INamingStrategy)GenericFacadeFactory.createFacade(
+				INamingStrategy.class, 
+				WrapperFactory.createNamingStrategyWrapper(DefaultNamingStrategy.class.getName()));
 		// For native configuration
 		Field namingStrategyField = nativeConfigurationTarget.getClass().getDeclaredField("namingStrategy");
 		namingStrategyField.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/INamingStrategyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/INamingStrategyTest.java
@@ -3,6 +3,8 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hibernate.cfg.DefaultNamingStrategy;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +18,9 @@ public class INamingStrategyTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		namingStrategyFacade = FACADE_FACTORY.createNamingStrategy(TestNamingStrategy.class.getName());
+		namingStrategyFacade = (INamingStrategy)GenericFacadeFactory.createFacade(
+				INamingStrategy.class, 
+				WrapperFactory.createNamingStrategyWrapper(TestNamingStrategy.class.getName()));
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -81,14 +81,6 @@ public class NewFacadeFactoryTest {
 	}
 	
 	@Test
-	public void testCreateNamingStrategy() {
-		INamingStrategy facade = facadeFactory.createNamingStrategy(DefaultNamingStrategy.class.getName());
-		Object target = ((IFacade)facade).getTarget();
-		assertNotNull(target);
-		assertTrue(NamingStrategy.class.isAssignableFrom(target.getClass()));
-	}
-	
-	@Test
 	public void testCreateOverrideRepository() {
 		IOverrideRepository facade = facadeFactory.createOverrideRepository();
 		Object target = ((IFacade)facade).getTarget();


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createNamingStrategy(String)' 
      * in method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newNamingStrategy(String)' 
      * in test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.INamingStrategyTest#beforeEach()' 
      * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IConfigurationTest#testSetNamingStrategy()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateNamingStrategy()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createNamingStrategy(String)'