### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental …

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -205,8 +205,10 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
-	public IColumn newColumn(String string) {
-		return newFacadeFactory.createColumn(string);
+	public IColumn newColumn(String name) {
+		return (IColumn)GenericFacadeFactory.createFacade(
+				IColumn.class, 
+				WrapperFactory.createColumnWrapper(name));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -8,7 +8,6 @@ import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
-import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
@@ -58,12 +57,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	}
 	
 	
-	public IColumn createColumn(String name) {
-		return (IColumn)GenericFacadeFactory.createFacade(
-				IColumn.class, 
-				WrapperFactory.createColumnWrapper(name));
-	}
-
 	public IConfiguration createNativeConfiguration() {
 		return (IConfiguration)GenericFacadeFactory.createFacade(
 				IConfiguration.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IColumnTest.java
@@ -21,6 +21,8 @@ import org.hibernate.tool.orm.jbt.util.MockDialect;
 import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.wrp.DelegatingColumnWrapperImpl;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
@@ -38,7 +40,9 @@ public class IColumnTest {
 	
 	@BeforeEach
 	public void beforeEach() throws Exception {
-		columnFacade = FACADE_FACTORY.createColumn(null);
+		columnFacade = (IColumn)GenericFacadeFactory.createFacade(
+				IColumn.class, 
+				WrapperFactory.createColumnWrapper(null));
 		columnTarget = ((ColumnWrapper)((IFacade)columnFacade).getTarget()).getWrappedObject();
 	}
 	
@@ -69,7 +73,9 @@ public class IColumnTest {
 		columnTarget.setSqlType("foobar");
 		assertEquals("foobar", columnFacade.getSqlType());
 		// IColumn#getSqlType(IConfiguration)
-		columnFacade = FACADE_FACTORY.createColumn(null);
+		columnFacade = (IColumn)GenericFacadeFactory.createFacade(
+				IColumn.class, 
+				WrapperFactory.createColumnWrapper(null));
 		columnTarget = ((ColumnWrapper)((IFacade)columnFacade).getTarget()).getWrappedObject();
 		columnTarget.setValue(createValue());
 		IConfiguration configurationFacade = FACADE_FACTORY.createNativeConfiguration();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IReverseEngineeringSettingsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hibernate.tool.api.reveng.RevengSettings;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
@@ -16,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 public class IReverseEngineeringSettingsTest {
 
-	private static NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
-	
 	private RevengSettings revengSettingsTarget = null;
 	private IReverseEngineeringSettings revengSettingsFacade = null;
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITableTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITableTest.java
@@ -19,6 +19,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IColumn;
@@ -56,7 +58,9 @@ public class ITableTest {
 	
 	@Test
 	public void testAddColumn() {
-		IColumn columnFacade = NewFacadeFactory.INSTANCE.createColumn("foo");
+		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
+				IColumn.class, 
+				WrapperFactory.createColumnWrapper("foo"));
 		Column columnTarget = ((ColumnWrapper)((IFacade)columnFacade).getTarget()).getWrappedObject();
 		assertNull(tableTarget.getColumn(columnTarget));
 		tableFacade.addColumn(columnFacade);
@@ -91,7 +95,9 @@ public class ITableTest {
 	public void testGetColumnIterator() {
 		Iterator<IColumn> columnIterator = tableFacade.getColumnIterator();
 		assertFalse(columnIterator.hasNext());
-		IColumn columnFacade1 = NewFacadeFactory.INSTANCE.createColumn("bar");
+		IColumn columnFacade1 = (IColumn)GenericFacadeFactory.createFacade(
+				IColumn.class, 
+				WrapperFactory.createColumnWrapper("bar"));
 		tableFacade.addColumn(columnFacade1);
 		columnIterator = tableFacade.getColumnIterator();
 		IColumn columnFacade2 = columnIterator.next();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -35,7 +35,6 @@ import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.NativeConfiguration;
 import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
-import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper;
@@ -44,7 +43,6 @@ import org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper;
 import org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.spi.IColumn;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IEnvironment;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
@@ -95,15 +93,6 @@ public class NewFacadeFactoryTest {
 		Object jpaConfigurationTarget = ((IFacade)jpaConfigurationFacade).getTarget();
 		assertNotNull(jpaConfigurationTarget);
 		assertTrue(jpaConfigurationTarget instanceof JpaConfiguration);
-	}
-	
-	@Test
-	public void testCreateColumn() {
-		IColumn columnFacade = facadeFactory.createColumn(null);
-		assertNotNull(columnFacade);
-		Object columnTarget = ((IFacade)columnFacade).getTarget();
-		assertNotNull(columnTarget);
-		assertTrue(columnTarget instanceof ColumnWrapper);
 	}
 	
 	@Test


### PR DESCRIPTION
…runtime plugin

  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createColumn(String)' 
      * in method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newColumn(String)' 
      * in test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IColumnTest#beforeEach()' 
      * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IColumnTest#testGetSqlType()' 
      * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ITableTest#testAddColumn()' 
      * in test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ITableTest#testGetColumnIterator()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateColumn()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createColumn(String)'