### PR TITLE
JBIDE-29046: Move the existing Hibernate 6.2 runtime plugin and make use of the new JBoss Tools adapter

### DIFF
--- a/features/org.hibernate.eclipse.feature/feature.xml
+++ b/features/org.hibernate.eclipse.feature/feature.xml
@@ -388,13 +388,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.jboss.tools.hibernate.runtime.v_6_2"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.jboss.tools.hibernate.libs.jakarta-persistence-api.v_3_1"
          download-size="0"
          install-size="0"

--- a/features/org.jboss.tools.hibernate.orm.runtime.feature/feature.xml
+++ b/features/org.jboss.tools.hibernate.orm.runtime.feature/feature.xml
@@ -27,4 +27,11 @@ Also this plugin is an addition to JBoss Tools Hibernate plugin which is license
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.jboss.tools.hibernate.orm.runtime.v_6_2"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/plugin.properties
@@ -1,1 +1,1 @@
-hibernate.version=6.2.x
+hibernate.version=6.2

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_2/plugin.properties
@@ -1,1 +1,1 @@
-hibernate.version=6.2
+hibernate.version=6.2.old

--- a/orm/plugin/runtime/pom.xml
+++ b/orm/plugin/runtime/pom.xml
@@ -14,6 +14,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	
 	<modules>
 		<module>org.jboss.tools.hibernate.orm.runtime.common</module>
+		<module>org.jboss.tools.hibernate.orm.runtime.v_6_2</module>
 		<module>org.jboss.tools.hibernate.runtime.common</module>
 		<module>org.jboss.tools.hibernate.runtime.spi</module>
 		<module>org.jboss.tools.hibernate.runtime.v_3_5</module>
@@ -29,7 +30,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.jboss.tools.hibernate.runtime.v_5_6</module>
 		<module>org.jboss.tools.hibernate.runtime.v_6_0</module>
 		<module>org.jboss.tools.hibernate.runtime.v_6_1</module>
-		<module>org.jboss.tools.hibernate.runtime.v_6_2</module>
 	</modules>
 
 </project>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/VersionTest.java
@@ -20,6 +20,6 @@ public class VersionTest {
 	
 	@Test 
 	public void testRuntimeVersion() {
-		assertSame(RuntimeServiceManager.getInstance().findService("6.2.x").getClass(), ServiceImpl.class);
+		assertSame(RuntimeServiceManager.getInstance().findService("6.2").getClass(), ServiceImpl.class);
 	}
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_2.test/src/org/jboss/tools/hibernate/runtime/v_6_2/VersionTest.java
@@ -21,6 +21,6 @@ public class VersionTest {
 
 	@Test 
 	public void testRuntimeVersion() {
-		assertSame(RuntimeServiceManager.getInstance().findService("6.2").getClass(), ServiceImpl.class);
+		assertSame(RuntimeServiceManager.getInstance().findService("6.2.old").getClass(), ServiceImpl.class);
 	}
 }

--- a/orm/test/runtime/pom.xml
+++ b/orm/test/runtime/pom.xml
@@ -29,9 +29,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	    <module>org.jboss.tools.hibernate.runtime.v_5_6.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_0.test</module>
 	    <module>org.jboss.tools.hibernate.runtime.v_6_1.test</module>
-	    <module>org.jboss.tools.hibernate.runtime.v_6_2.test</module>
 	    <module>org.jboss.tools.hibernate.orm.runtime.common.test</module>
-	    <module>org.jboss.tools.hibernate.orm.runtime.exp.test</module>
+	    <module>org.jboss.tools.hibernate.orm.runtime.v_6_2.test</module>
 	</modules>
 	
 </project>


### PR DESCRIPTION
  - Add plugin 'org.jboss.tools.hibernate.orm.runtime.v_6_2' to feature 'org.jboss.tools.hibernate.orm.runtime.feature'
  - Remove plugin 'org.jboss.tools.hibernate.runtime.v_6_2' from feature 'org.hibernate.eclipse.feature'
  - Change 'hibernate.version' property of plugin 'org.jboss.tools.hibernate.orm.runtime.v_6_2' to '6.2'
  - Change 'hibernate.version' property of plugin 'org.jboss.tools.hibernate.runtime.v_6_2' to '6.2.old'
  - Add module 'org.jboss.tools.hibernate.orm.runtime.v_6_2' to 'pom.xml' of 'org.jboss.tools.hibernatetools.orm.runtime'
  - Remove module 'org.jboss.tools.hibernate.runtime.v_6_2' from 'pom.xml' of 'org.jboss.tools.hibernatetools.orm.runtime'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.v_6_2.test.VersionTest#testRuntimeVersion()'
  - Adapt test case 'org.jboss.tools.hibernate.runtime.v_6_2.test.VersionTest#testRuntimeVersion()'
  - Add module 'org.jboss.tools.hibernate.orm.runtime.v_6_2.test' to 'pom.xml' of 'org.jboss.tools.hibernatetools.orm.test.runtime'
  - Remove module 'org.jboss.tools.hibernate.orm.runtime.exp.test' and 'org.jboss.tools.hibernate.runtime.v_6_2.test' from 'pom.xml' of 'org.jboss.tools.hibernatetools.orm.test.runtime'