### PR TITLE
JBIDE-29221: Make sure that the Exporter classes needed by plugin 'org.hibernate.eclipse.console' are visible and available

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/Hbm2DDLExporter.java
@@ -1,0 +1,5 @@
+package org.hibernate.tool.hbm2x;
+
+import org.hibernate.tool.internal.export.ddl.DdlExporter;
+
+public class Hbm2DDLExporter extends DdlExporter {}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_2;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_3;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_4;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_6_6;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.orm.runtime.v_7_0;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_3_5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_3_6;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_4_0;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_4_3;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_0;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_1;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_2;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_3;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_4;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_5_6;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_6_0;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.hibernate.runtime.v_6_1;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class ExportersPresenceTest {
+	
+	@Test
+	public void testDdlExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
+			assertNotNull(ddlExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
+}


### PR DESCRIPTION
  - Handle the case of 'org.hibernate.tool.hbm2x.Hbm2DDLExporter'