### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -262,7 +262,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IValue newPrimitiveArray(IPersistentClass persistentClass) {
-		return newFacadeFactory.createPrimitiveArray(persistentClass);
+		return (IValue)GenericFacadeFactory.createFacade(
+				IValue.class, 
+				WrapperFactory.createPrimitiveArrayWrapper(((IFacade)persistentClass).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -58,12 +58,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return null;
 	}
 
-	public IValue createPrimitiveArray(IPersistentClass persistentClass) {
-		return (IValue)GenericFacadeFactory.createFacade(
-				IValue.class, 
-				WrapperFactory.createPrimitiveArrayWrapper(((IFacade)persistentClass).getTarget()));
-	}
-
 	public IValue createSet(IPersistentClass persistentClass) {
 		return (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.PrimitiveArray;
 import org.hibernate.mapping.Set;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.export.Exporter;
@@ -47,22 +46,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreatePrimitiveArray() {
-		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
-				IPersistentClass.class, 
-				WrapperFactory.createRootClassWrapper());
-		PersistentClass rootClass = (PersistentClass)((Wrapper)((IFacade)rootClassFacade).getTarget()).getWrappedObject();
-		IValue primitiveArrayFacade = 
-				facadeFactory.createPrimitiveArray(rootClassFacade);
-		Object primitiveArrayWrapper = ((IFacade)primitiveArrayFacade).getTarget();
-		assertNotNull(primitiveArrayWrapper);
-		assertTrue(primitiveArrayWrapper instanceof Wrapper);
-		Object wrappedPrimitiveArray = ((Wrapper)primitiveArrayWrapper).getWrappedObject();
-		assertTrue(wrappedPrimitiveArray instanceof PrimitiveArray);
-		assertSame(rootClass, ((PrimitiveArray)wrappedPrimitiveArray).getOwner());
-	}
-	
 	@Test
 	public void testCreateSet() {
 		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createPrimitiveArray(IPersistentClass)' 
    * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newPrimitiveArray(IPersistentClass)'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreatePrimitiveArray()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createPrimitiveArray(IPersistentClass)'