### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -153,7 +153,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IReverseEngineeringStrategy newDefaultReverseEngineeringStrategy() {
-		return newFacadeFactory.createReverseEngineeringStrategy();
+		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				WrapperFactory.createRevengStrategyWrapper());
 	}
 	
 	@Override
@@ -173,9 +175,9 @@ public class ServiceImpl extends AbstractService {
 	public IReverseEngineeringStrategy newReverseEngineeringStrategy(
 			String strategyName,
 			IReverseEngineeringStrategy delegate) {
-		return newFacadeFactory.createReverseEngineeringStrategy(
-				strategyName, 
-				((IFacade)delegate).getTarget());
+		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				WrapperFactory.createRevengStrategyWrapper(strategyName, delegate));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -58,12 +58,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
 	}
 	
-	public IReverseEngineeringStrategy createReverseEngineeringStrategy(Object...objects) {
-		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
-				IReverseEngineeringStrategy.class, 
-				WrapperFactory.createRevengStrategyWrapper(objects));				
-	}
-	
 	public IReverseEngineeringSettings createReverseEngineeringSettings(Object revengStrategy) {
 		return (IReverseEngineeringSettings)GenericFacadeFactory.createFacade(
 				IReverseEngineeringSettings.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
@@ -655,7 +655,9 @@ public class IConfigurationTest {
 	@Test
 	public void testSetReverseEngineeringStrategy() {
 		IReverseEngineeringStrategy strategyFacade = 
-				NEW_FACADE_FACTORY.createReverseEngineeringStrategy();
+				(IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+						IReverseEngineeringStrategy.class, 
+						WrapperFactory.createRevengStrategyWrapper());
 		RevengStrategy reverseEngineeringStrategy = (RevengStrategy)((IFacade)strategyFacade).getTarget();
 		// For native configuration 
 		try {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IOverrideRepositoryTest.java
@@ -67,7 +67,9 @@ public class IOverrideRepositoryTest {
 	
 	@Test
 	public void testGetReverseEngineeringStrategy() throws Exception {
-		IReverseEngineeringStrategy resFacade = FACADE_FACTORY.createReverseEngineeringStrategy();
+		IReverseEngineeringStrategy resFacade = (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				WrapperFactory.createRevengStrategyWrapper());
 		Object res = ((IFacade)resFacade).getTarget();
 		IReverseEngineeringStrategy result = overrideRepositoryFacade.getReverseEngineeringStrategy(resFacade);
 		DelegatingStrategy resultTarget = 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hibernate.tool.api.reveng.RevengSettings;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
@@ -22,7 +24,9 @@ public class IReverseEngineeringSettingsTest {
 	@BeforeEach
 	public void beforeEach() {
 		IReverseEngineeringStrategy revengStrategyFacade = 
-				FACADE_FACTORY.createReverseEngineeringStrategy();
+				(IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+						IReverseEngineeringStrategy.class, 
+						WrapperFactory.createRevengStrategyWrapper());
 		revengSettingsFacade = FACADE_FACTORY.createReverseEngineeringSettings(
 				((IFacade)revengStrategyFacade).getTarget());
 		revengSettingsTarget = (RevengSettings)((IFacade)revengSettingsFacade).getTarget();	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.lang.reflect.Field;
 
 import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
@@ -18,7 +20,9 @@ public class IReverseEngineeringStrategyTest {
 	
 	@Test
 	public void testSetSettings() throws Exception {
-		IReverseEngineeringStrategy revengStrategyFacade = FACADE_FACTORY.createReverseEngineeringStrategy();
+		IReverseEngineeringStrategy revengStrategyFacade = (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				WrapperFactory.createRevengStrategyWrapper());
 		Object revengStrategyTarget = ((IFacade)revengStrategyFacade).getTarget();
 		IReverseEngineeringSettings revengSettingsFacade = 
 				FACADE_FACTORY.createReverseEngineeringSettings(revengStrategyTarget);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.lang.reflect.Field;
 
 import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Bag;
@@ -31,7 +30,6 @@ import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.GenericExporter;
-import org.hibernate.tool.internal.reveng.strategy.DefaultStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
 import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
@@ -46,6 +44,7 @@ import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper;
 import org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
@@ -75,28 +74,11 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 	
-	@Test
-	public void testCreateRevengStrategy() throws Exception {
-		IReverseEngineeringStrategy facade = facadeFactory.createReverseEngineeringStrategy();
-		Object firstTarget = ((IFacade)facade).getTarget();
-		assertNotNull(firstTarget);
-		assertTrue(firstTarget instanceof DefaultStrategy);
-		facade = facadeFactory.createReverseEngineeringStrategy(TestRevengStrategy.class.getName(), firstTarget);
-		Object secondTarget = ((IFacade)facade).getTarget();
-		assertNotNull(secondTarget);
-		assertTrue(secondTarget instanceof DelegatingStrategy);
-		Field delegateField = DelegatingStrategy.class.getDeclaredField("delegate");
-		delegateField.setAccessible(true);
-		assertSame(delegateField.get(secondTarget), firstTarget);
-		facade = facadeFactory.createReverseEngineeringStrategy(DefaultStrategy.class.getName(), secondTarget);
-		Object thirdTarget = ((IFacade)facade).getTarget();
-		assertNotNull(thirdTarget);
-		assertTrue(thirdTarget instanceof DefaultStrategy);
-	}
-	
 	@Test 
 	public void testCreateRevengSettings() {
-		IReverseEngineeringStrategy strategyFacade = facadeFactory.createReverseEngineeringStrategy();
+		IReverseEngineeringStrategy strategyFacade = (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
+				IReverseEngineeringStrategy.class, 
+				WrapperFactory.createRevengStrategyWrapper());
 		Object strategyTarget = ((IFacade)strategyFacade).getTarget();
 		IReverseEngineeringSettings settingsFacade = facadeFactory.createReverseEngineeringSettings(strategyTarget);
 		assertNotNull(settingsFacade);


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createReverseEngineeringStrategy() 
    * in method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newDefaultReverseEngineeringStrategy()' 
    * in method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl# newDefaultReverseEngineeringStrategy(String,IReverseEngineeringStrategy)'
    * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IConfigurationTest#testSetReverseEngineeringStrategy()'
    * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IOverrideRepositoryTest#testGetReverseEngineeringStrategy()'
    * in test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringSettingsTest#beforeEach()'
    * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringStrategyTest#testSetSettings()'
    * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateRevengSettings()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateRevengStrategy()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createReverseEngineeringStrategy(Object...)'