### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -148,7 +148,9 @@ public class ServiceImpl extends AbstractService {
 	@Override
 	public IReverseEngineeringSettings newReverseEngineeringSettings(
 			IReverseEngineeringStrategy res) {
-		return newFacadeFactory.createReverseEngineeringSettings(((IFacade)res).getTarget());
+		return (IReverseEngineeringSettings)GenericFacadeFactory.createFacade(
+				IReverseEngineeringSettings.class, 
+				WrapperFactory.createRevengSettingsWrapper(((IFacade)res).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -19,7 +19,6 @@ import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
-import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
@@ -58,12 +57,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
 	}
 	
-	public IReverseEngineeringSettings createReverseEngineeringSettings(Object revengStrategy) {
-		return (IReverseEngineeringSettings)GenericFacadeFactory.createFacade(
-				IReverseEngineeringSettings.class, 
-				WrapperFactory.createRevengSettingsWrapper(revengStrategy));
-				
-	}
 	
 	public IColumn createColumn(String name) {
 		return (IColumn)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
@@ -27,8 +27,9 @@ public class IReverseEngineeringSettingsTest {
 				(IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
 						IReverseEngineeringStrategy.class, 
 						WrapperFactory.createRevengStrategyWrapper());
-		revengSettingsFacade = FACADE_FACTORY.createReverseEngineeringSettings(
-				((IFacade)revengStrategyFacade).getTarget());
+		revengSettingsFacade = (IReverseEngineeringSettings)GenericFacadeFactory.createFacade(
+				IReverseEngineeringSettings.class, 
+				WrapperFactory.createRevengSettingsWrapper(((IFacade)revengStrategyFacade).getTarget()));
 		revengSettingsTarget = (RevengSettings)((IFacade)revengSettingsFacade).getTarget();	
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringStrategyTest.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Field;
 import org.hibernate.tool.internal.reveng.strategy.AbstractStrategy;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -16,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 public class IReverseEngineeringStrategyTest {
 
-	private static NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
-	
 	@Test
 	public void testSetSettings() throws Exception {
 		IReverseEngineeringStrategy revengStrategyFacade = (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
@@ -25,7 +22,9 @@ public class IReverseEngineeringStrategyTest {
 				WrapperFactory.createRevengStrategyWrapper());
 		Object revengStrategyTarget = ((IFacade)revengStrategyFacade).getTarget();
 		IReverseEngineeringSettings revengSettingsFacade = 
-				FACADE_FACTORY.createReverseEngineeringSettings(revengStrategyTarget);
+				(IReverseEngineeringSettings)GenericFacadeFactory.createFacade(
+						IReverseEngineeringSettings.class, 
+						WrapperFactory.createRevengSettingsWrapper(revengStrategyTarget));
 		Object revengSettingsTarget = ((IFacade)revengSettingsFacade).getTarget();
 		Field field = AbstractStrategy.class.getDeclaredField("settings");
 		field.setAccessible(true);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -26,7 +26,6 @@ import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
-import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.GenericExporter;
@@ -44,7 +43,6 @@ import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper;
 import org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
-import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
@@ -55,8 +53,6 @@ import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
-import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
-import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.ITableFilter;
@@ -72,20 +68,6 @@ public class NewFacadeFactoryTest {
 	@BeforeEach
 	public void beforeEach() throws Exception {
 		facadeFactory = NewFacadeFactory.INSTANCE;
-	}
-	
-	@Test 
-	public void testCreateRevengSettings() {
-		IReverseEngineeringStrategy strategyFacade = (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
-				IReverseEngineeringStrategy.class, 
-				WrapperFactory.createRevengStrategyWrapper());
-		Object strategyTarget = ((IFacade)strategyFacade).getTarget();
-		IReverseEngineeringSettings settingsFacade = facadeFactory.createReverseEngineeringSettings(strategyTarget);
-		assertNotNull(settingsFacade);
-		Object settingsTarget = ((IFacade)settingsFacade).getTarget();
-		assertNotNull(settingsTarget);
-		assertTrue(settingsTarget instanceof RevengSettings);
-		assertSame(strategyTarget, ((RevengSettings)settingsTarget).getRootStrategy());
 	}
 	
 	@Test


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createReverseEngineeringSettings(Object)' 
      * in method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newReverseEngineeringSettings(IReverseEngineeringStrategy)' 
      * in test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringSettingsTest#beforeEach()' 
      * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IReverseEngineeringStrategyTest#testSetSettings()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateRevengSettings()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createReverseEngineeringSettings(Object)'