### PR TITLE
JBIDE-29221: Make sure that the Exporter classes needed by plugin 'org.hibernate.eclipse.console' are visible and available

### DIFF
--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_0/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/QueryExporter.java
+++ b/orm/plugin/runtime/org.jboss.tools.hibernate.runtime.v_6_1/src/org/hibernate/tool/hbm2x/QueryExporter.java
@@ -1,0 +1,3 @@
+package org.hibernate.tool.hbm2x;
+
+public class QueryExporter extends org.hibernate.tool.internal.export.query.QueryExporter {}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_2.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_2/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_3.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_3/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_4.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_4/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_5.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_5/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_6_6.test/src/org/jboss/tools/hibernate/orm/runtime/v_6_6/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.orm.runtime.v_7_0.test/src/org/jboss/tools/hibernate/orm/runtime/v_7_0/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_5.test/src/org/jboss/tools/hibernate/runtime/v_3_5/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_3_6.test/src/org/jboss/tools/hibernate/runtime/v_3_6/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_0.test/src/org/jboss/tools/hibernate/runtime/v_4_0/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_4_3.test/src/org/jboss/tools/hibernate/runtime/v_4_3/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_0.test/src/org/jboss/tools/hibernate/runtime/v_5_0/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_1.test/src/org/jboss/tools/hibernate/runtime/v_5_1/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_2.test/src/org/jboss/tools/hibernate/runtime/v_5_2/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_3.test/src/org/jboss/tools/hibernate/runtime/v_5_3/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_4.test/src/org/jboss/tools/hibernate/runtime/v_5_4/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_5.test/src/org/jboss/tools/hibernate/runtime/v_5_5/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_5_6.test/src/org/jboss/tools/hibernate/runtime/v_5_6/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_0.test/src/org/jboss/tools/hibernate/runtime/v_6_0/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,22 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testDocExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> docExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.DocExporter");
-			assertNotNull(docExporterClass);
-		} catch (Throwable t) {
-			fail(t);
-		}
-	}
-
-	@Test
-	public void testHibernateHbm2DDLExporter() {
-		try {
-			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}

--- a/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
+++ b/orm/test/runtime/org.jboss.tools.hibernate.runtime.v_6_1.test/src/org/jboss/tools/hibernate/runtime/v_6_1/ExportersPresenceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class ExportersPresenceTest {
 	
 	@Test
-	public void testDdlExporter() {
+	public void testHbm2DDLExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> ddlExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
@@ -19,7 +19,7 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testPojoExporter() {
+	public void testPOJOExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
 			Class<?> pojoExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.POJOExporter");
@@ -74,11 +74,11 @@ public class ExportersPresenceTest {
 	}
 
 	@Test
-	public void testHibernateHbm2DDLExporter() {
+	public void testQueryExporter() {
 		try {
 			ClassLoader cl = getClass().getClassLoader();
-			Class<?> hbm2DDLExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.Hbm2DDLExporter");
-			assertNotNull(hbm2DDLExporterClass);
+			Class<?> queryExporterClass = cl.loadClass("org.hibernate.tool.hbm2x.QueryExporter");
+			assertNotNull(queryExporterClass);
 		} catch (Throwable t) {
 			fail(t);
 		}


### PR DESCRIPTION
  - Handle the case of 'org.hibernate.tool.hbm2x.QueryExporter'