### PR TITLE
JBIDE-29054: Create a Hibernate 6.3 runtime plugin

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/META-INF/MANIFEST.MF
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/META-INF/MANIFEST.MF
@@ -23,6 +23,6 @@ Require-Bundle: org.jboss.tools.hibernate.libs.antlr4-runtime.v_4_10,
 Bundle-ClassPath: .,
  lib/hibernate-ant-6.3.0.CR1.jar,
  lib/hibernate-core-6.3.0.CR1.jar,
- lib/hibernate-tools-orm-6.3.0-SNAPSHOT.jar,
- lib/hibernate-tools-orm-jbt-6.3.0-SNAPSHOT.jar,
- lib/hibernate-tools-utils-6.3.0-SNAPSHOT.jar
+ lib/hibernate-tools-orm-6.3.0.CR1.jar,
+ lib/hibernate-tools-orm-jbt-6.3.0.CR1.jar,
+ lib/hibernate-tools-utils-6.3.0.CR1.jar

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/pom.xml
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/pom.xml
@@ -12,8 +12,7 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<hibernate.tools.version>6.3.0-SNAPSHOT</hibernate.tools.version>
-		<hibernate.orm.version>6.3.0.CR1</hibernate.orm.version>
+		<hibernate.version>6.3.0.CR1</hibernate.version>
 	</properties>
 
 	<build>
@@ -35,27 +34,27 @@
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-orm</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-orm-jbt</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.tool</groupId>
 							<artifactId>hibernate-tools-utils</artifactId>
-							<version>${hibernate.tools.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.orm</groupId>
 							<artifactId>hibernate-ant</artifactId>
-							<version>${hibernate.orm.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.hibernate.orm</groupId>
 							<artifactId>hibernate-core</artifactId>
-							<version>${hibernate.orm.version}</version>
+							<version>${hibernate.version}</version>
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/VersionTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/VersionTest.java
@@ -15,7 +15,7 @@ public class VersionTest {
 
 	@Test
 	public void testToolsVersion() {
-		assertEquals("6.3.0-SNAPSHOT", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
+		assertEquals("6.3.0.CR1", org.hibernate.tool.api.version.Version.CURRENT_VERSION);
 	}
 	
 	@Test 


### PR DESCRIPTION
  - Modify dependency on Hibernate Tools to version '6.3.0.CR1'
  - Adapt test case 'org.jboss.tools.hibernate.orm.runtime.v_6_3.VersionTest#testToolsVersion()'