### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -303,7 +303,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IPersistentClass newSingleTableSubclass(IPersistentClass persistentClass) {
-		return newFacadeFactory.createSingleTableSubclass(persistentClass);
+		return (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createSingleTableSubClassWrapper(((IFacade)persistentClass).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -56,12 +56,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	}
 	
 	
-	public IPersistentClass createSingleTableSubclass(IPersistentClass persistentClass) {
-		return (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createSingleTableSubClassWrapper(((IFacade)persistentClass).getTarget()));
-	}
-
 	public IPersistentClass createJoinedTableSubclass(IPersistentClass persistentClass) {
 		return (IPersistentClass)GenericFacadeFactory.createFacade(
 				IPersistentClass.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -66,7 +66,9 @@ public class IPersistentClassTest {
 				WrapperFactory.createRootClassWrapper());
 		PersistentClassWrapper rootClassWrapper = (PersistentClassWrapper)((IFacade)rootClassFacade).getTarget();
 		rootClassTarget = rootClassWrapper.getWrappedObject();
-		singleTableSubclassFacade = FACADE_FACTORY.createSingleTableSubclass(rootClassFacade);
+		singleTableSubclassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createSingleTableSubClassWrapper(rootClassTarget));
 		PersistentClassWrapper singleTableSubclassWrapper = (PersistentClassWrapper)((IFacade)singleTableSubclassFacade).getTarget();
 		singleTableSubclassTarget = singleTableSubclassWrapper.getWrappedObject();
 		joinedSubclassFacade = FACADE_FACTORY.createJoinedTableSubclass(rootClassFacade);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -22,7 +22,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
-import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
@@ -65,25 +64,7 @@ public class NewFacadeFactoryTest {
 	public void beforeEach() throws Exception {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
-	
-	@Test
-	public void testCreateSingleTableSubclass() {
-		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createRootClassWrapper());
-		Object rootClassTarget = ((IFacade)rootClassFacade).getTarget();
-		IPersistentClass singleTableSubclassFacade = 
-				facadeFactory.createSingleTableSubclass(rootClassFacade);
-		Object singleTableSubclassWrapper = ((IFacade)singleTableSubclassFacade).getTarget();
-		assertNotNull(singleTableSubclassWrapper);
-		assertTrue(singleTableSubclassWrapper instanceof PersistentClassWrapper);
-		Object singleTableSubclassTarget = ((PersistentClassWrapper)singleTableSubclassWrapper).getWrappedObject();
-		assertTrue(singleTableSubclassTarget instanceof SingleTableSubclass);
-		assertSame(
-				((SingleTableSubclass)singleTableSubclassTarget).getRootClass(), 
-				((PersistentClassWrapper)rootClassTarget).getWrappedObject());
-	}
-	
+		
 	@Test
 	public void testCreateJoinedTableSubclass() {
 		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSingleTableSubclass(IPersistentClass)' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newSingleTableSubclass(IPersistentClass)' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#beforeEach()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateSingleTableSubclass()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSingleTableSubclass(IPersistentClass)'