### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -24,7 +24,6 @@ import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractService;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.HibernateException;
@@ -56,8 +55,6 @@ public class ServiceImpl extends AbstractService {
 
 	private static final String HIBERNATE_VERSION = "6.1";
 	
-	private NewFacadeFactory newFacadeFactory = NewFacadeFactory.INSTANCE;
-
 	@Override
 	public IConfiguration newAnnotationConfiguration() {
 		return newDefaultConfiguration();
@@ -97,10 +94,12 @@ public class ServiceImpl extends AbstractService {
 	}
 
 	@Override
-	public IHQLCodeAssist newHQLCodeAssist(IConfiguration hcfg) {
+	public IHQLCodeAssist newHQLCodeAssist(IConfiguration configuration) {
 		IHQLCodeAssist result = null;
-		if (hcfg instanceof IConfiguration) {
-			result = newFacadeFactory.createHQLCodeAssist(hcfg);
+		if (configuration instanceof IConfiguration) {
+			result = (IHQLCodeAssist)GenericFacadeFactory.createFacade(
+					IHQLCodeAssist.class, 
+					WrapperFactory.createHqlCodeAssistWrapper(((IFacade)configuration).getTarget()));
 		}
 		return result;
 	}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactory.java
@@ -1,12 +1,8 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
-import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
-import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
-import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
 import org.jboss.tools.hibernate.runtime.spi.INamingStrategy;
 import org.jboss.tools.hibernate.runtime.spi.IOverrideRepository;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
@@ -47,12 +43,6 @@ public class NewFacadeFactory extends AbstractFacadeFactory {
 	@Override
 	public IPersistentClass createSpecialRootClass(IProperty property) {
 		return null;
-	}
-
-	public IHQLCodeAssist createHQLCodeAssist(IConfiguration configuration) {
-		return (IHQLCodeAssist)GenericFacadeFactory.createFacade(
-				IHQLCodeAssist.class, 
-				WrapperFactory.createHqlCodeAssistWrapper(((IFacade)configuration).getTarget()));
 	}
 
 	@Override

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/NewFacadeFactoryTest.java
@@ -1,40 +1,10 @@
 package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.reveng.strategy.DelegatingStrategy;
-import org.hibernate.tool.orm.jbt.wrp.HqlCodeAssistWrapper;
-import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
-import org.jboss.tools.hibernate.runtime.common.IFacade;
-import org.jboss.tools.hibernate.runtime.spi.IConfiguration;
-import org.jboss.tools.hibernate.runtime.spi.IHQLCodeAssist;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class NewFacadeFactoryTest {
 
-	private NewFacadeFactory facadeFactory;
-
-	@BeforeEach
-	public void beforeEach() throws Exception {
-		facadeFactory = NewFacadeFactory.INSTANCE;
-	}
-		
-	@Test
-	public void testCreateHqlCodeAssist() {
-		IConfiguration configuration = (IConfiguration)GenericFacadeFactory.createFacade(
-				IConfiguration.class, 
-				WrapperFactory.createNativeConfigurationWrapper());
-		configuration.setProperty("hibernate.connection.url", "jdbc:h2:mem:test");
-		IHQLCodeAssist hqlCodeAssistFacade = facadeFactory.createHQLCodeAssist(configuration);
-		assertNotNull(hqlCodeAssistFacade);
-		Object hqlCodeAssistWrapper = ((IFacade)hqlCodeAssistFacade).getTarget();
-		assertNotNull(hqlCodeAssistWrapper);
-		assertTrue(hqlCodeAssistWrapper instanceof HqlCodeAssistWrapper);
-	}
-	
 	public static class TestRevengStrategy extends DelegatingStrategy {
 		public TestRevengStrategy(RevengStrategy delegate) {
 			super(delegate);


### PR DESCRIPTION
  - Inline method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createHQLCodeAssist(IConfiguration)' 
     * In method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#newHQLCodeAssist(IConfiguration)'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactoryTest#testCreateHqlCodeAssist()'
  - Remove unused method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory#createHQLCodeAssist(IConfiguration)'