### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/src/org/jboss/tools/hibernate/orm/runtime/common/IDatabaseReader.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.common/src/org/jboss/tools/hibernate/orm/runtime/common/IDatabaseReader.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.hibernate.orm.runtime.exp.internal;
+package org.jboss.tools.hibernate.orm.runtime.common;
 
 import java.util.List;
 import java.util.Map;

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.exp/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.tool.api.reveng.RevengStrategy;
 import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
+import org.jboss.tools.hibernate.orm.runtime.common.IDatabaseReader;
 import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
 import org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactory;
 import org.jboss.tools.hibernate.runtime.spi.HibernateException;


### PR DESCRIPTION
  - Move interface 'org.jboss.tools.hibernate.orm.runtime.exp.internal.IDatabaseReader' from 'org.jboss.tools.hibernate.orm.runtime.exp' to 'org.jboss.tools.hibernate.orm.runtime.common.IDatabaseReader' in 'org.jboss.tools.hibernate.orm.runtime.common'