### PR TITLE
JBIDE-29054: Create a Hibernate 6.3 runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/plugin.properties
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/plugin.properties
@@ -1,0 +1,1 @@
+hibernate.version=6.3 Preview

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/plugin.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/plugin.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.jboss.tools.hibernate.runtime.spi.services">
+      <service
+            class="org.jboss.tools.hibernate.orm.runtime.v_6_3.ServiceImpl"
+            name="%hibernate.version">
+      </service>
+   </extension>
+
+</plugin>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/VersionTest.java
@@ -1,7 +1,9 @@
 package org.jboss.tools.hibernate.orm.runtime.v_6_3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import org.jboss.tools.hibernate.runtime.spi.RuntimeServiceManager;
 import org.junit.jupiter.api.Test;
 
 public class VersionTest {
@@ -16,4 +18,8 @@ public class VersionTest {
 		assertEquals("6.3.0-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
+	@Test 
+	public void testRuntimeVersion() {
+		assertSame(RuntimeServiceManager.getInstance().findService("6.3 Preview").getClass(), ServiceImpl.class);
+	}
 }


### PR DESCRIPTION
  - Contribute 'org.jboss.tools.hibernate.orm.runtime.v_6_3.ServiceImpl' to extension point 'org.jboss.tools.hibernate.runtime.spi.services' with version identifier '6.3 Preview'
  - Add test case 'org.jboss.tools.hibernate.orm.runtime.v_6_3.VersionTest#testRuntimeVersion()'