### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -316,8 +316,10 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
-	public IPersistentClass newSpecialRootClass(IProperty ormElement) {
-		return newFacadeFactory.createSpecialRootClass(ormElement);
+	public IPersistentClass newSpecialRootClass(IProperty property) {
+		return (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createSpecialRootClassWrapper(((IFacade)property).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -57,9 +57,7 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	
 	@Override
 	public IPersistentClass createSpecialRootClass(IProperty property) {
-		return (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createSpecialRootClassWrapper(((IFacade)property).getTarget()));
+		return null;
 	}
 
 	public IProperty createProperty() {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -79,7 +79,9 @@ public class IPersistentClassTest {
 		propertyFacade = FACADE_FACTORY.createProperty();
 		Wrapper propertyWrapper = (Wrapper)((IFacade)propertyFacade).getTarget();
 		propertyTarget = (Property)propertyWrapper.getWrappedObject();
-		specialRootClassFacade = FACADE_FACTORY.createSpecialRootClass(propertyFacade);
+		specialRootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createSpecialRootClassWrapper(propertyWrapper));
 		PersistentClassWrapper specialRootClassWrapper = (PersistentClassWrapper)((IFacade)specialRootClassFacade).getTarget();
 		specialRootClassTarget = specialRootClassWrapper.getWrappedObject();
 	}
@@ -731,7 +733,9 @@ public class IPersistentClassTest {
 		IProperty propertyFacade = FACADE_FACTORY.createProperty();
 		propertyFacade.setValue(componentFacade);
 		propertyFacade.setPersistentClass(rootClassFacade);
-		specialRootClassFacade = FACADE_FACTORY.createSpecialRootClass(propertyFacade);
+		specialRootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createSpecialRootClassWrapper(((IFacade)propertyFacade).getTarget()));
 		IProperty parentProperty = specialRootClassFacade.getParentProperty();
 		assertNotNull(parentProperty);
 		assertEquals("foo", parentProperty.getName());

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -29,11 +29,9 @@ import org.hibernate.tool.ide.completion.HQLCompletionProposal;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.internal.reveng.strategy.TableFilter;
-import org.hibernate.tool.orm.jbt.util.SpecialRootClass;
 import org.hibernate.tool.orm.jbt.wrp.EnvironmentWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper;
-import org.hibernate.tool.orm.jbt.wrp.PersistentClassWrapper;
 import org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper;
 import org.hibernate.tool.orm.jbt.wrp.TypeFactoryWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
@@ -64,20 +62,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreateSpecialRootClass() {
-		IProperty propertyFacade = facadeFactory.createProperty();
-		IPersistentClass specialRootClassFacade = facadeFactory.createSpecialRootClass(propertyFacade);
-		Object specialRootClassWrapper = ((IFacade)specialRootClassFacade).getTarget();
-		assertNotNull(specialRootClassWrapper);
-		assertTrue(specialRootClassWrapper instanceof PersistentClassWrapper);
-		Object specialRootClassTarget = ((PersistentClassWrapper)specialRootClassWrapper).getWrappedObject();
-		assertTrue(specialRootClassTarget instanceof SpecialRootClass);
-		assertSame(
-				((Wrapper)((SpecialRootClass)specialRootClassTarget).getProperty()).getWrappedObject(), 
-				((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject());
-	}
-	
 	@Test
 	public void testCreateProperty() {
 		IProperty propertyFacade = facadeFactory.createProperty();


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSpecialRootClass(IProperty)' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newSpecialRootClass(IProperty)' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#beforeEach()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateSpecialRootClass()'
  - Override method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSpecialRootClass(IProperty)' to return 'null'