### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -310,7 +310,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IPersistentClass newJoinedSubclass(IPersistentClass persistentClass) {
-		return newFacadeFactory.createJoinedTableSubclass(persistentClass);
+		return (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createJoinedTableSubClassWrapper(((IFacade)persistentClass).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -55,13 +55,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		throw new RuntimeException("use 'NewFacadeFactory#createReverseEngineeringStrategy(String)");
 	}
 	
-	
-	public IPersistentClass createJoinedTableSubclass(IPersistentClass persistentClass) {
-		return (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createJoinedTableSubClassWrapper(((IFacade)persistentClass).getTarget()));
-	}
-	
 	@Override
 	public IPersistentClass createSpecialRootClass(IProperty property) {
 		return (IPersistentClass)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -68,10 +68,12 @@ public class IPersistentClassTest {
 		rootClassTarget = rootClassWrapper.getWrappedObject();
 		singleTableSubclassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
 				IPersistentClass.class, 
-				WrapperFactory.createSingleTableSubClassWrapper(rootClassTarget));
+				WrapperFactory.createSingleTableSubClassWrapper(rootClassWrapper));
 		PersistentClassWrapper singleTableSubclassWrapper = (PersistentClassWrapper)((IFacade)singleTableSubclassFacade).getTarget();
 		singleTableSubclassTarget = singleTableSubclassWrapper.getWrappedObject();
-		joinedSubclassFacade = FACADE_FACTORY.createJoinedTableSubclass(rootClassFacade);
+		joinedSubclassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createJoinedTableSubClassWrapper(rootClassWrapper));
 		PersistentClassWrapper joinedSubclassWrapper = (PersistentClassWrapper)((IFacade)joinedSubclassFacade).getTarget();
 		joinedSubclassTarget = joinedSubclassWrapper.getWrappedObject();
 		propertyFacade = FACADE_FACTORY.createProperty();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import org.hibernate.mapping.Array;
 import org.hibernate.mapping.Bag;
 import org.hibernate.mapping.Component;
-import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.List;
 import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.Map;
@@ -65,24 +64,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreateJoinedTableSubclass() {
-		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createRootClassWrapper());
-		Object rootClassTarget = ((IFacade)rootClassFacade).getTarget();
-		IPersistentClass joinedTableSubclassFacade = 
-				facadeFactory.createJoinedTableSubclass(rootClassFacade);
-		Object joinedTableSubclassWrapper = ((IFacade)joinedTableSubclassFacade).getTarget();
-		assertNotNull(joinedTableSubclassWrapper);
-		assertTrue(joinedTableSubclassWrapper instanceof PersistentClassWrapper);
-		Object joinedTableSubclassTarget = ((PersistentClassWrapper)joinedTableSubclassWrapper).getWrappedObject();
-		assertTrue(joinedTableSubclassTarget instanceof JoinedSubclass);
-		assertSame(
-				((JoinedSubclass)joinedTableSubclassTarget).getRootClass(), 
-				((PersistentClassWrapper)rootClassTarget).getWrappedObject());
-	}
-	
 	@Test
 	public void testCreateSpecialRootClass() {
 		IProperty propertyFacade = facadeFactory.createProperty();


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createJoinedTableSubclass(IPersistentClass)' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newJoinedSubclass(IPersistentClass)' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#beforeEach()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateJoinedTableSubclass()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createJoinedTableSubclass(IPersistentClass)'