### PR TITLE
JBIDE-29046: Move the existing Hibernate 6.2 runtime plugin and make use of the new JBoss Tools adapter

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
  org.jboss.tools.hibernate.runtime.spi,
  org.jboss.tools.hibernate.orm.runtime.common
 Bundle-ClassPath: .,
- lib/hibernate-ant-6.2.6.Final.jar,
- lib/hibernate-core-6.2.6.Final.jar,
- lib/hibernate-tools-orm-6.2.7-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.2.7-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.2.7-SNAPSHOT.jar
+ lib/hibernate-ant-6.2.7.Final.jar,
+ lib/hibernate-core-6.2.7.Final.jar,
+ lib/hibernate-tools-orm-6.2.7.Final.jar,
+ lib/hibernate-tools-orm-jbt-6.2.7.Final.jar,
+ lib/hibernate-tools-utils-6.2.7.Final.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/pom.xml
@@ -12,8 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.orm.version>6.2.6.Final</hibernate.orm.version>
-		<hibernate.tools.version>6.2.7-SNAPSHOT</hibernate.tools.version>
+		<hibernate.version>6.2.7.Final</hibernate.version>
 	</properties>
 
 	<build>
@@ -35,27 +34,27 @@
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-orm</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-orm-jbt</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-utils</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.orm</groupId>
 							<artifactId>hibernate-ant</artifactId>
-							<version>${hibernate.orm.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.orm</groupId>
 							<artifactId>hibernate-core</artifactId>
-							<version>${hibernate.orm.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
@@ -10,12 +10,12 @@ public class VersionTest {
 	
 	@Test 
 	public void testCoreVersion() {
-		assertEquals("6.2.6.Final", org.hibernate.Version.getVersionString());
+		assertEquals("6.2.7.Final", org.hibernate.Version.getVersionString());
 	}
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.2.7-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.2.7.Final", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 


### PR DESCRIPTION
  - Update the dependency on Hibernate Core to version '6.2.7.Final'
  - Update the dependency on Hibernate Tools to version '6.2.7.Final'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.v_6_2.VersionTest#testCoreVersion()'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.v_6_2.VersionTest#testToolsVersion()'