### PR TITLE
JBIDE-29221: Make sure that the Exporter classes needed by plugin 'org.hibernate.eclipse.console' are visible and available

### DIFF
--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
@@ -18,4 +18,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testPojoExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
+			assertNotNull(pojoExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }


### PR DESCRIPTION
  - Handle the case of 'org.hibernate.tool.hbm2x.POJOExporter'