### PR TITLE
JBIDE-29046: Move the existing Hibernate 6.2 runtime plugin and make use of the new JBoss Tools adapter

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ServiceImpl.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ServiceImpl.java
@@ -20,6 +20,7 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.api.reveng.RevengStrategy;
+import org.hibernate.tool.internal.export.cfg.CfgExporter;
 import org.hibernate.tool.orm.jbt.util.JpaMappingFileHelper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.common.GenericFacadeFactory;
@@ -110,9 +111,9 @@ public class ServiceImpl implements IService {
 
 	@Override
 	public IExporter createCfgExporter() {
-		// TODO Auto-generated method stub
-		return null;
+		return createExporter(CfgExporter.class.getName());
 	}
+	
 
 	@Override
 	public IExporter createExporter(String exporterClassName) {

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.exp.test/src/org/jboss/tools/hibernate/orm/runtime/exp/internal/ServiceImplTest.java
@@ -198,6 +198,16 @@ public class ServiceImplTest {
 	}
 	
 	@Test
+	public void testCreateCfgExporter() {
+		IExporter exporter = service.createCfgExporter();
+		assertNotNull(exporter);
+		Object exporterWrapper = ((IFacade)exporter).getTarget();
+		assertNotNull(exporterWrapper);
+		Exporter wrappedExporter = (Exporter)((Wrapper)exporterWrapper).getWrappedObject();
+		assertTrue(wrappedExporter instanceof CfgExporter);
+	}
+	
+	@Test
 	public void testNewArtifactCollector() {
 		IArtifactCollector artifactCollector = service.newArtifactCollector();
 		assertNotNull(artifactCollector);

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ServiceImplTest.java
@@ -198,6 +198,16 @@ public class ServiceImplTest {
 	}
 	
 	@Test
+	public void testCreateCfgExporter() {
+		IExporter exporter = service.createCfgExporter();
+		assertNotNull(exporter);
+		Object exporterWrapper = ((IFacade)exporter).getTarget();
+		assertNotNull(exporterWrapper);
+		Exporter wrappedExporter = (Exporter)((Wrapper)exporterWrapper).getWrappedObject();
+		assertTrue(wrappedExporter instanceof CfgExporter);
+	}
+	
+	@Test
 	public void testNewArtifactCollector() {
 		IArtifactCollector artifactCollector = service.newArtifactCollector();
 		assertNotNull(artifactCollector);


### PR DESCRIPTION
  - Add new test case 'org.jboss.tools.hibernate.orm.runtime.v_6_2.ServiceImplTest#testCreateCfgExporter()'
  - Add new test case 'org.jboss.tools.hibernate.orm.runtime.exp.ServiceImplTest#testCreateCfgExporter()'
  - Implement method 'org.jboss.tools.hibernate.orm.runtime.v_6_2.ServiceImpl#createCfgExporter()'