### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
@@ -3,14 +3,13 @@ package org.jboss.tools.hibernate.orm.runtime.exp.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hibernate.mapping.BasicValue;
-import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
+import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
-import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.NewFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.AbstractPropertyFacade;
 import org.jboss.tools.hibernate.runtime.spi.ICfg2HbmTool;
 import org.jboss.tools.hibernate.runtime.spi.IPersistentClass;
 import org.jboss.tools.hibernate.runtime.spi.IProperty;
@@ -18,8 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ICfg2HbmToolTest {
-
-	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
 
 	private ICfg2HbmTool facade = null;
 	
@@ -32,22 +29,25 @@ public class ICfg2HbmToolTest {
 
 	@Test
 	public void testGetTagPersistentClass() {
-		PersistentClass target = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		IPersistentClass persistentClass = FACADE_FACTORY.createPersistentClass(target);
-		assertEquals("class", facade.getTag(persistentClass));
+		IPersistentClass persistentClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(
+				IPersistentClass.class, 
+				WrapperFactory.createRootClassWrapper());
+		assertEquals("class", facade.getTag(persistentClassFacade));
 	}
 
 	@Test
 	public void testGetTagProperty() throws Exception {
+		IProperty propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
+				IProperty.class, 
+				WrapperFactory.createPropertyWrapper());
+		Property propertyTarget = (Property)((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject();
 		RootClass rc = new RootClass(DummyMetadataBuildingContext.INSTANCE);
-		Property p = new Property();
 		BasicValue basicValue = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		basicValue.setTypeName("foobar");
-		p.setValue(basicValue);
-		p.setPersistentClass(rc);
-		rc.setVersion(p);
-		IProperty property = new AbstractPropertyFacade(FACADE_FACTORY, p) {};
-		assertEquals("version", facade.getTag(property));
+		propertyTarget.setValue(basicValue);
+		propertyTarget.setPersistentClass(rc);
+		rc.setVersion(propertyTarget);
+		assertEquals("version", facade.getTag(propertyFacade));
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IClassMetadataTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IClassMetadataTest.java
@@ -60,8 +60,6 @@ public class IClassMetadataTest {
 		public Set<String> bars = new HashSet<String>();
 	}
 	
-	private static final NewFacadeFactory FACADE_FACTORY = NewFacadeFactory.INSTANCE;
-	
 	@TempDir
 	public File tempDir;
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITypeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITypeFactoryTest.java
@@ -249,7 +249,7 @@ public class ITypeFactoryTest {
 		assertEquals("42", typeFormats.get(typeFactoryFacade.getLongType()));
 		assertEquals("a string", typeFormats.get(typeFactoryFacade.getStringType()));
 		assertEquals("a text", typeFormats.get(typeFactoryFacade.getTextType()));
-		assertEquals(12, typeFormats.get(typeFactoryFacade.getTimeType()).length());
+		assertEquals(':', typeFormats.get(typeFactoryFacade.getTimeType()).charAt(2));
 		assertEquals(
 				new SimpleDateFormat("yyyy-MM-dd").format(new Date()), 
 				typeFormats.get(typeFactoryFacade.getTimestampType()).substring(0, 10));


### PR DESCRIPTION
  - Make test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ITypeFactoryTest#testGetTypeFormats()' more reliable
  - Remove unused class variable 'FACADE_FACTORY' from test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IClassMetadataTest'
  - Adapt test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ICfg2HbmToolTest' to not use the inherited funtionality of 'org.jboss.tools.hibernate.runtime.common.AbstractFacadeFactory' anymore