### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -318,7 +318,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IPersistentClass newRootClass() {
-		return newFacadeFactory.createRootClass();
+		return (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -56,12 +56,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	}
 	
 	
-	public IPersistentClass createRootClass() {
-		return (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createRootClassWrapper());
-	}	
-	
 	public IPersistentClass createSingleTableSubclass(IPersistentClass persistentClass) {
 		return (IPersistentClass)GenericFacadeFactory.createFacade(
 				IPersistentClass.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IJoinTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IJoinTest.java
@@ -11,7 +11,8 @@ import org.hibernate.mapping.Join;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -26,7 +27,9 @@ public class IJoinTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		IPersistentClass persistentClassFacade = NewFacadeFactory.INSTANCE.createRootClass();
+		IPersistentClass persistentClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass persistentClassTarget = 
 				(PersistentClass)((Wrapper)((IFacade)persistentClassFacade).getTarget()).getWrappedObject();
 		joinTarget = new Join();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -31,6 +31,8 @@ import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IJoin;
@@ -58,8 +60,10 @@ public class IPersistentClassTest {
 	private Property propertyTarget = null;
 	
 	@BeforeEach
-	public void setUp() {
-		rootClassFacade = FACADE_FACTORY.createRootClass();
+	public void beforeEach() {
+		rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClassWrapper rootClassWrapper = (PersistentClassWrapper)((IFacade)rootClassFacade).getTarget();
 		rootClassTarget = rootClassWrapper.getWrappedObject();
 		singleTableSubclassFacade = FACADE_FACTORY.createSingleTableSubclass(rootClassFacade);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
@@ -24,6 +24,7 @@ import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
 import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -71,7 +72,9 @@ public class IPropertyTest {
 	@Test
 	public void testSetPersistentClass() {
 		assertNull(propertyTarget.getPersistentClass());
-		IPersistentClass persistentClassFacade = NewFacadeFactory.INSTANCE.createRootClass();
+		IPersistentClass persistentClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClassWrapper persistentClassTarget = 
 				(PersistentClassWrapper)((IFacade)persistentClassFacade).getTarget();
 		propertyFacade.setPersistentClass(persistentClassFacade);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -57,7 +57,8 @@ import org.hibernate.tool.orm.jbt.util.RevengConfiguration;
 import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.ColumnWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
@@ -505,7 +506,9 @@ public class ServiceImplTest {
 	
 	@Test
 	public void testNewSingleTableSubclass() {
-		IPersistentClass persistentClass = NewFacadeFactory.INSTANCE.createRootClass();
+		IPersistentClass persistentClass =(IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		IPersistentClass singleTableSublass = service.newSingleTableSubclass(persistentClass);
 		assertNotNull(singleTableSublass);
 		Object target = ((IFacade)singleTableSublass).getTarget();
@@ -520,7 +523,9 @@ public class ServiceImplTest {
 	
 	@Test
 	public void testNewJoinedSubclass() {
-		IPersistentClass persistentClass = NewFacadeFactory.INSTANCE.createRootClass();
+		IPersistentClass persistentClass = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		IPersistentClass joinedSubclass = service.newJoinedSubclass(persistentClass);
 		assertNotNull(joinedSubclass);
 		Object target = ((IFacade)joinedSubclass).getTarget();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -67,18 +67,10 @@ public class NewFacadeFactoryTest {
 	}
 	
 	@Test
-	public void testCreateRootClass() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
-		assertNotNull(rootClassFacade);
-		Object rootClassWrapper = ((IFacade)rootClassFacade).getTarget();
-		assertNotNull(rootClassWrapper);
-		assertTrue(rootClassWrapper instanceof PersistentClassWrapper);
-		assertTrue(((PersistentClassWrapper)rootClassWrapper).getWrappedObject() instanceof RootClass);
-	}
-	
-	@Test
 	public void testCreateSingleTableSubclass() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		Object rootClassTarget = ((IFacade)rootClassFacade).getTarget();
 		IPersistentClass singleTableSubclassFacade = 
 				facadeFactory.createSingleTableSubclass(rootClassFacade);
@@ -94,7 +86,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateJoinedTableSubclass() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		Object rootClassTarget = ((IFacade)rootClassFacade).getTarget();
 		IPersistentClass joinedTableSubclassFacade = 
 				facadeFactory.createJoinedTableSubclass(rootClassFacade);
@@ -147,7 +141,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateArray() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue arrayFacade = 
 				facadeFactory.createArray(rootClassFacade);
@@ -162,7 +158,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateBag() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue bagFacade = 
 				facadeFactory.createBag(rootClassFacade);
@@ -176,7 +174,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateList() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue listFacade = 
 				facadeFactory.createList(rootClassFacade);
@@ -216,7 +216,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateMap() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue mapFacade = 
 				facadeFactory.createMap(rootClassFacade);
@@ -230,7 +232,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateOneToMany() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		Table table = new Table("", "foo");
 		((RootClass)rootClass).setTable(table);
@@ -246,7 +250,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateOneToOne() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		Table table = new Table("", "foo");
 		((RootClass)rootClass).setTable(table);
@@ -264,7 +270,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreatePrimitiveArray() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue primitiveArrayFacade = 
 				facadeFactory.createPrimitiveArray(rootClassFacade);
@@ -278,7 +286,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateSet() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue setFacade = 
 				facadeFactory.createSet(rootClassFacade);
@@ -302,7 +312,9 @@ public class NewFacadeFactoryTest {
 	
 	@Test
 	public void testCreateComponentValue() {
-		IPersistentClass rootClassFacade = facadeFactory.createRootClass();
+		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
 		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
 		IValue componentFacade = facadeFactory.createComponent(rootClassFacade);
 		Object componentWrapper = ((IFacade)componentFacade).getTarget();


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createRootClass()' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newRootClass()' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IJoinTest#beforeEach()' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#beforeEach()' 
      * In test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPropertyTest#testSetPersistentClass()' 
      * In test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImplTest#testNewSingleTableSubclass()' 
      * In the different tests of 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateRootClass()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createRootClass()'