### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/META-INF/MANIFEST.MF
@@ -24,6 +24,6 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
 Bundle-ClassPath: .,
  lib/hibernate-ant-6.2.6.Final.jar,
  lib/hibernate-core-6.2.6.Final.jar,
- lib/hibernate-tools-orm-6.2.6.Final.jar,
- lib/hibernate-tools-orm-jbt-6.2.6.Final.jar,
- lib/hibernate-tools-utils-6.2.6.Final.jar
+ lib/hibernate-tools-orm-6.2.6a.Final.jar,
+ lib/hibernate-tools-orm-jbt-6.2.6a.Final.jar,
+ lib/hibernate-tools-utils-6.2.6a.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/pom.xml
@@ -13,7 +13,7 @@
 
 	<properties>
 		<hibernate.orm.version>6.2.6.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.2.6.Final</hibernate.tools.version>
+		<hibernate.tools.version>6.2.6a.Final</hibernate.tools.version>
 	</properties>
 
 	<build>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/util/GenericFacadeFactory.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.jboss.tools.hibernate.orm.runtime.common.ReflectUtil;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.IClassMetadata;
@@ -146,15 +145,7 @@ public class GenericFacadeFactory {
 			result = new Object[args.length];
 			for (int i = 0; i < args.length; i++) {
 				if (args[i] != null && IFacade.class.isAssignableFrom(args[i].getClass())) {
-					Object target = ((IFacade)args[i]).getTarget();
-					Class<?> targetClass = target.getClass();
-					if (Proxy.isProxyClass(targetClass)) {
-						targetClass = targetClass.getInterfaces()[0];
-					}
-					if (Wrapper.class.isAssignableFrom(targetClass)) {
-						target = ((Wrapper)target).getWrappedObject();
-					}
-					result[i] = target;
+					result[i] = ((IFacade)args[i]).getTarget();
 				} else {
 					result[i] = args[i];
 				}
@@ -240,9 +231,6 @@ public class GenericFacadeFactory {
 					argClass = target.getClass();
 					if (Proxy.isProxyClass(argClass)) {
 						argClass = argClass.getInterfaces()[0];
-					}
-					if (Wrapper.class.isAssignableFrom(argClass)) {
-						argClass = ((Wrapper)target).getWrappedObject().getClass();
 					}
 				}
 				result[i] = argClass;

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/VersionTest.java
@@ -13,7 +13,7 @@ public class VersionTest {
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.2.6.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.2.6a.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ICfg2HbmToolTest.java
@@ -6,7 +6,6 @@ import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.tool.orm.jbt.util.DummyMetadataBuildingContext;
-import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
@@ -40,7 +39,7 @@ public class ICfg2HbmToolTest {
 		IProperty propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
 				IProperty.class, 
 				WrapperFactory.createPropertyWrapper());
-		Property propertyTarget = (Property)((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject();
+		Property propertyTarget = (Property)((IFacade)propertyFacade).getTarget();
 		RootClass rc = new RootClass(DummyMetadataBuildingContext.INSTANCE);
 		BasicValue basicValue = new BasicValue(DummyMetadataBuildingContext.INSTANCE);
 		basicValue.setTypeName("foobar");

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IForeignKeyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IForeignKeyTest.java
@@ -87,12 +87,12 @@ public class IForeignKeyTest {
 	
 	@Test
 	public void testContainsColumn() throws Exception {
-		Column columnTarget = new Column("foo");
+		Column columnWrapper = new DelegatingColumnWrapperImpl(new Column("foo"));
 		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
-				new DelegatingColumnWrapperImpl(columnTarget));
+				columnWrapper);
 		assertFalse(foreignKeyFacade.containsColumn(columnFacade));
-		foreignKeyTarget.addColumn(columnTarget);
+		foreignKeyTarget.addColumn(columnWrapper);
 		assertTrue(foreignKeyFacade.containsColumn(columnFacade));
 	}
 	

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPersistentClassTest.java
@@ -571,12 +571,12 @@ public class IPersistentClassTest {
 		IProperty firstPropertyFacade = (IProperty)GenericFacadeFactory.createFacade(
 				IProperty.class, 
 				WrapperFactory.createPropertyWrapper());
-		Property firstPropertyTarget = (Property)((Wrapper)((IFacade)firstPropertyFacade).getTarget()).getWrappedObject();
+		Property firstPropertyTarget = (Property)((IFacade)firstPropertyFacade).getTarget();
 		firstPropertyTarget.setName("foo");
 		IProperty secondPropertyFacade = (IProperty)GenericFacadeFactory.createFacade(
 				IProperty.class, 
 				WrapperFactory.createPropertyWrapper());
-		Property secondPropertyTarget = (Property)((Wrapper)((IFacade)secondPropertyFacade).getTarget()).getWrappedObject();
+		Property secondPropertyTarget = (Property)((IFacade)secondPropertyFacade).getTarget();
 		secondPropertyTarget.setName("bar");
 		try {
 			rootClassTarget.getProperty("foo");
@@ -651,7 +651,7 @@ public class IPersistentClassTest {
 		ITable tableFacade = (ITable)GenericFacadeFactory.createFacade(
 				ITable.class, 
 				WrapperFactory.createTableWrapper(""));
-		Table tableTarget = (Table)((Wrapper)((IFacade)tableFacade).getTarget()).getWrappedObject();
+		Table tableTarget = (Table)((IFacade)tableFacade).getTarget();
 		assertNull(rootClassTarget.getTable());
 		assertNull(singleTableSubclassTarget.getTable());
 		rootClassFacade.setTable(tableFacade);
@@ -685,13 +685,13 @@ public class IPersistentClassTest {
 			rootClassFacade.setKey(valueFacade);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 		try {
 			singleTableSubclassFacade.setKey(valueFacade);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 		joinedSubclassFacade.setKey(valueFacade);
 		assertSame(valueTarget, joinedSubclassTarget.getKey());
@@ -699,7 +699,7 @@ public class IPersistentClassTest {
 			specialRootClassFacade.setKey(valueFacade);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("setKey(KeyValue) is only allowed on JoinedSubclass", e.getMessage());
+			assertEquals("setKey(Value) is only allowed on JoinedSubclass", e.getMessage());
 		}
 	}
 	
@@ -755,7 +755,7 @@ public class IPersistentClassTest {
 		IProperty propertyFacade = (IProperty)GenericFacadeFactory.createFacade(
 				IProperty.class, 
 				WrapperFactory.createPropertyWrapper());
-		Property propertyTarget = (Property)((Wrapper)((IFacade)propertyFacade).getTarget()).getWrappedObject();
+		Property propertyTarget = (Property)((IFacade)propertyFacade).getTarget();
 		assertNull(rootClassTarget.getIdentifierProperty());
 		rootClassFacade.setIdentifierProperty(propertyFacade);
 		assertSame(propertyTarget, rootClassTarget.getIdentifierProperty());
@@ -793,13 +793,13 @@ public class IPersistentClassTest {
 			singleTableSubclassFacade.setIdentifier(valueFacade);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+			assertEquals("Method 'setIdentifier(Value)' can only be called on RootClass instances", e.getMessage());
 		}
 		try {
 			joinedSubclassFacade.setIdentifier(valueFacade);
 			fail();
 		} catch (RuntimeException e) {
-			assertEquals("Method 'setIdentifier(KeyValue)' can only be called on RootClass instances", e.getMessage());
+			assertEquals("Method 'setIdentifier(Value)' can only be called on RootClass instances", e.getMessage());
 		}
 		assertNull(specialRootClassTarget.getIdentifier());
 		specialRootClassFacade.setIdentifier(valueFacade);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPrimaryKeyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPrimaryKeyTest.java
@@ -45,10 +45,10 @@ public class IPrimaryKeyTest {
 
 	@Test
 	public void testAddColumn() throws Exception {
-		Column columnTarget = new Column("foo");
+		Column columnTarget = new DelegatingColumnWrapperImpl(new Column("foo"));
 		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
-				new DelegatingColumnWrapperImpl(columnTarget));
+				columnTarget);
 		assertTrue(primaryKeyTarget.getColumns().isEmpty());
 		primaryKeyFacade.addColumn(columnFacade);
 		assertEquals(1, primaryKeyTarget.getColumns().size());
@@ -98,10 +98,10 @@ public class IPrimaryKeyTest {
 	
 	@Test
 	public void testContainsColumn() {
-		Column columnTarget = new Column("foo");
+		Column columnTarget = new DelegatingColumnWrapperImpl(new Column("foo"));
 		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
-				new DelegatingColumnWrapperImpl(columnTarget));
+				columnTarget);
 		assertFalse(primaryKeyFacade.containsColumn(columnFacade));
 		primaryKeyTarget.addColumn(columnTarget);
 		assertTrue(primaryKeyFacade.containsColumn(columnFacade));

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IPropertyTest.java
@@ -132,7 +132,7 @@ public class IPropertyTest {
 		IValue valueFacade = (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 
 				WrapperFactory.createSimpleValueWrapper());
-		Value valueTarget = (Value)((Wrapper)((IFacade)valueFacade).getTarget()).getWrappedObject();
+		Value valueTarget = (Value)((IFacade)valueFacade).getTarget();
 		propertyFacade.setValue(valueFacade);
 		assertSame(valueTarget, propertyTarget.getValue());
 	}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITableTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ITableTest.java
@@ -62,7 +62,7 @@ public class ITableTest {
 		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
 				WrapperFactory.createColumnWrapper("foo"));
-		Column columnTarget = ((ColumnWrapper)((IFacade)columnFacade).getTarget()).getWrappedObject();
+		Column columnTarget = (Column)((IFacade)columnFacade).getTarget();
 		assertNull(tableTarget.getColumn(columnTarget));
 		tableFacade.addColumn(columnFacade);
 		assertSame(columnTarget, tableTarget.getColumn(columnTarget));

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IValueTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/IValueTest.java
@@ -415,15 +415,15 @@ public class IValueTest {
 		persistentClassFacade.setTable(null);
 		assertNull(arrayValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)arrayValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)arrayValueFacade.getTable()).getTarget());
 		persistentClassFacade.setTable(null);
 		assertNull(bagValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)bagValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)bagValueFacade.getTable()).getTarget());
 		persistentClassFacade.setTable(null);
 		assertNull(listValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)listValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)listValueFacade.getTable()).getTarget());
 		((ManyToOne)manyToOneValueTarget).setTable(null);
 		assertNull(manyToOneValueFacade.getTable());
 		((ManyToOne)manyToOneValueTarget).setTable(tableTarget);
@@ -431,27 +431,27 @@ public class IValueTest {
 		persistentClassFacade.setTable(null);
 		assertNull(mapValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)mapValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)mapValueFacade.getTable()).getTarget());
 		assertNull(oneToManyValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
 		oneToManyValueFacade = (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 
 				WrapperFactory.createOneToManyWrapper(((IFacade)persistentClassFacade).getTarget()));
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)oneToManyValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)oneToManyValueFacade.getTable()).getTarget());
 		assertNull(oneToOneValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
 		oneToOneValueFacade = (IValue)GenericFacadeFactory.createFacade(
 				IValue.class, 
 				WrapperFactory.createOneToOneWrapper(((IFacade)persistentClassFacade).getTarget()));
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)oneToOneValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)oneToOneValueFacade.getTable()).getTarget());
 		persistentClassFacade.setTable(null);
 		assertNull(primitiveArrayValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)primitiveArrayValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)primitiveArrayValueFacade.getTable()).getTarget());
 		persistentClassFacade.setTable(null);
 		assertNull(setValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)setValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)setValueFacade.getTable()).getTarget());
 		((SimpleValue)simpleValueTarget).setTable(null);
 		assertNull(simpleValueFacade.getTable());
 		((SimpleValue)simpleValueTarget).setTable(tableTarget);
@@ -470,7 +470,7 @@ public class IValueTest {
 		persistentClassFacade.setTable(null);
 		assertNull(identifierBagValueFacade.getTable());
 		persistentClassFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((IFacade)identifierBagValueFacade.getTable()).getTarget());
+		assertSame(tableTarget, ((IFacade)identifierBagValueFacade.getTable()).getTarget());
 	}
 
 	@Test
@@ -519,19 +519,19 @@ public class IValueTest {
 	public void testSetElement() {
 		assertNull(((Collection)arrayValueTarget).getElement());
 		arrayValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)arrayValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)arrayValueTarget).getElement()).getWrappedObject());
 		assertNull(((Collection)bagValueTarget).getElement());
 		bagValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)bagValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)bagValueTarget).getElement()).getWrappedObject());
 		assertNull(((Collection)listValueTarget).getElement());
 		listValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)listValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)listValueTarget).getElement()).getWrappedObject());
 		assertNull(manyToOneValueFacade.getElement());
 		manyToOneValueFacade.setElement(simpleValueFacade);
 		assertNull(manyToOneValueFacade.getElement());
 		assertNull(((Collection)mapValueTarget).getElement());
 		mapValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)mapValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)mapValueTarget).getElement()).getWrappedObject());
 		assertNull(oneToManyValueFacade.getElement());
 		oneToManyValueFacade.setElement(simpleValueFacade);
 		assertNull(oneToManyValueFacade.getElement());
@@ -540,10 +540,10 @@ public class IValueTest {
 		assertNull(oneToOneValueFacade.getElement());
 		assertNull(((Collection)primitiveArrayValueTarget).getElement());
 		primitiveArrayValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)primitiveArrayValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)primitiveArrayValueTarget).getElement()).getWrappedObject());
 		assertNull(((Collection)setValueTarget).getElement());
 		setValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)setValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)setValueTarget).getElement()).getWrappedObject());
 		assertNull(simpleValueFacade.getElement());
 		simpleValueFacade.setElement(arrayValueFacade);
 		assertNull(simpleValueFacade.getElement());
@@ -558,26 +558,26 @@ public class IValueTest {
 		assertNull(anyValueFacade.getElement());
 		assertNull(((Collection)identifierBagValueTarget).getElement());
 		identifierBagValueFacade.setElement(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)identifierBagValueTarget).getElement());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)identifierBagValueTarget).getElement()).getWrappedObject());
 	}
 	
 	@Test
 	public void testSetCollectionTable() {
 		assertNull(((Collection)arrayValueTarget).getCollectionTable());
 		arrayValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)arrayValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)arrayValueTarget).getCollectionTable());
 		assertNull(((Collection)bagValueTarget).getCollectionTable());
 		bagValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)bagValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)bagValueTarget).getCollectionTable());
 		assertNull(((Collection)listValueTarget).getCollectionTable());
 		listValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)listValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)listValueTarget).getCollectionTable());
 		assertNull(manyToOneValueFacade.getCollectionTable());
 		manyToOneValueFacade.setCollectionTable(tableFacade);
 		assertNull(manyToOneValueFacade.getElement());
 		assertNull(((Collection)mapValueTarget).getCollectionTable());
 		mapValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)mapValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)mapValueTarget).getCollectionTable());
 		assertNull(oneToManyValueFacade.getCollectionTable());
 		oneToManyValueFacade.setCollectionTable(tableFacade);
 		assertNull(oneToManyValueFacade.getCollectionTable());
@@ -586,10 +586,10 @@ public class IValueTest {
 		assertNull(oneToOneValueFacade.getCollectionTable());
 		assertNull(((Collection)primitiveArrayValueTarget).getCollectionTable());
 		primitiveArrayValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)primitiveArrayValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)primitiveArrayValueTarget).getCollectionTable());
 		assertNull(((Collection)setValueTarget).getCollectionTable());
 		setValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)setValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)setValueTarget).getCollectionTable());
 		assertNull(simpleValueFacade.getCollectionTable());
 		simpleValueFacade.setCollectionTable(tableFacade);
 		assertNull(simpleValueFacade.getCollectionTable());
@@ -604,7 +604,7 @@ public class IValueTest {
 		assertNull(anyValueFacade.getCollectionTable());
 		assertNull(((Collection)identifierBagValueTarget).getCollectionTable());
 		identifierBagValueFacade.setCollectionTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), ((Collection)identifierBagValueTarget).getCollectionTable());
+		assertSame(tableTarget, ((Collection)identifierBagValueTarget).getCollectionTable());
 	}
 	
 	@Test
@@ -629,7 +629,7 @@ public class IValueTest {
 		assertNull(oneToManyValueTarget.getTable());
 		assertNull(oneToOneValueTarget.getTable());
 		oneToOneValueFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), oneToOneValueTarget.getTable());
+		assertSame(tableTarget, oneToOneValueTarget.getTable());
 		assertNull(primitiveArrayValueTarget.getTable());
 		primitiveArrayValueFacade.setTable(tableFacade);
 		assertNull(primitiveArrayValueTarget.getTable());
@@ -638,10 +638,10 @@ public class IValueTest {
 		assertNull(setValueTarget.getTable());
 		assertNull(simpleValueTarget.getTable());
 		simpleValueFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), simpleValueTarget.getTable());
+		assertSame(tableTarget, simpleValueTarget.getTable());
 		assertNull(componentValueTarget.getTable());
 		componentValueFacade.setTable(tableFacade);
-		assertSame(((Wrapper)tableTarget).getWrappedObject(), componentValueTarget.getTable());
+		assertSame(tableTarget, componentValueTarget.getTable());
 		assertSame(tableTarget, dependantValueTarget.getTable());
 		dependantValueFacade.setTable(null);
 		assertNull(dependantValueTarget.getTable());
@@ -675,19 +675,19 @@ public class IValueTest {
 	public void testSetIndex() {
 		assertNull(((IndexedCollection)arrayValueTarget).getIndex());
 		arrayValueFacade.setIndex(simpleValueFacade);
-		assertSame(simpleValueTarget, ((IndexedCollection)arrayValueTarget).getIndex());
+		assertSame(simpleValueTarget, ((Wrapper)((IndexedCollection)arrayValueTarget).getIndex()).getWrappedObject());
 		assertNull(bagValueFacade.getIndex());
 		bagValueFacade.setIndex(simpleValueFacade);
 		assertNull(bagValueFacade.getIndex());
 		assertNull(((IndexedCollection)listValueTarget).getIndex());
 		listValueFacade.setIndex(simpleValueFacade);
-		assertSame(simpleValueTarget, ((IndexedCollection)listValueTarget).getIndex());
+		assertSame(simpleValueTarget, ((Wrapper)((IndexedCollection)listValueTarget).getIndex()).getWrappedObject());
 		assertNull(manyToOneValueFacade.getIndex());
 		manyToOneValueFacade.setIndex(simpleValueFacade);
 		assertNull(manyToOneValueFacade.getIndex());
 		assertNull(((IndexedCollection)mapValueTarget).getIndex());
 		mapValueFacade.setIndex(simpleValueFacade);
-		assertSame(simpleValueTarget, ((IndexedCollection)mapValueTarget).getIndex());
+		assertSame(simpleValueTarget, ((Wrapper)((IndexedCollection)mapValueTarget).getIndex()).getWrappedObject());
 		assertNull(oneToManyValueFacade.getIndex());
 		oneToManyValueFacade.setIndex(simpleValueFacade);
 		assertNull(oneToManyValueFacade.getIndex());
@@ -696,7 +696,7 @@ public class IValueTest {
 		assertNull(oneToOneValueFacade.getIndex());
 		assertNull(((IndexedCollection)primitiveArrayValueTarget).getIndex());
 		primitiveArrayValueFacade.setIndex(simpleValueFacade);
-		assertSame(simpleValueTarget, ((IndexedCollection)primitiveArrayValueTarget).getIndex());
+		assertSame(simpleValueTarget, ((Wrapper)((IndexedCollection)primitiveArrayValueTarget).getIndex()).getWrappedObject());
 		assertNull(setValueFacade.getIndex());
 		setValueFacade.setIndex(simpleValueFacade);
 		assertNull(setValueFacade.getIndex());
@@ -1567,7 +1567,7 @@ public class IValueTest {
 		IColumn columnFacade = (IColumn)GenericFacadeFactory.createFacade(
 				IColumn.class, 
 				WrapperFactory.createColumnWrapper("foo"));
-		Column columnTarget = (Column)((Wrapper)((IFacade)columnFacade).getTarget()).getWrappedObject();
+		Column columnTarget = (Column)((IFacade)columnFacade).getTarget();
 		assertFalse(manyToOneValueTarget.getColumns().contains(columnTarget));
 		manyToOneValueFacade.addColumn(columnFacade);
 		assertTrue(manyToOneValueTarget.getColumns().contains(columnTarget));
@@ -2011,25 +2011,25 @@ public class IValueTest {
 	public void testSetKey() {
 		assertNull(((Collection)arrayValueTarget).getKey());
 		arrayValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)arrayValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)arrayValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)bagValueTarget).getKey());
 		bagValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)bagValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)bagValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)listValueTarget).getKey());
 		listValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)listValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)listValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)mapValueTarget).getKey());
 		mapValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)mapValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)mapValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)primitiveArrayValueTarget).getKey());
 		primitiveArrayValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)primitiveArrayValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)primitiveArrayValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)setValueTarget).getKey());
 		setValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)setValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)setValueTarget).getKey()).getWrappedObject());
 		assertNull(((Collection)identifierBagValueTarget).getKey());
 		identifierBagValueFacade.setKey(simpleValueFacade);
-		assertSame(simpleValueTarget, ((Collection)identifierBagValueTarget).getKey());
+		assertSame(simpleValueTarget, ((Wrapper)((Collection)identifierBagValueTarget).getKey()).getWrappedObject());
 		try {
 			manyToOneValueFacade.setKey(simpleValueFacade);
 			fail();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -322,7 +322,9 @@ public class ServiceImplTest {
 		assertNotNull(cfg2HbmTool);
 		Object target = ((IFacade)cfg2HbmTool).getTarget();
 		assertNotNull(target);
-		assertTrue(target instanceof Cfg2HbmTool);
+		assertTrue(target instanceof Wrapper);
+		Object wrappedObject = ((Wrapper)target).getWrappedObject();
+		assertTrue(wrappedObject instanceof Cfg2HbmTool);
 	}
 	
 	@Test


### PR DESCRIPTION
  - Update dependency of plugin 'org.jboss.tools.hibernate.orm.runtime.exp' on Hibernate Tools to version '6.2.6a.Final' because of some needed changes in the JBT bridge
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.exp.VersionTest#testToolsVersion()' to the above change
  - Remove the references to class 'org.hibernate.tool.orm.jbt.wrp.Wrapper' from methods 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory#unwrapFacades(Object[])' and 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory#argumentClasses(Object[])' as this is now handled in the JBT bridge
  - Adapt the relevant tests to all the above changes