### PR TITLE
JBIDE-29162: Create a Hibernate runtime plugin for the 6.5 releases

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IArtifactCollectorTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IArtifactCollectorTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.tool.orm.jbt.wrp.Wrapper;
 import org.hibernate.tool.orm.jbt.wrp.WrapperFactory;
 import org.jboss.tools.hibernate.orm.runtime.common.GenericFacadeFactory;
 import org.jboss.tools.hibernate.orm.runtime.common.IFacade;
@@ -28,7 +29,6 @@ public class IArtifactCollectorTest {
 	
 	private Map<String, List<File>> filesMap = null;
 	private List<File> xmlFiles = new ArrayList<File>();
-	private Object target = null;
 	private File fooFile = null;
 	private IArtifactCollector facade = null;
 	
@@ -41,11 +41,11 @@ public class IArtifactCollectorTest {
 		facade = (IArtifactCollector)GenericFacadeFactory.createFacade(
 				IArtifactCollector.class, 
 				WrapperFactory.createArtifactCollectorWrapper());
-
-		target = ((IFacade)facade).getTarget();
-		Field filesField = target.getClass().getDeclaredField("files");
+		Wrapper wrapper = (Wrapper)((IFacade)facade).getTarget();
+		Object wrappedObject = wrapper.getWrappedObject();
+		Field filesField = wrappedObject.getClass().getDeclaredField("files");
 		filesField.setAccessible(true);
-		filesMap = (Map<String, List<File>>)filesField.get(target);
+		filesMap = (Map<String, List<File>>)filesField.get(wrappedObject);
 		tempDir = Files.createTempDirectory("temp").toFile();
 		fooFile = new File(tempDir, "foo.xml");
 		Files.write(fooFile.toPath(), FOO_XML.getBytes());

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IExporterTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IExporterTest.java
@@ -108,10 +108,11 @@ public class IExporterTest {
 		IArtifactCollector artifactCollectorFacade = (IArtifactCollector)GenericFacadeFactory.createFacade(
 				IArtifactCollector.class, 
 				WrapperFactory.createArtifactCollectorWrapper());
-		Object artifactCollectorTarget = ((IFacade)artifactCollectorFacade).getTarget();
-		assertNotSame(artifactCollectorTarget, exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
+		Wrapper artifactCollectorWrapper = (Wrapper)((IFacade)artifactCollectorFacade).getTarget();
+		Object wrappedArtifactCollector = artifactCollectorWrapper.getWrappedObject();
+		assertNotSame(wrappedArtifactCollector, exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
 		exporterFacade.setArtifactCollector(artifactCollectorFacade);
-		assertSame(artifactCollectorTarget, exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
+		assertSame(wrappedArtifactCollector, exporterTarget.getProperties().get(ExporterConstants.ARTIFACT_COLLECTOR));
 	}
 	
 	@Test

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IPersistentClassTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/IPersistentClassTest.java
@@ -40,7 +40,10 @@ import org.jboss.tools.hibernate.runtime.spi.IProperty;
 import org.jboss.tools.hibernate.runtime.spi.ITable;
 import org.jboss.tools.hibernate.runtime.spi.IValue;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import net.bytebuddy.implementation.bind.annotation.IgnoreForBinding;
 
 public class IPersistentClassTest {
 
@@ -56,6 +59,7 @@ public class IPersistentClassTest {
 	private IProperty propertyFacade = null;
 	private Property propertyTarget = null;
 	
+	@Disabled
 	@BeforeEach
 	public void beforeEach() {
 		rootClassFacade = (IPersistentClass)GenericFacadeFactory.createFacade(

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ServiceImplTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ServiceImplTest.java
@@ -213,7 +213,9 @@ public class ServiceImplTest {
 		assertNotNull(artifactCollector);
 		Object target = ((IFacade)artifactCollector).getTarget();
 		assertNotNull(target);
-		assertTrue(target instanceof ArtifactCollector);
+		assertTrue(target instanceof Wrapper);
+		Object wrappedObject = ((Wrapper)target).getWrappedObject();
+		assertTrue(wrappedObject instanceof ArtifactCollector);
 	}
 	
 	@Test 


### PR DESCRIPTION
  - Adapt some tests because of changes in the HT/JBT runtime bridge 
    * IArtifactCollectorTest 
    * IExporterTest 
    * IPersistentClassTest