### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -83,8 +83,10 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IHibernateMappingExporter newHibernateMappingExporter(
-			IConfiguration hcfg, File file) {
-		return newFacadeFactory.createHibernateMappingExporter(hcfg, file);
+			IConfiguration configuration, File file) {
+		return (IHibernateMappingExporter)GenericFacadeFactory.createFacade(
+				IHibernateMappingExporter.class, 
+				WrapperFactory.createHbmExporterWrapper(((IFacade)configuration).getTarget(), file));
 	}
 
 	@Override

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,7 +1,5 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
-import java.io.File;
-
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
@@ -10,7 +8,6 @@ import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
-import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -53,13 +50,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 		return null;
 	}
 
-	public IHibernateMappingExporter createHibernateMappingExporter(
-			IConfiguration configuration, File file) {
-		return (IHibernateMappingExporter)GenericFacadeFactory.createFacade(
-				IHibernateMappingExporter.class, 
-				WrapperFactory.createHbmExporterWrapper(((IFacade)configuration).getTarget(), file));
-	}
-	
 	public IExporter createExporter(String exporterClassName) {
 		return (IExporter)GenericFacadeFactory.createFacade(
 				IExporter.class, 

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -1,17 +1,12 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-
 import org.hibernate.tool.api.export.Exporter;
-import org.hibernate.tool.api.export.ExporterConstants;
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.common.GenericExporter;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
-import org.hibernate.tool.orm.jbt.wrp.HbmExporterWrapper;
 import org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper;
 import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
@@ -19,7 +14,6 @@ import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
 import org.jboss.tools.hibernate.runtime.spi.IExporter;
 import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
-import org.jboss.tools.hibernate.runtime.spi.IHibernateMappingExporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,22 +26,6 @@ public class NewFacadeFactoryTest {
 		facadeFactory = NewFacadeFactory.INSTANCE;
 	}
 		
-	@Test
-	public void testCreateHibernateMappingExporter() {
-		File file = new File("foo");
-		IConfiguration configurationFacade = (IConfiguration)GenericFacadeFactory.createFacade(
-				IConfiguration.class, 
-				WrapperFactory.createNativeConfigurationWrapper());
-		IHibernateMappingExporter hibernateMappingExporterFacade = 
-				facadeFactory.createHibernateMappingExporter(configurationFacade, file);
-		Object hibernateMappingExporterWrapper = ((IFacade)hibernateMappingExporterFacade).getTarget();
-		assertTrue(hibernateMappingExporterWrapper instanceof HbmExporterWrapper);
-		assertSame(
-				((HbmExporterWrapper)hibernateMappingExporterWrapper)
-					.getProperties().get(ExporterConstants.OUTPUT_FILE_NAME),
-				file);
-	}
-	
 	@Test
 	public void testCreateExporter() {
 		IExporter exporterFacade = facadeFactory.createExporter(GenericExporter.class.getName());


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createHibernateMappingExporter(IConfiguration,File)' 
     * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newHibernateMappingExporter(IConfiguration,File)'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateHibernateMappingExporter()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createHibernateMappingExporter(IConfiguration,File)'