### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -202,7 +202,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IProperty newProperty() {
-		return newFacadeFactory.createProperty();
+		return (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -60,12 +60,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return null;
 	}
 
-	public IProperty createProperty() {
-		return (IProperty)GenericFacadeFactory.createFacade(
-				IProperty.class, 
-				WrapperFactory.createPropertyWrapper());
-	}
-	
 	@Override 
 	public IHQLCompletionProposal createHQLCompletionProposal(Object target) {
 		return (IHQLCompletionProposal)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCompletionHandlerTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IHQLCompletionHandlerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionHandler;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCompletionProposal;
@@ -97,7 +99,11 @@ public class IHQLCompletionHandlerTest {
 		public int getCompletionKind() { return Integer.MAX_VALUE; }
 		public String getEntityName() { return "foobar"; }
 		public String getShortEntityName() { return "foobar"; }
-		public IProperty getProperty() { return NewFacadeFactory.INSTANCE.createProperty(); }
+		public IProperty getProperty() { 
+			return (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper()); 
+		}
 		
 		public int aliasRefKind() { return Integer.MAX_VALUE; }
 		public int entityNameKind() { return Integer.MAX_VALUE; }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -76,7 +76,9 @@ public class IPersistentClassTest {
 				WrapperFactory.createJoinedTableSubClassWrapper(rootClassWrapper));
 		PersistentClassWrapper joinedSubclassWrapper = (PersistentClassWrapper)((IFacade)joinedSubclassFacade).getTarget();
 		joinedSubclassTarget = joinedSubclassWrapper.getWrappedObject();
-		propertyFacade = FACADE_FACTORY.createProperty();
+		propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		Wrapper propertyWrapper = (Wrapper)((IFacade)propertyFacade).getTarget();
 		propertyTarget = (Property)propertyWrapper.getWrappedObject();
 		specialRootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
@@ -569,10 +571,14 @@ public class IPersistentClassTest {
 	
 	@Test
 	public void testAddProperty() {
-		IProperty firstPropertyFacade = FACADE_FACTORY.createProperty();
+		IProperty firstPropertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		Property firstPropertyTarget = (Property)((Wrapper)((IFacade)firstPropertyFacade).getTarget()).getWrappedObject();
 		firstPropertyTarget.setName("foo");
-		IProperty secondPropertyFacade = FACADE_FACTORY.createProperty();
+		IProperty secondPropertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		Property secondPropertyTarget = (Property)((Wrapper)((IFacade)secondPropertyFacade).getTarget()).getWrappedObject();
 		secondPropertyTarget.setName("bar");
 		try {
@@ -730,7 +736,9 @@ public class IPersistentClassTest {
 				rootClassTarget);
 		component.setParentProperty("foo");
 		IValue componentFacade = FACADE_FACTORY.createValue(component);
-		IProperty propertyFacade = FACADE_FACTORY.createProperty();
+		IProperty propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		propertyFacade.setValue(componentFacade);
 		propertyFacade.setPersistentClass(rootClassFacade);
 		specialRootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
@@ -743,7 +751,9 @@ public class IPersistentClassTest {
 	
 	@Test
 	public void testSetIdentifierProperty() {
-		IProperty propertyFacade = FACADE_FACTORY.createProperty();
+		IProperty propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		Property propertyTarget = (Property)((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject();
 		assertNull(rootClassTarget.getIdentifierProperty());
 		rootClassFacade.setIdentifierProperty(propertyFacade);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
@@ -41,7 +41,9 @@ public class IPropertyTest {
 	
 	@BeforeEach
 	public void beforeEach() {
-		propertyFacade = NewFacadeFactory.INSTANCE.createProperty();
+		propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
 		Wrapper propertyWrapper = (Wrapper)((IFacade)propertyFacade).getTarget();
 		propertyTarget = (Property)propertyWrapper.getWrappedObject();
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -63,18 +63,6 @@ public class NewFacadeFactoryTest {
 	}
 		
 	@Test
-	public void testCreateProperty() {
-		IProperty propertyFacade = facadeFactory.createProperty();
-		assertNotNull(propertyFacade);
-		Object propertyWrapper = ((IFacade)propertyFacade).getTarget();
-		assertNotNull(propertyWrapper);
-		assertTrue(propertyWrapper instanceof Wrapper);
-		Object propertyTarget = ((Wrapper)propertyWrapper).getWrappedObject();
-		assertNotNull(propertyTarget);
-		assertTrue(propertyTarget instanceof Property);
-	}
-	
-	@Test
 	public void testCreateHQLCompletionProposal() {
 		HQLCompletionProposal hqlCompletionProposalTarget = new HQLCompletionProposal(0, 0);
 		IHQLCompletionProposal hqlCompletionProposalFacade = 


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createProperty()' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newProperty()' 
      * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IHQLCompletionHandlerTest.TestHqlCompletionProposal#getProperty()' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#beforeEach()' 
      * In test cases 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#testAddProperty()' 
      * In test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPersistentClassTest#testSetIdentifierProperty()' 
      * In test setup 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IPropertyTest#beforeEach()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateProperty()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createProperty()'