### PR TITLE
JBIDE-29046: Move the existing Hibernate 6.2 runtime plugin and make use of the new JBoss Tools adapter

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/META-INF/MANIFEST.MF
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Experimental Hibernate Runtime Tests
+Bundle-SymbolicName: org.jboss.tools.hibernate.orm.runtime.v_6_2.test
+Automatic-Module-Name: org.jboss.tools.hibernate.orm.runtime.v_6_2.test
+Bundle-Version: 5.4.22.qualifier
+Fragment-Host: org.jboss.tools.hibernate.orm.runtime.v_6_2
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.junit.jupiter.api,
+ org.jboss.tools.hibernate.libs.h2.v_1_4
+Bundle-ClassPath: .

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/build.properties
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .
+               

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/pom.xml
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion> 
+	<parent>
+		<groupId>org.jboss.tools.hibernatetools.orm.test</groupId>
+		<artifactId>runtime</artifactId>
+		<version>5.4.20-SNAPSHOT</version>
+	</parent>
+	<groupId>org.jboss.tools.hibernatetools.orm.test.runtime</groupId>
+	<artifactId>org.jboss.tools.hibernate.orm.runtime.v_6_2.test</artifactId> 
+
+	<packaging>eclipse-test-plugin</packaging>
+	
+	<build>
+		<plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+<version>5.4.22-SNAPSHOT</version>
+</project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
@@ -1,0 +1,19 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class VersionTest {
+	
+	@Test 
+	public void testCoreVersion() {
+		assertEquals("6.2.6.Final", org.hibernate.Version.getVersionString());
+	}
+
+	@Test
+	public void testToolsVersion() {
+		assertEquals("6.2.7-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+	}
+	
+}


### PR DESCRIPTION
  - Initial creation of new test fragment 'org.jboss.tools.hibernate.orm.runtime.v_6_2.test'