### PR TITLE
JBIDE-29047: Extract the generic functionality from the experimental runtime plugin

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Hibernate ORM Runtime Common Tests
+Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.common.test
+Automatic-Module-Name: org.jboss.tools.hibernate.orm.runtime.common.test
+Bundle-Version: 5.4.22.qualifier
+Fragment-Host: org.jboss.tools.hibernate.orm.runtime.common
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.junit.jupiter.api
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .
+               

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion> 
+	<parent>
+		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
+		<artifactId>runtime</artifactId>
+		<version>5.4.20-SNAPSHOT</version>
+	</parent>
+	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
+	<artifactId>org.jboss.tools.hibernate.orm.runtime.common.test</artifactId> 
+
+	<packaging>eclipse-test-plugin</packaging>
+	
+	<build>
+		<plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+<version>5.4.22-SNAPSHOT</version>
+</project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/src/org/jboss/tools/hibernate/orm/runtime/common/GenericFacadeFactoryTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.common.test/src/org/jboss/tools/hibernate/orm/runtime/common/GenericFacadeFactoryTest.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.hibernate.orm.runtime.exp.internal.util;
+package org.jboss.tools.hibernate.orm.runtime.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -30,6 +30,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	    <module>org.jboss.tools.hibernate.runtime.v_6_0.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_1.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_2.test</module>
+	    <module>org.jboss.tools.hibernate.orm.runtime.common.test</module>
 	    <module>org.jboss.tools.hibernate.orm.runtime.exp.test</module>
 	</modules>
 	


### PR DESCRIPTION
  - Create a new test fragment 'org.jboss.tools.hibernate.orm.runtime.common.test'
  - Move test class 'org.jboss.tools.hibernate.orm.runtime.exp.internal.util.GenericFacadeFactoryTest' from 'org.jboss.tools.hibernate.orm.runtime.exp.test' to 'org.jboss.tools.hibernate.orm.runtime.common.GenericFacadeFactoryTest' in 'org.jboss.tools.hibernate.orm.runtime.common.test'