### PR TITLE
JBIDE-29046: Move the existing Hibernate 6.2 runtime plugin and make use of the new JBoss Tools adapter

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.properties
@@ -1,1 +1,1 @@
-hibernate.version=6.2-new
+hibernate.version=6.2.x

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.jboss.tools.hibernate.runtime.spi.services">
+      <service
+            class="org.jboss.tools.hibernate.orm.runtime.v_6_2.ServiceImpl"
+            name="%hibernate.version">
+      </service>
+   </extension>
+
+</plugin>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
@@ -1,7 +1,9 @@
 package org.jboss.tools.hibernate.orm.runtime.v_6_2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.jboss.tools.hibernate.runtime.spi.RuntimeServiceManager;
 import org.junit.jupiter.api.Test;
 
 public class VersionTest {
@@ -16,4 +18,8 @@ public class VersionTest {
 		assertEquals("6.2.7-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
+	@Test 
+	public void testRuntimeVersion() {
+		assertSame(RuntimeServiceManager.getInstance().findService("6.2.x").getClass(), ServiceImpl.class);
+	}
 }


### PR DESCRIPTION
  - Add test case 'org.jboss.tools.hibernate.orm.runtime.v_6_2.VersionTest#testRuntimeVersion()'
  - Contribute 'org.jboss.tools.hibernate.orm.runtime.v_6_2.ServiceImpl' to the 'org.jboss.tools.hibernate.runtime.spi.services' extension point
  - Make sure contributed version is '6.2.x' to avoid confusion with '6.2'