### PR TITLE
JBIDE-29221: Make sure that the Exporter classes needed by plugin 'org.hibernate.eclipse.console' are visible and available

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/DocExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/DocExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class DocExporter extends org.hibernate.tool.internal.export.doc.DocExporter {}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
@@ -73,4 +73,15 @@ public class ExportersPresenceTest {
 		}
 	}
 
+	@Test
+	public void testDocExporter() {
+		try {
+			ClassLoader cl = getClass().getClassLoader();
+			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
+			assertNotNull(docExporterClass);
+		} catch (Throwable t) {
+			fail(t);
+		}
+	}
+
 }


### PR DESCRIPTION
  - Handle the case of 'org.hibernate.tool.hbm2x.DocExporter'