### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -257,7 +257,9 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IValue newSimpleValue() {
-		return newFacadeFactory.createSimpleValue();
+		return (IValue)GenericFacadeFactory.createFacade(
+				IValue.class, 
+				WrapperFactory.createSimpleValueWrapper());
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -58,12 +58,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return null;
 	}
 
-	public IValue createSimpleValue() {
-		return (IValue)GenericFacadeFactory.createFacade(
-				IValue.class, 
-				WrapperFactory.createSimpleValueWrapper());
-	}
-
 	public IValue createComponent(IPersistentClass persistentClass) {
 		return (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.SimpleValue;
 import org.hibernate.tool.api.export.Exporter;
 import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
@@ -45,16 +44,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreateSimpleValue() {
-		IValue simpleValueFacade = facadeFactory.createSimpleValue();
-		Object simpleValueWrapper = ((IFacade)simpleValueFacade).getTarget();
-		assertNotNull(simpleValueWrapper);
-		assertTrue(simpleValueWrapper instanceof Wrapper);
-		Object wrappedSimpleValue = ((Wrapper)simpleValueWrapper).getWrappedObject();
-		assertTrue(wrappedSimpleValue instanceof SimpleValue);
-	}
-	
 	@Test
 	public void testCreateComponentValue() {
 		IPersistentClass rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSimpleValue()' 
     * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newSimpleValue()'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateSimpleValue()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSimpleValue()'