### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -195,7 +195,7 @@ public class ServiceImpl extends AbstractService {
 			IReverseEngineeringStrategy delegate) {
 		return (IReverseEngineeringStrategy)GenericFacadeFactory.createFacade(
 				IReverseEngineeringStrategy.class, 
-				WrapperFactory.createRevengStrategyWrapper(strategyName, delegate));
+				WrapperFactory.createRevengStrategyWrapper(strategyName, ((IFacade)delegate).getTarget()));
 	}
 
 	@Override

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -30,6 +30,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	    <module>org.jboss.tools.hibernate.runtime.v_6_0.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_1.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_2.test</module>
+	    <module>org.jboss.tools.hibernate.orm.runtime.exp.test</module>
 	</modules>
 	
 </project>


### PR DESCRIPTION
  - Fix the runtime exception in 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImplTest#testNewReverseEngineeringStrategy()'
  - Include test plugin 'org.jboss.tools.hibernate.orm.runtime.exp.test' in the build