### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -88,8 +88,10 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
-	public ISchemaExport newSchemaExport(IConfiguration hcfg) {
-		return newFacadeFactory.createSchemaExport(hcfg);
+	public ISchemaExport newSchemaExport(IConfiguration configuration) {
+		return (ISchemaExport)GenericFacadeFactory.createFacade(
+				ISchemaExport.class, 
+				WrapperFactory.createSchemaExport(((IFacade)configuration).getTarget()));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -16,7 +16,6 @@ import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
-import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 
 public class NewFacadeFactory extends AbstractFacadeFactory {
 	
@@ -54,12 +53,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return null;
 	}
 
-	public ISchemaExport createSchemaExport(IConfiguration configuration) {
-		return (ISchemaExport)GenericFacadeFactory.createFacade(
-				ISchemaExport.class, 
-				WrapperFactory.createSchemaExport(((IFacade)configuration).getTarget()));
-	}
-	
 	public IHibernateMappingExporter createHibernateMappingExporter(
 			IConfiguration configuration, File file) {
 		return (IHibernateMappingExporter)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -13,7 +13,6 @@ import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
 import org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper;
-import org.hibernate.tool.orm.jbt.wrp.SchemaExportWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -21,7 +20,6 @@ import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
-import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,16 +32,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreateSchemaExport() {
-		IConfiguration configurationFacade = (IConfiguration)GenericFacadeFactory.createFacade(
-				IConfiguration.class, 
-				WrapperFactory.createNativeConfigurationWrapper());
-		ISchemaExport schemaExportFacade = facadeFactory.createSchemaExport(configurationFacade);
-		Object schemaExportWrapper = ((IFacade)schemaExportFacade).getTarget();
-		assertTrue(schemaExportWrapper instanceof SchemaExportWrapper);
-	}
-	
 	@Test
 	public void testCreateHibernateMappingExporter() {
 		File file = new File("foo");


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSchemaExport(IConfiguration)' * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newSchemaExport(IConfiguration)'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateSchemaExport()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createSchemaExport(IConfiguration)'