### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -24,7 +24,6 @@ import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
-import org.jboss.tools.hibernate.runtime.common.AbstractService;
 import org.jboss.tools.hibernate.runtime.common.IFacade;
 import org.jboss.tools.hibernate.runtime.spi.HibernateException;
 import org.jboss.tools.hibernate.runtime.spi.IArtifactCollector;
@@ -44,6 +43,7 @@ import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringSettings;
 import org.jboss.tools.hibernate.runtime.spi.IReverseEngineeringStrategy;
 import org.jboss.tools.hibernate.runtime.spi.ISchemaExport;
+import org.jboss.tools.hibernate.runtime.spi.IService;
 import org.jboss.tools.hibernate.runtime.spi.ISessionFactory;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.ITableFilter;
@@ -51,10 +51,8 @@ import org.jboss.tools.hibernate.runtime.spi.ITypeFactory;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
 import org.xml.sax.EntityResolver;
 
-public class ServiceImpl extends AbstractService {
+public class ServiceImpl implements  IService {
 
-	private static final String HIBERNATE_VERSION = "6.1";
-	
 	@Override
 	public IConfiguration newAnnotationConfiguration() {
 		return newDefaultConfiguration();
@@ -72,7 +70,6 @@ public class ServiceImpl extends AbstractService {
 
 	@Override
 	public IConfiguration newDefaultConfiguration() {
-		getUsageTracker().trackNewConfigurationEvent(HIBERNATE_VERSION);
 		return (IConfiguration)GenericFacadeFactory.createFacade(
 				IConfiguration.class, 
 				WrapperFactory.createNativeConfigurationWrapper());
@@ -393,9 +390,10 @@ public class ServiceImpl extends AbstractService {
 	}
 	
 	@Override
-	protected String getCfgExporterClassName() {
-		return CfgExporter.class.getName();
+	public IExporter createCfgExporter() {
+		return createExporter(CfgExporter.class.getName());
 	}
+	
 
 	private ServiceRegistry buildServiceRegistry(Properties properties) {
 		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -391,13 +391,6 @@ public class ServiceImplTest {
 	}
 	
 	@Test
-	public void testGetCfgExporterClassName() {
-		assertEquals(
-				CfgExporter.class.getName(), 
-				service.getCfgExporterClassName());
-	}
-	
-	@Test
 	public void testSimpleValue() {
 		IValue simpleValue = service.newSimpleValue();
 		assertNotNull(simpleValue);


### PR DESCRIPTION
  - Implement method 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#createCfgExporter()'
  - Class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.Service Impl' does not inherit anymore from 'org.jboss.tools.hibernate.runtime.common.AbstractService' but implements 'org.jboss.tools.hibernate.runtime.spi.IService'
  - Remove unneeded test case 'org.jboss.tools.hibernate.orm.runtime.exp.internal.ServiceImpl#testGetCfgExporterClassName()'