### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -68,7 +68,9 @@ public class ServiceImpl extends AbstractService {
 			String entityResolver, 
 			String persistenceUnit,
 			Map<Object, Object> overrides) {
-		return newFacadeFactory.createJpaConfiguration(persistenceUnit, overrides);
+		return (IConfiguration)GenericFacadeFactory.createFacade(
+				IConfiguration.class, 
+				WrapperFactory.createJpaConfigurationWrapper(persistenceUnit, overrides));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,7 +1,6 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import java.io.File;
-import java.util.Map;
 
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
@@ -56,12 +55,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
 	}
 	
-	
-	public IConfiguration createJpaConfiguration(String persistenceUnit, Map<?,?> properties) {
-		return (IConfiguration)GenericFacadeFactory.createFacade(
-				IConfiguration.class, 
-				WrapperFactory.createJpaConfigurationWrapper(persistenceUnit, properties));
-	}
 	
 	public IPersistentClass createRootClass() {
 		return (IPersistentClass)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IConfigurationTest.java
@@ -903,7 +903,9 @@ public class IConfigurationTest {
 				IConfiguration.class, 
 				WrapperFactory.createRevengConfigurationWrapper());
 		revengConfigurationTarget = (RevengConfiguration)((IFacade)revengConfigurationFacade).getTarget();
-		jpaConfigurationFacade = NEW_FACADE_FACTORY.createJpaConfiguration("foobar", null);
+		jpaConfigurationFacade = (IConfiguration)GenericFacadeFactory.createFacade(
+				IConfiguration.class, 
+				WrapperFactory.createJpaConfigurationWrapper("foobar", null));
 		jpaConfigurationTarget = (JpaConfiguration)((IFacade)jpaConfigurationFacade).getTarget();	
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -31,7 +31,6 @@ import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
-import org.hibernate.tool.orm.jbt.util.JpaConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper;
@@ -65,15 +64,6 @@ public class NewFacadeFactoryTest {
 	@BeforeEach
 	public void beforeEach() throws Exception {
 		facadeFactory = NewFacadeFactory.INSTANCE;
-	}
-	
-	@Test
-	public void testCreateJpaConfiguration() {
-		IConfiguration jpaConfigurationFacade = facadeFactory.createJpaConfiguration(null, null);
-		assertNotNull(jpaConfigurationFacade);
-		Object jpaConfigurationTarget = ((IFacade)jpaConfigurationFacade).getTarget();
-		assertNotNull(jpaConfigurationTarget);
-		assertTrue(jpaConfigurationTarget instanceof JpaConfiguration);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createJpaConfiguration(String,Map)' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newJpaConfiguration(String,String,Map)' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IConfigurationTest#initializeFacadesAndTargets()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateJpaConfiguration()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createJpaConfiguration(String,Map)'